### PR TITLE
Add build time UPM scaling support to variable font artifact pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pyclipper==1.1.0.post3    # via booleanoperations
 pytz==2020.1              # via fs
 six==1.14.0               # via fs
 typing-extensions==3.7.4.2  # via ufolib2
-ufo2ft==2.13.0            # via fontmake
+ufo2ft==2.14.0            # via fontmake
 ufolib2==0.7.1            # via fontmake, glyphslib
 unicodedata2==13.0.0.post2  # via fonttools
 

--- a/scripts/scale_ufo.py
+++ b/scripts/scale_ufo.py
@@ -95,6 +95,10 @@ def _scale_glyphs(font, scale_factor):
     scale = TransformationsFilter(ScaleX=scale_factor * 100, ScaleY=scale_factor * 100)
     scale(font)
 
+    for glyph in font:
+        glyph.width *= scale_factor
+        glyph.height *= scale_factor
+
 
 def scale_ufo(font, scale_factor, inplace=True):
     if not inplace:

--- a/scripts/scale_ufo.py
+++ b/scripts/scale_ufo.py
@@ -16,64 +16,93 @@
 from copy import deepcopy
 import logging
 from ufoLib2 import Font
-from fontMath import MathInfo, MathKerning, MathGlyph
+from ufo2ft.filters.transformations import TransformationsFilter
 
 
 __all__ = ["scale_ufo"]
 
 
