### PR TITLE
Add remote WIP font build push + download support through GH Actions

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -1,0 +1,93 @@
+name: Artifact Uploads
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master # Push events on master branch
+      - "build/**" # Push events to branches matching refs/heads/build/[ANYTHING]
+      - "build-*" # Push events to branches matching refs/heads/build-[ANYTHING]
+
+jobs:
+  static-artifact-uploads:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    name: Upload static artifacts
+    steps:
+      - name: Configuration
+        id: config
+        uses: f-actions/font-setup@master
+        with:
+          projectname: "Google Sans"
+          sourcepath: "src"
+          buildpath: "build/GoogleSans/static" # static font dir
+          dependpath: "requirements.txt"
+          py-version: ${{ matrix.python-version }}
+          buildcommand: "make gs-static" # static font make target
+      - name: Check out ${{ steps.config.outputs.projectname }} source repository
+        uses: actions/checkout@v2
+      - name: Set up Python v${{ steps.config.outputs.py-version }} environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ steps.config.outputs.py-version }}
+      - name: Python build dependency cache lookup
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          # Check for requirements file cache hit
+          key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
+      - name: Install Python build dependencies
+        uses: py-actions/py-dependency-install@v1
+        with:
+          update-wheel: "true"
+          update-setuptools: "true"
+      - name: Build fonts
+        run: ${{ steps.config.outputs.buildcommand }}
+      - name: Push static font artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: GoogleSans-static
+          path: ${{ steps.config.outputs.buildpath }}
+
+  variable-artifact-uploads:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    name: Upload variable artifacts
+    steps:
+      - name: Configuration
+        id: config
+        uses: f-actions/font-setup@master
+        with:
+          projectname: "Google Sans"
+          sourcepath: "src"
+          buildpath: "build/GoogleSans/variable" # variable font dir
+          dependpath: "requirements.txt"
+          py-version: ${{ matrix.python-version }}
+          buildcommand: "make gs-vf" # static font make target
+      - name: Check out ${{ steps.config.outputs.projectname }} source repository
+        uses: actions/checkout@v2
+      - name: Set up Python v${{ steps.config.outputs.py-version }} environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ steps.config.outputs.py-version }}
+      - name: Python build dependency cache lookup
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          # Check for requirements file cache hit
+          key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
+      - name: Install Python build dependencies
+        uses: py-actions/py-dependency-install@v1
+        with:
+          update-wheel: "true"
+          update-setuptools: "true"
+      - name: Build fonts
+        run: ${{ steps.config.outputs.buildcommand }}
+      - name: Push variable font artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: GoogleSans-variable
+          path: ${{ steps.config.outputs.buildpath }}


### PR DESCRIPTION
This PR adds support for uploads of static and variable font build artifacts when commits are pushed to `master`, `build-*`, or `build/*` git branches.

The artifacts are compiled with the same reproducible build pipeline that is checked by our CI tests and pushed for download through the GitHub Actions UI.

<img width="1643" alt="2020-05-20_16-04-47" src="https://user-images.githubusercontent.com/4249591/82492183-c6999980-9ab3-11ea-8db3-c7aa63483c0d.png">

This will support WIP testing of font files during development.  These push workflows are intentionally separate from the CI test workflows so that builds + pushes occur even when CI tests fail as binaries may need to be inspected as part of CI failure diagnostics. 

These artifacts are stored for 90 days. They are meant to be temporary builds for testing support.  Releases will be pushed as permanent artifacts using GitHub releases when a version formatted git tag is pushed to the remote.  Release artifact support will be added in a separate PR.

With these changes, designers will be able to push design source updates to a `build-*` or `build/*` branch and click to download test fonts without a local build environment requirement.