### PR TITLE
Add single `wght` axis partial VF instance support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ list-deps:
 update-deps:
 	pip-compile -U
 
+# ------------------------------
+# Testing
+# ------------------------------
 
 test-fb: test-fb-static-expert test-fb-vf-expert
 
@@ -90,12 +93,18 @@ test-fb-static-expert:
 	@echo " fontbakery v`fontbakery --version` static font checks"
 	@echo "========================================================="
 	fontbakery check-profile -C --loglevel WARN qa/check-googlesans.py $(EXPERT_STATIC_BUILD_DIR)/*.ttf
+	fontbakery check-profile -C --loglevel WARN qa/check-charset.py $(EXPERT_STATIC_BUILD_DIR)/*.ttf
 
 test-fb-vf-expert:
 	@echo "========================================================="
 	@echo " fontbakery v`fontbakery --version` variable font checks"
 	@echo "========================================================="
+	# default build checks
 	fontbakery check-profile -C --loglevel WARN qa/check-googlesans.py $(EXPERT_VARIABLE_BUILD_DIR)/*.ttf
+	fontbakery check-profile -C --loglevel WARN qa/check-charset.py $(EXPERT_VARIABLE_BUILD_DIR)/*.ttf
+	# non-default build checks
+	#  - partial instances do not repeat char set checks that were executed above in default build checks
+	fontbakery check-profile -C --loglevel WARN qa/check-googlesans.py $(EXPERT_VARIABLE_BUILD_DIR)/partial/*.ttf
 
 
 .PHONY: all \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ gs-vf-upright gs-vf-italic:
 setup:
 	mkdir -p "$(VENV_DIR)"
 	python3 -m venv "$(VENV_DIR)"
-	"$(VENV_DIR)/bin/pip" install --upgrade pip
+	"$(VENV_DIR)/bin/pip" install --upgrade pip wheel setuptools
 	"$(VENV_DIR)/bin/pip" install -r requirements.txt
 	@echo "\n\nDependency versions installed in your venv are:\n"
 	@$(MAKE) list-deps

--- a/qa/check-charset.py
+++ b/qa/check-charset.py
@@ -1,0 +1,108 @@
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from fontbakery.checkrunner import Section, PASS, FAIL, WARN, ERROR, INFO, SKIP
+from fontbakery.callable import condition, check, disable
+from fontbakery.constants import PriorityLevel
+from fontbakery.message import Message
+from fontbakery.fonts_profile import profile_factory
+
+profile_imports = ()
+profile = profile_factory(
+    default_section=Section("Google Sans Custom Character Set Checks")
+)
+
+GOOGLESANS_PROFILE_CHECKS = [
+    "com.google.fonts/check/googlesans/glyphs/glyphset-contents",
+]
+
+excluded_check_ids = (
+    "com.google.fonts/check/ftxvalidator_is_available",
+    "com.google.fonts/check/dsig",
+    "com.google.fonts/check/family/win_ascent_and_descent",  # replaced by custom checks
+    "com.google.fonts/check/varfont/regular_opsz_coord",  # we really do want our opsz definition on regular instance
+    # "com.google.fonts/check/os2_metrics_match_hhea",
+    # "com.google.fonts/check/unwanted_tables",
+)
+
+# ================================================
+# Glyph set checks
+# ================================================
+
+# ::::::::::::::::::::::::::::::::::::::::::::::::
+# Glyph set support
+# ::::::::::::::::::::::::::::::::::::::::::::::::
+# compare against a newline-delimited list of expected glyph names
+# this includes all Unicode encoded and non-Unicode encoded glyph definitions
+
+
+@check(
+    id="com.google.fonts/check/googlesans/glyphs/glyphset-contents",
+    rationale="""
+    Confirms that the fonts include all expected Unicode encoded and \
+    non-Unicode encoded glyph definitions. This test also confirms that \
+    fonts have the expected glyph order.
+    """,
+)
+def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFonts):
+    """Confirm that fonts have all expected Unicode encoded and \
+       non-Unicoded encoded glyph definitions.This test also confirms \
+       that the glyph order is defined as expected."""
+    try:
+        glyph_definition_basedir = os.path.join("qa", "definitions")
+
+        tests_passed = True
+        for tt in ttFonts:
+            glyph_list_raw = ""
+            base_file_path = os.path.basename(tt.reader.file.name) + ".glyphsetdef"
+            expected_glyph_definition_path = os.path.join(
+                glyph_definition_basedir, base_file_path
+            )
+            with open(expected_glyph_definition_path, "r") as f:
+                glyph_list_raw = f.read()
+
+            glyph_list = glyph_list_raw.split("\n")
+            # must have (1) glyph set contents & (2) glyph set order as defined in def file
+            if not (tt.getGlyphOrder() == glyph_list):
+                tests_passed = False
+                yield FAIL, "{} failed expected glyph set check".format(
+                    tt.reader.file.name
+                )
+        if tests_passed:
+            yield PASS, "All fonts passed the expected glyph set checks"
+    except Exception as e:
+        sys.stderr.write("[ERROR]: {}".format(str(e)))
+        sys.exit(1)
+
+
+# ================================================
+#
+# End check definitions
+#
+# ================================================
+
+# skip filter function to exclude checks defined in the
+# fontbakery universal profile
+def check_skip_filter(checkid, font=None, **iterargs):
+    if font and checkid in excluded_check_ids:
+        return False, ("Check skipped in Google Sans profile")
+    return True, None
+
+
+profile.check_skip_filter = check_skip_filter
+profile.auto_register(globals())
+profile.test_expected_checks(GOOGLESANS_PROFILE_CHECKS, exclusive=True)

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -26,7 +26,6 @@ profile_imports = ("fontbakery.profiles.universal",)
 profile = profile_factory(default_section=Section("Google Sans Custom Checks"))
 
 GOOGLESANS_PROFILE_CHECKS = UNIVERSAL_PROFILE_CHECKS + [
-    "com.google.fonts/check/googlesans/glyphs/glyphset-contents",
     "com.google.fonts/check/googlesans/opentype/os2/fsselectionbit7",
     "com.google.fonts/check/googlesans/opentype/os2/winascent",
     "com.google.fonts/check/googlesans/opentype/os2/windescent",
@@ -256,51 +255,6 @@ def is_not_variable_font(ttFont):
 # Begin check definitions
 #
 # ================================================
-
-# ================================================
-# Glyph set checks
-# ================================================
-
-# ::::::::::::::::::::::::::::::::::::::::::::::::
-# Glyph set support
-# ::::::::::::::::::::::::::::::::::::::::::::::::
-# compare against a newline-delimited list of expected glyph names
-# this includes all Unicode encoded and non-Unicode encoded glyph definitions
-
-
-@check(
-    id="com.google.fonts/check/googlesans/glyphs/glyphset-contents",
-    rationale="""
-    Confirms that the fonts include all expected Unicode encoded and \
-    non-Unicode encoded glyph definitions. This test also confirms that \
-    fonts have the expected glyph order.
-    """,
-)
-def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFonts):
-    """Confirm that fonts have all expected Unicode encoded and \
-       non-Unicoded encoded glyph definitions.This test also confirms \
-       that the glyph order is defined as expected."""
-    try:
-        glyph_definition_basedir = os.path.join("qa", "definitions")
-
-        tests_passed = True
-        for tt in ttFonts:
-            glyph_list_raw = ""
-            base_file_path = os.path.basename(tt.reader.file.name) + ".glyphsetdef"
-            expected_glyph_definition_path = os.path.join(glyph_definition_basedir, base_file_path)
-            with open(expected_glyph_definition_path, "r") as f:
-                glyph_list_raw = f.read()
-
-            glyph_list = glyph_list_raw.split("\n")
-            # must have (1) glyph set contents & (2) glyph set order as defined in def file
-            if not (tt.getGlyphOrder() == glyph_list):
-                tests_passed = False
-                yield FAIL, "{} failed expected glyph set check".format(tt.reader.file.name)
-        if tests_passed:
-            yield PASS, "All fonts passed the expected glyph set checks"
-    except Exception as e:
-        sys.stderr.write("[ERROR]: {}".format(str(e)))
-        sys.exit(1)
 
 
 # ================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,23 +4,24 @@
 #
 #    pip-compile
 #
-appdirs==1.4.3            # via fs
+appdirs==1.4.4            # via fs
 attrs==19.3.0             # via fontmake, ufolib2
 booleanoperations==0.9.0  # via fontmake, ufo2ft
 compreffor==0.5.0         # via ufo2ft
 cu2qu==1.6.7              # via fontmake, ufo2ft
-fontmake==2.0.10          # via -r requirements.in
-fontmath==0.5.2           # via fontmake
-fonttools[lxml,ufo,unicode]==4.4.1  # via booleanoperations, compreffor, cu2qu, fontmake, fontmath, glyphslib, ufo2ft, ufolib2
+fontmake==2.1.3           # via -r requirements.in
+fontmath==0.6.0           # via fontmake
+fonttools[lxml,ufo,unicode]==4.10.2  # via booleanoperations, compreffor, cu2qu, fontmake, fontmath, glyphslib, ufo2ft, ufolib2
 fs==2.4.11                # via fonttools
-glyphslib==5.1.7          # via fontmake
-lxml==4.5.0               # via fonttools
+glyphslib==5.1.10         # via fontmake
+lxml==4.5.1               # via fonttools
 pyclipper==1.1.0.post3    # via booleanoperations
-pytz==2019.3              # via fs
+pytz==2020.1              # via fs
 six==1.14.0               # via fs
-ufo2ft==2.12.2            # via fontmake
-ufolib2==0.6.1            # via fontmake, glyphslib
-unicodedata2==12.1.0      # via fonttools
+typing-extensions==3.7.4.2  # via ufolib2
+ufo2ft==2.13.0            # via fontmake
+ufolib2==0.7.1            # via fontmake, glyphslib
+unicodedata2==13.0.0.post2  # via fonttools
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/scripts/gs-partial-instancer.py
+++ b/scripts/gs-partial-instancer.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+
+from fontTools.ttLib import TTFont
+from fontTools.varLib import instancer
+
+MIN_OPSZ_SIZE = 14
+MAX_OPSZ_SIZE = 18
+
+VARIABLE_DIR = "../build/GoogleSans/variable/expert"
+VARIABLE_INPATH = f"{VARIABLE_DIR}/*.ttf"
+
+FAMILY_MAX = "Google Sans"
+FAMILY_MIN = "Google Sans Text"
+NAMEID_1_MAX = f"{FAMILY_MAX}"
+NAMEID_1_MIN = f"{FAMILY_MIN}"
+NAMEID_2_UPRIGHT = "Regular"
+NAMEID_2_ITALIC = "Italic"
+NAMEID_4_MAX_UPRIGHT = f"{FAMILY_MAX}"
+NAMEID_4_MIN_UPRIGHT = f"{FAMILY_MIN}"
+NAMEID_4_MAX_ITALIC = f"{FAMILY_MAX} Italic"
+NAMEID_4_MIN_ITALIC = f"{FAMILY_MIN} Italic"
+NAMEID_6_MAX_UPRIGHT = "GoogleSans-Regular"
+NAMEID_6_MIN_UPRIGHT = "GoogleSansText-Regular"
+NAMEID_6_MAX_ITALIC = "GoogleSans-Italic"
+NAMEID_6_MIN_ITALIC = "GoogleSansText-Italic"
+
+
+def main():
+    print(VARIABLE_INPATH)
+    in_var_paths = glob.glob(VARIABLE_INPATH)
+    assert len(in_var_paths) > 0
+    for fontpath in in_var_paths:
+        # determine if this is the italic or upright VF build
+        is_italic = False
+        if "Italic" in fontpath:
+            is_italic = True
+
+        vf_full = TTFont(fontpath)
+        pre_axis_tags = [a.axisTag for a in vf_full["fvar"].axes]
+        assert len(pre_axis_tags) == 2
+        assert "opsz" in pre_axis_tags
+        assert "wght" in pre_axis_tags
+
+        # partial instance of min optical size design
+        print(
+            f"[PARTIAL INSTANCE] {fontpath} to min optical size partial instance builds..."
+        )
+        vf_partial_min_opsz = instancer.instantiateVariableFont(
+            vf_full, {"opsz": MIN_OPSZ_SIZE}
+        )
+        # partial instance of amx optical size design
+        print(
+            f"[PARTIAL INSTANCE] {fontpath} to max optical size partial instance builds..."
+        )
+        vf_partial_max_opsz = instancer.instantiateVariableFont(
+            vf_full, {"opsz": MAX_OPSZ_SIZE}
+        )
+
+        # verify that partial instance builds include the expected axis
+        # definitions
+        for vf_partial in (vf_partial_min_opsz, vf_partial_max_opsz):
+            post_axis_tags = [a.axisTag for a in vf_partial["fvar"].axes]
+            assert len(post_axis_tags) == 1
+            assert "wght" in post_axis_tags
+
+        # ========================================
+        # Fix name tables after partial instancing
+        # ========================================
+        namerecord_list_min_opsz = vf_partial_min_opsz["name"].names
+        namerecord_list_max_opsz = vf_partial_max_opsz["name"].names
+
+        # *** min opsz name fix ***
+        new_min_opsz_namerecords = []
+        for record in namerecord_list_min_opsz:
+            skip_record = False
+            if record.nameID == 1:
+                record.string = FAMILY_MIN
+            elif record.nameID == 2:
+                if is_italic:
+                    record.string = NAMEID_2_ITALIC
+                else:
+                    record.string = NAMEID_2_UPRIGHT
+            elif record.nameID == 3:
+                nameID3 = record.toUnicode()
+                if is_italic:
+                    record.string = nameID3.replace(
+                        "GoogleSans-TextItalic", "GoogleSansText-Italic"
+                    )
+                else:
+                    record.string = nameID3.replace(
+                        "GoogleSans-TextRegular", "GoogleSansText-Regular"
+                    )
+            elif record.nameID == 4:
+                if is_italic:
+                    record.string = NAMEID_4_MIN_ITALIC
+                else:
+                    record.string = NAMEID_4_MIN_UPRIGHT
+            elif record.nameID == 6:
+                if is_italic:
+                    record.string = NAMEID_6_MIN_ITALIC
+                else:
+                    record.string = NAMEID_6_MIN_UPRIGHT
+            elif record.nameID == 16:
+                # eliminate nameID 16
+                skip_record = True
+            elif record.nameID == 17:
+                # eliminate nameID 17
+                skip_record = True
+
+            if not skip_record:
+                new_min_opsz_namerecords.append(record)
+
+        # define new min opsz name records following above edits
+        vf_partial_min_opsz["name"].names = new_min_opsz_namerecords
+
+        # *** max opsz name fix ***
+        new_max_opsz_namerecords = []
+        for record in namerecord_list_max_opsz:
+            skip_record = False
+            if record.nameID == 1:
+                record.string = FAMILY_MAX
+            elif record.nameID == 2:
+                if is_italic:
+                    record.string = NAMEID_2_ITALIC
+                else:
+                    record.string = NAMEID_2_UPRIGHT
+            elif record.nameID == 3:
+                nameID3 = record.toUnicode()
+                if is_italic:
+                    record.string = nameID3.replace("-TextItalic", "-Italic")
+                else:
+                    record.string = nameID3.replace("-TextRegular", "-Regular")
+            elif record.nameID == 4:
+                if is_italic:
+                    record.string = NAMEID_4_MAX_ITALIC
+                else:
+                    record.string = NAMEID_4_MAX_UPRIGHT
+            elif record.nameID == 6:
+                if is_italic:
+                    record.string = NAMEID_6_MAX_ITALIC
+                else:
+                    record.string = NAMEID_6_MAX_UPRIGHT
+            elif record.nameID == 16:
+                # eliminate nameID 16
+                skip_record = True
+            elif record.nameID == 17:
+                # eliminate nameID 17
+                skip_record = True
+
+            if not skip_record:
+                new_max_opsz_namerecords.append(record)
+
+        # define new max opsz name records following above edits
+        vf_partial_max_opsz["name"].names = new_max_opsz_namerecords
+
+        # write to min + max opsz file paths
+        vf_filepath = os.path.abspath(fontpath)
+        vf_partial_min_opsz.save(os.path.abspath(fontpath) + ".MIN_INSTANCE")
+        vf_partial_max_opsz.save(os.path.abspath(fontpath) + ".MAX_INSTANCE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gs-partial-instancer.py
+++ b/scripts/gs-partial-instancer.py
@@ -42,7 +42,6 @@ NAMEID_6_MIN_ITALIC = "GoogleSansText-Italic"
 
 
 def main():
-    print(VARIABLE_INPATH)
     in_var_paths = glob.glob(VARIABLE_INPATH)
     assert len(in_var_paths) > 0
     for fontpath in in_var_paths:

--- a/scripts/gs-partial-instancer.py
+++ b/scripts/gs-partial-instancer.py
@@ -170,7 +170,6 @@ def main():
         vf_partial_max_opsz["name"].names = new_max_opsz_namerecords
 
         # write to min + max opsz file paths
-        vf_filepath = os.path.abspath(fontpath)
         vf_partial_min_opsz.save(os.path.abspath(fontpath) + ".MIN_INSTANCE")
         vf_partial_max_opsz.save(os.path.abspath(fontpath) + ".MAX_INSTANCE")
 

--- a/scripts/gs-stat-partial.py
+++ b/scripts/gs-stat-partial.py
@@ -16,7 +16,6 @@
 from fontTools.otlLib.builder import buildStatTable
 from fontTools.ttLib import TTFont
 
-
 UPRIGHT_AXES = [
     dict(
         tag="wght",

--- a/scripts/gs-stat-partial.py
+++ b/scripts/gs-stat-partial.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fontTools.otlLib.builder import buildStatTable
+from fontTools.ttLib import TTFont
+
+
+UPRIGHT_AXES = [
+    dict(
+        tag="wght",
+        name="Weight",
+        ordering=0,
+        values=[
+            dict(value=400, name="Regular", flags=0x2),  # Regular
+            dict(value=500, name="Medium"),  # Medium
+            dict(value=700, name="Bold"),  # Bold
+        ],
+    ),
+    dict(
+        tag="ital",
+        name="Italic",
+        ordering=1,
+        values=[dict(value=0, name="Regular", flags=0x2, linkedValue=1)],  # Regular
+    ),
+]
+
+ITALIC_AXES = [
+    dict(
+        tag="wght",
+        name="Weight",
+        ordering=0,
+        values=[
+            dict(value=400, name="Regular", flags=0x2),  # Regular
+            dict(value=500, name="Medium"),  # Medium
+            dict(value=700, name="Bold"),  # Bold
+        ],
+    ),
+    dict(
+        tag="ital",
+        name="Italic",
+        ordering=1,
+        values=[dict(value=1, name="Italic")],  # Italic
+    ),
+]
+
+VARIABLE_DIR = "../build/GoogleSans/variable/expert/partial"
+GS_UPRIGHT = f"{VARIABLE_DIR}/GoogleSans[wght].ttf"
+GS_ITALIC = f"{VARIABLE_DIR}/GoogleSans-Italic[wght].ttf"
+GST_UPRIGHT = f"{VARIABLE_DIR}/GoogleSansText[wght].ttf"
+GST_ITALIC = f"{VARIABLE_DIR}/GoogleSansText-Italic[wght].ttf"
+
+
+def main():
+    upright_paths = (GS_UPRIGHT, GST_UPRIGHT)
+    italics_paths = (GS_ITALIC, GST_ITALIC)
+
+    # process upright files
+    for filepath in upright_paths:
+        tt = TTFont(filepath)
+        buildStatTable(tt, UPRIGHT_AXES)
+        tt.save(filepath)
+        print(f"[STAT TABLE] Added STAT table to {filepath}")
+
+    # process italics files
+    for filepath in italics_paths:
+        tt = TTFont(filepath)
+        buildStatTable(tt, ITALIC_AXES)
+        tt.save(filepath)
+        print(f"[STAT TABLE] Added STAT table to {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gs-subset.py
+++ b/scripts/gs-subset.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2020 Google Sans Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,9 @@ import sys
 
 from fontTools.subset import main as subset_main
 
+STATIC_INPATH = "../build/GoogleSans/static/expert/*.ttf"
+VARIABLE_INPATH = "../build/GoogleSans/variable/expert/*.ttf"
+
 
 def main():
     # ===============================================
@@ -30,7 +34,7 @@ def main():
     # This build includes all shaping and OT feature support,
     # *including* all alternate designs supported through the
     # `aalt` OpenType feature
-    in_static_filepaths = glob.glob("../build/GoogleSans/static/expert/*.ttf")
+    in_static_filepaths = glob.glob(STATIC_INPATH)
 
     for rel_filepath in in_static_filepaths:
         print(f"[SUBSET] {rel_filepath} to Expert build...")
@@ -79,7 +83,7 @@ def main():
     # This build eliminates the OpenType `aalt` feature
     # support and all alternate glyph designs.
 
-    in_static_filepaths = glob.glob("../build/GoogleSans/static/expert/*.ttf")
+    in_static_filepaths = glob.glob(STATIC_INPATH)
 
     for rel_filepath in in_static_filepaths:
         print(f"[SUBSET] {rel_filepath} to Default build...")

--- a/source/Makefile
+++ b/source/Makefile
@@ -151,7 +151,11 @@ gs-vf: $(FONT_BUILD_DIR)
 	mv "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX)" "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX_TARGET)"
 	mv "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN)" "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN_TARGET)"
 	mv "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN)" "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN_TARGET)"
-	
+	@echo "================================"
+	@echo " Add STAT tables"
+	@echo "================================"
+	# partial instance build VF STAT tables
+	$(PYTHON3_EXE) ../scripts/gs-stat-partial.py
 
 #
 #  Individual static instance build targets

--- a/source/Makefile
+++ b/source/Makefile
@@ -43,11 +43,28 @@ DEFAULT_STATIC_BUILD_DIR=$(FONT_BUILD_DIR)/static/default
 EXPERT_VARIABLE_BUILD_DIR=$(FONT_BUILD_DIR)/variable/expert
 DEFAULT_VARIABLE_BUILD_DIR=$(FONT_BUILD_DIR)/variable/default
 
-# Variable font paths
+PARTIAL_INSTANCE_VARIABLE_BUILD_DIR=$(EXPERT_VARIABLE_BUILD_DIR)/partial
+
+# Variable font build artifacts
+
+# upright
 VARIABLE_BUILD_PATH_UPRIGHT=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans-VF.ttf
 VARIABLE_BUILD_PATH_UPRIGHT_TARGET=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans[opsz,wght].ttf
+
+# italic
 VARIABLE_BUILD_PATH_ITALIC=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans-Italic-VF.ttf
 VARIABLE_BUILD_PATH_ITALIC_TARGET=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans-Italic[opsz,wght].ttf
+
+# partial instances ('wght' axis only)
+VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MAX=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans[opsz,wght].ttf.MAX_INSTANCE
+VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans-Italic[opsz,wght].ttf.MAX_INSTANCE
+VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans[opsz,wght].ttf.MIN_INSTANCE
+VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN=$(EXPERT_VARIABLE_BUILD_DIR)/GoogleSans-Italic[opsz,wght].ttf.MIN_INSTANCE
+
+VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MAX_TARGET=$(PARTIAL_INSTANCE_VARIABLE_BUILD_DIR)/GoogleSans[wght].ttf
+VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX_TARGET=$(PARTIAL_INSTANCE_VARIABLE_BUILD_DIR)/GoogleSans-Italic[wght].ttf
+VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN_TARGET=$(PARTIAL_INSTANCE_VARIABLE_BUILD_DIR)/GoogleSansText[wght].ttf
+VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN_TARGET=$(PARTIAL_INSTANCE_VARIABLE_BUILD_DIR)/GoogleSansText-Italic[wght].ttf
 
 # --------------------------------------------------------
 #  UFO intermediates and designspace paths
@@ -89,7 +106,7 @@ gs-static: $(FONT_BUILD_DIR)
 	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) --interpolate -o ttf --output-dir $(EXPERT_STATIC_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) --interpolate -o ttf --output-dir $(EXPERT_STATIC_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	@echo "================================"
-	@echo " Beginning post-compile fixes..."
+	@echo " Beginning post-compile edits..."
 	@echo "================================"
 	@echo "================================"
 	@echo " Beginning font subsetting..."
@@ -111,7 +128,7 @@ gs-vf: $(FONT_BUILD_DIR)
 	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	@echo "================================"
-	@echo " Beginning post-compile fixes..."
+	@echo " Beginning post-compile edits..."
 	@echo "================================"
 	@echo "================================"
 	@echo " MVAR table removal"
@@ -125,6 +142,16 @@ gs-vf: $(FONT_BUILD_DIR)
 	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $(EXPERT_VARIABLE_BUILD_DIR)/*.ttf
 	# remove the backups that the script leaves behind
 	rm $(EXPERT_VARIABLE_BUILD_DIR)/*prep-gasp.ttf
+	@echo "================================"
+	@echo " Partial instance build targets"
+	@echo "================================"
+	$(PYTHON3_EXE) ../scripts/gs-partial-instancer.py
+	mkdir -p "$(PARTIAL_INSTANCE_VARIABLE_BUILD_DIR)"
+	mv "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MAX)" "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MAX_TARGET)"
+	mv "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX)" "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MAX_TARGET)"
+	mv "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN)" "$(VARIABLE_BUILD_PATH_PARTIAL_UPRIGHT_MIN_TARGET)"
+	mv "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN)" "$(VARIABLE_BUILD_PATH_PARTIAL_ITALIC_MIN_TARGET)"
+	
 
 #
 #  Individual static instance build targets


### PR DESCRIPTION
Adds support for variable `wght` axis only VF build artifacts with instances at min opsz = 14 and max opsz = 18.  Builds occur in a new `build/GoogleSans/variable/expert/partial` directory path.  This approach uses the `fontTools.varLib.instancer` library and requires post-compile edits of the name tables in the partially instantiated fonts.

### TODO:

- [x] add STAT tables to partial instance builds (https://github.com/googlefonts/googlesans/pull/5/commits/e2d53f5ead757b2299a498d7f67bcfa2d1ee727d)
- [x] pin fontTools version number in requirements.txt after the new `fontTools.otlLib.builder.buildStatTable` function submitted in  https://github.com/fonttools/fonttools/pull/1926 is released.

### Blockers
- blocked on release of Just van Rossum's new `fontTools.otlLib.builder` function that supports STAT table gens with fontTools library.  This is currently merged into master. [Addressed in [https://github.com/googlefonts/googlesans/pull/5/commits/099046b6618826ce2fa32da201a8b26eb207356a ](https://github.com/googlefonts/googlesans/pull/5/commits/099046b6618826ce2fa32da201a8b26eb207356a)]


Closes #6 
Closes #7 