### PR TITLE
Add GH Actions OpenType sanitizer checks on static and variable font builds

### DIFF
--- a/.github/workflows/static-artifact-ci.yml
+++ b/.github/workflows/static-artifact-ci.yml
@@ -62,3 +62,11 @@ jobs:
       #     subcmd: "check-profile"
       #     args: "-C --loglevel WARN qa/check-googlesans.py"
       #     path: "build/GoogleSans/static/default/*.ttf"
+      - name: OpenType Sanitizer checks (Expert artifacts)
+        uses: f-actions/opentype-sanitizer@master
+        with:
+          path: "${{ steps.config.outputs.buildpath }}"
+      - name: OpenType Sanitizer checks (Default artifacts)
+        uses: f-actions/opentype-sanitizer@master
+        with:
+          path: "build/GoogleSans/static/default/*.ttf"

--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -55,10 +55,18 @@ jobs:
       #     subcmd: "check-profile"
       #     args: "-C --loglevel WARN qa/check-charset.py"
       #     path: "${{ steps.config.outputs.buildpath }}"
-      - name: Font Bakery GS profile tests (1-axis Expert)
+      - name: Font Bakery GS profile tests (1-axis Expert artifacts)
         uses: f-actions/font-bakery@master
         with:
           version: "latest"
           subcmd: "check-profile"
           args: "-C --loglevel WARN qa/check-googlesans.py"
+          path: "build/GoogleSans/variable/expert/partial/*.ttf"
+      - name: OpenType Sanitizer checks (2-axis Expert artifacts)
+        uses: f-actions/opentype-sanitizer@master
+        with:
+          path: "${{ steps.config.outputs.buildpath }}"
+      - name: OpenType Sanitizer checks (1-axis Expert artifacts)
+        uses: f-actions/opentype-sanitizer@master
+        with:
           path: "build/GoogleSans/variable/expert/partial/*.ttf"


### PR DESCRIPTION
Related #1 

This PR adds OTS checks to the CI tests run on GH Actions.