-# fontinfo.plist attributes to exclude from fontMath's scaling operation
-EXCLUDE_INFO_ATTRIBUTES = {
-    "postscriptWeightName",
-    "openTypeHeadLowestRecPPEM",
-    "openTypeOS2WidthClass",
-    "openTypeOS2WeightClass",
-    "postscriptSlantAngle",
-    "postscriptBlueFuzz",
-    "postscriptBlueScale",
-    # TODO: check if other postcript hinting-related attributes should not be scaled
+# fontinfo.plist attributes to include in scaling operation
+INCLUDE_INFO_ATTRIBUTES = {
+    "unitsPerEm",
+    "descender",
+    "xHeight",
+    "capHeight",
+    "ascender",
+    "openTypeHheaAscender",
+    "openTypeHheaDescender",
+    "openTypeHheaLineGap",
+    "openTypeHheaCaretOffset",
+    "openTypeOS2TypoAscender",
+    "openTypeOS2TypoDescender",
+    "openTypeOS2TypoLineGap",
+    "openTypeOS2WinAscent",
+    "openTypeOS2WinDescent",
+    "openTypeOS2SubscriptXSize",
+    "openTypeOS2SubscriptYSize",
+    "openTypeOS2SubscriptXOffset",
+    "openTypeOS2SubscriptYOffset",
+    "openTypeOS2SuperscriptXSize",
+    "openTypeOS2SuperscriptYSize",
+    "openTypeOS2SuperscriptXOffset",
+    "openTypeOS2SuperscriptYOffset",
+    "openTypeOS2StrikeoutSize",
+    "openTypeOS2StrikeoutPosition",
+    "openTypeVheaVertTypoAscender",
+    "openTypeVheaVertTypoDescender",
+    "openTypeVheaVertTypoLineGap",
+    "openTypeVheaCaretOffset",
+    "postscriptUnderlineThickness",
+    "postscriptUnderlinePosition",
+    "postscriptBlueValues",
+    "postscriptOtherBlues",
+    "postscriptFamilyBlues",
+    "postscriptFamilyOtherBlues",
+    "postscriptStemSnapH",
+    "postscriptStemSnapV",
+    "postscriptBlueShift",
+    "postscriptDefaultWidthX",
+    "postscriptNominalWidthX",
 }
 
 
-def _scale_info(font, scale_factor, rounded=True):
-    minfo = MathInfo(font.info)
-    minfo *= scale_factor
-    if rounded:
-        minfo = minfo.round()
+def _scale_info(font, scale_factor):
 
-    excluded = {attr: getattr(font.info, attr) for attr in EXCLUDE_INFO_ATTRIBUTES}
-    minfo.extractInfo(font.info)
-    for attr, value in excluded.items():
-        setattr(font.info, attr, value)
+    def scale(v):
+        v *= scale_factor
+        if attr.startswith("openType"):
+            # ufoLib validators strictly require these to be formatted as integers
+            return round(v)
+        return v
 
-
-def _scale_kerning(font, scale_factor, rounded=True):
-    mkern = MathKerning(font.kerning)
-    mkern *= scale_factor
-    if rounded:
-        mkern.round()
-    mkern.extractKerning(font)
+    for attr in INCLUDE_INFO_ATTRIBUTES:
+        value = getattr(font.info, attr)
+        if isinstance(value, list):
+            setattr(font.info, attr, [scale(v) for v in value])
+        elif value is not None:
+            setattr(font.info, attr, scale(value))
 
 
-def _scale_glyphs(font, scale_factor, rounded=True):
-    for glyph_name in font.keys():
-        glyph = font[glyph_name]
-        # NOTE: 'scaleComponentTransform' option was added with fontMath 0.6.0
-        # https://github.com/robotools/fontMath/issues/193
-        mglyph = MathGlyph(glyph, scaleComponentTransform=False)
-        mglyph *= scale_factor
-        if rounded:
-            mglyph = mglyph.round()
-        mglyph.extractGlyph(glyph, onlyGeometry=True)
+def _scale_kerning(font, scale_factor):
+    for pair, value in font.kerning.items():
+        font.kerning[pair] = value * scale_factor
 
 
-def scale_ufo(font, scale_factor, rounded=True, inplace=True):
+def _scale_glyphs(font, scale_factor):
+    # ufo2ft transformations filter uses percentages for scale.
+    # NOTE: Make sure to use ufo2ft 2.14 as it fixes a bug with transformations of
+    # composite glyphs: https://github.com/googlefonts/ufo2ft/issues/378
+    scale = TransformationsFilter(ScaleX=scale_factor * 100, ScaleY=scale_factor * 100)
+    scale(font)
+
+
+def scale_ufo(font, scale_factor, inplace=True):
     if not inplace:
         font = deepcopy(font)
 
-    _scale_info(font, scale_factor, rounded=rounded)
-    _scale_kerning(font, scale_factor, rounded=rounded)
-    _scale_glyphs(font, scale_factor, rounded=rounded)
+    _scale_info(font, scale_factor)
+    _scale_kerning(font, scale_factor)
+    _scale_glyphs(font, scale_factor)
 
     return font
 
@@ -91,7 +120,6 @@ def main(args=None):
     parser.add_argument(
         "upem", metavar="UPEM", type=int, help="Units Per EM of the scaled UFO"
     )
-    parser.add_argument("--no-round", dest="rounded", action="store_false")
     options = parser.parse_args(args)
 
     logging.basicConfig(level="INFO")
@@ -99,10 +127,12 @@ def main(args=None):
     font = Font.open(options.input_ufo, lazy=False)
 
     scale_factor = options.upem / font.info.unitsPerEm
+    if scale_factor.is_integer():
+        scale_factor = int(scale_factor)
 
     logging.info("scale factor: %s", scale_factor)
 
-    scale_ufo(font, scale_factor, rounded=options.rounded)
+    scale_ufo(font, scale_factor)
 
     if options.output:
         font.save(options.output, overwrite=True)

--- a/scripts/scale_ufo.py
+++ b/scripts/scale_ufo.py
@@ -93,11 +93,13 @@ def _scale_glyphs(font, scale_factor):
     # NOTE: Make sure to use ufo2ft 2.14 as it fixes a bug with transformations of
     # composite glyphs: https://github.com/googlefonts/ufo2ft/issues/378
     scale = TransformationsFilter(ScaleX=scale_factor * 100, ScaleY=scale_factor * 100)
-    scale(font)
 
-    for glyph in font:
-        glyph.width *= scale_factor
-        glyph.height *= scale_factor
+    for layer in font.layers:
+        scale(font, glyphSet=layer)
+
+        for glyph in layer:
+            glyph.width *= scale_factor
+            glyph.height *= scale_factor
 
 
 def scale_ufo(font, scale_factor, inplace=True):

--- a/scripts/scale_ufo.py
+++ b/scripts/scale_ufo.py
@@ -1,0 +1,114 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from copy import deepcopy
+import logging
+from ufoLib2 import Font
+from fontMath import MathInfo, MathKerning, MathGlyph
+
+
+__all__ = ["scale_ufo"]
+
+
+# fontinfo.plist attributes to exclude from fontMath's scaling operation
+EXCLUDE_INFO_ATTRIBUTES = {
+    "postscriptWeightName",
+    "openTypeHeadLowestRecPPEM",
+    "openTypeOS2WidthClass",
+    "openTypeOS2WeightClass",
+    "postscriptSlantAngle",
+    "postscriptBlueFuzz",
+    "postscriptBlueScale",
+    # TODO: check if other postcript hinting-related attributes should not be scaled
+}
+
+
+def _scale_info(font, scale_factor, rounded=True):
+    minfo = MathInfo(font.info)
+    minfo *= scale_factor
+    if rounded:
+        minfo = minfo.round()
+
+    excluded = {attr: getattr(font.info, attr) for attr in EXCLUDE_INFO_ATTRIBUTES}
+    minfo.extractInfo(font.info)
+    for attr, value in excluded.items():
+        setattr(font.info, attr, value)
+
+
+def _scale_kerning(font, scale_factor, rounded=True):
+    mkern = MathKerning(font.kerning)
+    mkern *= scale_factor
+    if rounded:
+        mkern.round()
+    mkern.extractKerning(font)
+
+
+def _scale_glyphs(font, scale_factor, rounded=True):
+    for glyph_name in font.keys():
+        glyph = font[glyph_name]
+        # NOTE: 'scaleComponentTransform' option was added with fontMath 0.6.0
+        # https://github.com/robotools/fontMath/issues/193
+        mglyph = MathGlyph(glyph, scaleComponentTransform=False)
+        mglyph *= scale_factor
+        if rounded:
+            mglyph = mglyph.round()
+        mglyph.extractGlyph(glyph, onlyGeometry=True)
+
+
+def scale_ufo(font, scale_factor, rounded=True, inplace=True):
+    if not inplace:
+        font = deepcopy(font)
+
+    _scale_info(font, scale_factor, rounded=rounded)
+    _scale_kerning(font, scale_factor, rounded=rounded)
+    _scale_glyphs(font, scale_factor, rounded=rounded)
+
+    return font
+
+
+def main(args=None):
+    import argparse
+
+    parser = argparse.ArgumentParser("scale_ufo")
+    parser.add_argument(
+        "--output", metavar="OUTPUT_UFO", help="If omitted, save UFO in place"
+    )
+    parser.add_argument(
+        "input_ufo", metavar="INPUT_UFO", help="Path to input UFO to be scaled"
+    )
+    parser.add_argument(
+        "upem", metavar="UPEM", type=int, help="Units Per EM of the scaled UFO"
+    )
+    parser.add_argument("--no-round", dest="rounded", action="store_false")
+    options = parser.parse_args(args)
+
+    logging.basicConfig(level="INFO")
+
+    font = Font.open(options.input_ufo, lazy=False)
+
+    scale_factor = options.upem / font.info.unitsPerEm
+
+    logging.info("scale factor: %s", scale_factor)
+
+    scale_ufo(font, scale_factor, rounded=options.rounded)
+
+    if options.output:
+        font.save(options.output, overwrite=True)
+    else:
+        font.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/Makefile
+++ b/source/Makefile
@@ -22,6 +22,13 @@ VENV_DIR=.venv
 PYTHON3_EXE=python3
 
 # --------------------------------------------------------
+#  Variable font UPM value
+#    NOTE: used for scaling of variable font UFO sources
+#          at build time
+# --------------------------------------------------------
+UPM=2000
+
+# --------------------------------------------------------
 #  fontmake compiler executable
 #    NOTE: this builds from a venv install to support
 #          pinned dependency versions
@@ -78,21 +85,27 @@ UPRIGHT_DESIGNSPACE_PATH=$(MASTER_UFO_DIR)/$(UPRIGHT_DESIGNSPACE)
 ITALIC_DESIGNSPACE_PATH=$(MASTER_UFO_DIR)/$(ITALIC_DESIGNSPACE)
 
 # --------------------------------------------------------
-#  Master and instance intermediate UFO file paths
+#  Master intermediate UFO file paths
 # --------------------------------------------------------
-UFO_GS_REGULAR=$(MASTER_UFO_DIR)/GoogleSans-Regular.ufo
-UFO_GS_ITALIC=$(MASTER_UFO_DIR)/GoogleSans-Italic.ufo
-UFO_GS_MEDIUM=$(INSTANCE_UFO_DIR)/GoogleSans-Medium.ufo
-UFO_GS_MEDIUMITALIC=$(INSTANCE_UFO_DIR)/GoogleSans-MediumItalic.ufo
-UFO_GS_BOLD=$(MASTER_UFO_DIR)/GoogleSans-Bold.ufo
-UFO_GS_BOLDITALIC=$(MASTER_UFO_DIR)/GoogleSans-BoldItalic.ufo
+UFO_GS_REGULAR=$(MASTER_UFO_DIR)/GoogleSans-SansRegular.ufo
+UFO_GS_ITALIC=$(MASTER_UFO_DIR)/GoogleSans-SansItalic.ufo
+UFO_GS_BOLD=$(MASTER_UFO_DIR)/GoogleSans-SansBold.ufo
+UFO_GS_BOLDITALIC=$(MASTER_UFO_DIR)/GoogleSans-SansBoldItalic.ufo
 
 UFO_GS_TEXT_REGULAR=$(MASTER_UFO_DIR)/GoogleSans-TextRegular.ufo
 UFO_GS_TEXT_ITALIC=$(MASTER_UFO_DIR)/GoogleSans-TextItalic.ufo
+UFO_GS_TEXT_BOLD=$(MASTER_UFO_DIR)/GoogleSans-TextBold.ufo
+UFO_GS_TEXT_BOLDITALIC=$(MASTER_UFO_DIR)/GoogleSans-BoldTextItalic.ufo
+
+# --------------------------------------------------------
+#  Instance intermediate UFO file paths
+# --------------------------------------------------------
+
+UFO_GS_MEDIUM=$(INSTANCE_UFO_DIR)/GoogleSans-Medium.ufo
+UFO_GS_MEDIUMITALIC=$(INSTANCE_UFO_DIR)/GoogleSans-MediumItalic.ufo
+
 UFO_GS_TEXT_MEDIUM=$(INSTANCE_UFO_DIR)/GoogleSans-TextMedium.ufo
 UFO_GS_TEXT_MEDIUMITALIC=$(INSTANCE_UFO_DIR)/GoogleSans-TextMediumItalic.ufo
-UFO_GS_TEXT_BOLD=$(MASTER_UFO_DIR)/GoogleSans-TextBold.ufo
-UFO_GS_TEXT_BOLDITALIC=$(MASTER_UFO_DIR)/GoogleSans-TextBoldItalic.ufo
 
 # --------------------------------------------------------
 #  TARGETS
@@ -125,8 +138,27 @@ gs-static: $(FONT_BUILD_DIR)
 
 
 gs-vf: $(FONT_BUILD_DIR)
-	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
-	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
+	@echo "================================"
+	@echo " Build variable artifacts..."
+	@echo "================================"
+	# Build to intermediate UFO + designspace files
+	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) --interpolate -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
+	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) --interpolate -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
+	# Scale intermediate master sources to 2000 UPM
+	# upright sources
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_REGULAR) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_ITALIC) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_BOLD) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_BOLDITALIC) $(UPM)
+	# italic sources
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_TEXT_REGULAR) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_TEXT_ITALIC) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_TEXT_BOLD) $(UPM)
+	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_TEXT_BOLDITALIC) $(UPM)
+	# compile to ttf artifacts
+	$(FONTMAKE_EXE) -m $(UPRIGHT_DESIGNSPACE_PATH) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR)
+	$(FONTMAKE_EXE) -m $(ITALIC_DESIGNSPACE_PATH) -o variable --output-dir $(EXPERT_VARIABLE_BUILD_DIR)
+
 	@echo "================================"
 	@echo " Beginning post-compile edits..."
 	@echo "================================"

