### PR TITLE
Add 2-axis VF STAT table write support

### DIFF
--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -41,20 +41,20 @@ jobs:
           update-setuptools: "true"
       - name: Build fonts
         run: ${{ steps.config.outputs.buildcommand }}
-      # - name: Font Bakery GS profile tests (2-axis Expert)
-      #   uses: f-actions/font-bakery@master
-      #   with:
-      #     version: "latest"
-      #     subcmd: "check-profile"
-      #     args: "-C --loglevel WARN qa/check-googlesans.py"
-      #     path: "${{ steps.config.outputs.buildpath }}"
-      # - name: Font Bakery character set profile tests (2-axis Expert)
-      #   uses: f-actions/font-bakery@master
-      #   with:
-      #     version: "latest"
-      #     subcmd: "check-profile"
-      #     args: "-C --loglevel WARN qa/check-charset.py"
-      #     path: "${{ steps.config.outputs.buildpath }}"
+      - name: Font Bakery GS profile tests (2-axis Expert)
+        uses: f-actions/font-bakery@master
+        with:
+          version: "latest"
+          subcmd: "check-profile"
+          args: "-C --loglevel WARN qa/check-googlesans.py"
+          path: "${{ steps.config.outputs.buildpath }}"
+      - name: Font Bakery character set profile tests (2-axis Expert)
+        uses: f-actions/font-bakery@master
+        with:
+          version: "latest"
+          subcmd: "check-profile"
+          args: "-C --loglevel WARN qa/check-charset.py"
+          path: "${{ steps.config.outputs.buildpath }}"
       - name: Font Bakery GS profile tests (1-axis Expert artifacts)
         uses: f-actions/font-bakery@master
         with:

--- a/scripts/gs-stat.py
+++ b/scripts/gs-stat.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fontTools.otlLib.builder import buildStatTable
+from fontTools.ttLib import TTFont
+
+UPRIGHT_AXES = [
+    dict(
+        tag="opsz",
+        name="Optical Size",
+        ordering=0,
+        values=[
+            dict(
+                rangeMinValue=18, nominalValue=18, name="Max", flags=0x2
+            ),  # Max opsz, use elided name of "Google Sans" without opsz identifier
+            dict(rangeMinValue=6, nominalValue=14, rangeMaxValue=17, name="Text"),  # Text
+        ],
+    ),
+    dict(
+        tag="wght",
+        name="Weight",
+        ordering=1,
+        values=[
+            dict(value=400, name="Regular", flags=0x2),  # Regular
+            dict(value=500, name="Medium"),  # Medium
+            dict(value=700, name="Bold"),  # Bold
+        ],
+    ),
+    dict(
+        tag="ital",
+        name="Italic",
+        ordering=2,
+        values=[dict(value=0, name="Regular", flags=0x2, linkedValue=1)],  # Regular
+    ),
+]
+
+ITALIC_AXES = [
+    dict(
+        tag="opsz",
+        name="Optical Size",
+        ordering=0,
+        values=[
+            dict(
+                rangeMinValue=18, nominalValue=18, name="Max", flags=0x2
+            ),  # Max opsz, use elided name of "Google Sans" without opsz identifier
+            dict(rangeMinValue=6, nominalValue=14, rangeMaxValue=17, name="Text"),  # Text
+        ],
+    ),
+    dict(
+        tag="wght",
+        name="Weight",
+        ordering=1,
+        values=[
+            dict(value=400, name="Regular", flags=0x2),  # Regular
+            dict(value=500, name="Medium"),  # Medium
+            dict(value=700, name="Bold"),  # Bold
+        ],
+    ),
+    dict(
+        tag="ital",
+        name="Italic",
+        ordering=2,
+        values=[dict(value=1, name="Italic")],  # Italic
+    ),
+]
+
+VARIABLE_DIR = "../build/GoogleSans/variable/expert"
+GS_UPRIGHT = f"{VARIABLE_DIR}/GoogleSans[opsz,wght].ttf"
+GS_ITALIC = f"{VARIABLE_DIR}/GoogleSans-Italic[opsz,wght].ttf"
+
+
+def main():
+    # process upright files
+    filepath = GS_UPRIGHT
+    tt = TTFont(filepath)
+    buildStatTable(tt, UPRIGHT_AXES)
+    tt.save(filepath)
+    print(f"[STAT TABLE] Added STAT table to {filepath}")
+
+    # process italics files
+    filepath = GS_ITALIC
+    tt = TTFont(filepath)
+    buildStatTable(tt, ITALIC_AXES)
+    tt.save(filepath)
+    print(f"[STAT TABLE] Added STAT table to {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/Makefile
+++ b/source/Makefile
@@ -154,7 +154,9 @@ gs-vf: $(FONT_BUILD_DIR)
 	@echo "================================"
 	@echo " Add STAT tables"
 	@echo "================================"
-	# partial instance build VF STAT tables
+	# STAT tables for 2-axis VF build targets
+	$(PYTHON3_EXE) ../scripts/gs-stat.py
+	# STAT tables for 1-axis (wght) build targets
 	$(PYTHON3_EXE) ../scripts/gs-stat-partial.py
 
 #


### PR DESCRIPTION
Adds STAT table generation for 2-axis variable font builds.

The definitions in this PR include:

- min opsz range = 6 - 17 = "Google Sans Text"
- max opsz range = 18 + = "Google Sans", placeholder name "Max" defined as elided value
- wght 400 = Regular, defined as elided name value
- wght 500 = Medium
- wght 700 = Bold

Closes #11 