--- a/source/Makefile
+++ b/source/Makefile
@@ -142,7 +142,7 @@ gs-vf: $(FONT_BUILD_DIR)
 	@echo " Build variable artifacts..."
 	@echo "================================"
 	# Build to intermediate UFO + designspace files
-	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) --interpolate -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
+	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) --interpolate -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	# Scale intermediate master sources to 2000 UPM
 	# upright sources

--- a/source/Makefile
+++ b/source/Makefile
@@ -143,7 +143,7 @@ gs-vf: $(FONT_BUILD_DIR)
 	@echo "================================"
 	# Build to intermediate UFO + designspace files
 	$(FONTMAKE_EXE) -g $(UPRIGHT_SOURCE) -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
-	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) --interpolate -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
+	$(FONTMAKE_EXE) -g $(ITALIC_SOURCE) -o ufo --output-dir $(EXPERT_VARIABLE_BUILD_DIR) --master-dir $(MASTER_UFO_DIR) --instance-dir $(INSTANCE_UFO_DIR)
 	# Scale intermediate master sources to 2000 UPM
 	# upright sources
 	$(PYTHON3_EXE) ../scripts/scale_ufo.py $(UFO_GS_REGULAR) $(UPM)


### PR DESCRIPTION
This PR adds a [UPM scaling script](https://gist.github.com/anthrotype/62d0bfe1d38b8f11a199bd3b66574bcc) that works at the intermediate UFO stage of the fontmake variable font build process.  

#### TODO

- [ ] update fontbakery metrics value checks for variable fonts (must be scaled by factor of 2 with these changes)
- [x] check file size difference b/w 1000 UPM and 2000 UPM VF builds (~2% increase in size with 2000 UPM)
- [x] fix upm scaling script so that it scales values across all layers in the design (b289377)
- [ ] refactor static and VF make targets to eliminate duplication/take advantage of steps that can be parallelized in the build process with `make -j`

Closes #32 
Closes #33 
Fixes #48 