### PR TITLE
Min Opsz restructure

### DIFF
--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1286";
+.appVersion = "1237";
 classes = (
 {
 code = "zero one two three four five six seven eight nine";
@@ -3206,7 +3206,7 @@ position = "{91, 960}";
 );
 id = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 italicAngle = 10;
-weightValue = 14;
+weightValue = 17;
 widthValue = 380;
 xHeight = 526;
 },
@@ -3301,7 +3301,7 @@ verticalStems = (
 95
 );
 weight = Bold;
-weightValue = 14;
+weightValue = 17;
 widthValue = 734;
 xHeight = 526;
 },
@@ -9104,7 +9104,7 @@ unicode = 0046;
 },
 {
 glyphname = G;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:16 +0000";
 layers = (
 {
 anchors = (
@@ -9370,7 +9370,7 @@ position = "{476, 716}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "4EA8DA53-A620-4DD1-9424-B60B28B7E4D3";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9477,7 +9477,7 @@ position = "{493, 716}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "FC80B4FC-6917-4D48-AD4D-84FB370372BA";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9577,7 +9577,7 @@ nodes = (
 );
 };
 layerId = "418B8A48-8E35-4E59-8A7E-F3FF83C640EE";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9677,7 +9677,7 @@ nodes = (
 );
 };
 layerId = "9E059F69-376B-48B9-A0F0-0B2EC2DC38CE";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9725,7 +9725,7 @@ unicode = 0047;
 },
 {
 glyphname = Gbreve;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:26 +0000";
 layers = (
 {
 components = (
@@ -9791,7 +9791,7 @@ transform = "{1, 0, 0, 1, 227, 0}";
 }
 );
 layerId = "5AE0E551-FEA0-4610-BA33-C7274B9F758E";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -9806,7 +9806,7 @@ transform = "{1, 0, 0, 1, 236, 0}";
 }
 );
 layerId = "5D89527F-D23D-4D99-81BA-E1C9D163ABE6";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -9821,7 +9821,7 @@ transform = "{1, 0, 0, 1, 235, 0}";
 }
 );
 layerId = "42BD0172-88E6-4E98-84D2-4CBE9F6CE3FB";
-name = "[16]";
+name = "[17.5]";
 width = 814;
 },
 {
@@ -9836,7 +9836,7 @@ transform = "{1, 0, 0, 1, 230, 0}";
 }
 );
 layerId = "05F9A34A-FB17-4C34-8CDB-3E2B379EE0F4";
-name = "[16]";
+name = "[17.5]";
 width = 826;
 }
 );
@@ -9846,7 +9846,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:34 +0000";
 layers = (
 {
 components = (
@@ -9912,7 +9912,7 @@ transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
 layerId = "A083780D-FACF-4D01-8905-64DA8997F4C9";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -9927,7 +9927,7 @@ transform = "{1, 0, 0, 1, 215, 0}";
 }
 );
 layerId = "DEDF4123-CC98-4A5D-BEDF-4914AFE75CF4";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -9942,7 +9942,7 @@ transform = "{1, 0, 0, 1, 239, 0}";
 }
 );
 layerId = "788F724F-2D47-47A0-8952-048ED6C4A066";
-name = "[16]";
+name = "[17.5]";
 width = 814;
 },
 {
@@ -9957,7 +9957,7 @@ transform = "{1, 0, 0, 1, 211, 0}";
 }
 );
 layerId = "666C8A43-722B-4B18-8683-C89776D5BA9E";
-name = "[16]";
+name = "[17.5]";
 width = 826;
 }
 );
@@ -9967,7 +9967,7 @@ unicode = 011C;
 },
 {
 glyphname = Gcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:42 +0000";
 layers = (
 {
 components = (
@@ -10038,7 +10038,7 @@ transform = "{1, 0, 0, 1, 185, 0}";
 }
 );
 layerId = "41865487-84EA-4874-A1F4-0FC02F3168D8";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -10053,7 +10053,7 @@ transform = "{1, 0, 0, 1, 194, 0}";
 }
 );
 layerId = "89D2D957-82BF-4F6A-8F81-3AA599ECE290";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -10073,7 +10073,7 @@ position = "{423, -263}";
 }
 );
 layerId = "EC5EBFB5-BC88-448A-A831-0263F5DFB70B";
-name = "[16]";
+name = "[17.5]";
 width = 814;
 },
 {
@@ -10088,7 +10088,7 @@ transform = "{1, 0, 0, 1, 227, 0}";
 }
 );
 layerId = "958F3853-AFFD-4197-A90F-000E7239CE07";
-name = "[16]";
+name = "[17.5]";
 width = 826;
 }
 );
@@ -10098,7 +10098,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:47 +0000";
 layers = (
 {
 components = (
@@ -10164,7 +10164,7 @@ transform = "{1, 0, 0, 1, 282, 0}";
 }
 );
 layerId = "720371D6-25AA-43BB-8BDC-9CA711688F21";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -10179,7 +10179,7 @@ transform = "{1, 0, 0, 1, 273, 0}";
 }
 );
 layerId = "50EE2119-7F51-4AD1-A32D-00C0D8637464";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -10194,7 +10194,7 @@ transform = "{1, 0, 0, 1, 323, 0}";
 }
 );
 layerId = "2ADF4212-614F-4067-84B2-2EA84D077CA0";
-name = "[16]";
+name = "[17.5]";
 width = 814;
 },
 {
@@ -10209,7 +10209,7 @@ transform = "{1, 0, 0, 1, 308, 0}";
 }
 );
 layerId = "4A4D8ADA-5FC6-495F-857E-A9F96BF365FA";
-name = "[16]";
+name = "[17.5]";
 width = 826;
 }
 );
@@ -12246,7 +12246,7 @@ unicode = 004B;
 },
 {
 glyphname = Kcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:50:58 +0000";
 layers = (
 {
 components = (
@@ -12312,7 +12312,7 @@ transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
 layerId = "AF1E4E44-D6C8-4F98-B808-C46F577F74D3";
-name = "[16]";
+name = "[17.5]";
 width = 614;
 },
 {
@@ -12327,7 +12327,7 @@ transform = "{1, 0, 0, 1, 135, 0}";
 }
 );
 layerId = "87F202F1-B1A1-4B11-9140-5B26400CDFB8";
-name = "[16]";
+name = "[17.5]";
 width = 675;
 },
 {
@@ -12342,7 +12342,7 @@ transform = "{1, 0, 0, 1, 135, 0}";
 }
 );
 layerId = "20B37757-BF8D-4BE4-9D1F-BCB4164CB1ED";
-name = "[16]";
+name = "[17.5]";
 width = 626;
 },
 {
@@ -12357,7 +12357,7 @@ transform = "{1, 0, 0, 1, 151, 0}";
 }
 );
 layerId = "11887FB0-889A-4A82-AE33-3A4BF6DFF0FA";
-name = "[16]";
+name = "[17.5]";
 width = 683;
 }
 );
@@ -12644,7 +12644,7 @@ unicode = 013D;
 },
 {
 glyphname = Lcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:51:05 +0000";
 layers = (
 {
 components = (
@@ -12710,7 +12710,7 @@ transform = "{1, 0, 0, 1, 87, 0}";
 }
 );
 layerId = "127499F8-35DC-41D6-96E5-85749461E8D8";
-name = "[16]";
+name = "[17.5]";
 width = 556;
 },
 {
@@ -12725,7 +12725,7 @@ transform = "{1, 0, 0, 1, 103, 0}";
 }
 );
 layerId = "1E787795-59FF-495F-B10B-CD9F49F64E2A";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -12740,7 +12740,7 @@ transform = "{1, 0, 0, 1, 97, 0}";
 }
 );
 layerId = "6BFA580F-1352-4D6F-9F0A-96C8D1C8F705";
-name = "[16]";
+name = "[17.5]";
 width = 508;
 },
 {
@@ -12755,7 +12755,7 @@ transform = "{1, 0, 0, 1, 105, 0}";
 }
 );
 layerId = "BC009E83-3EC4-4D47-9B22-CAC38E125023";
-name = "[16]";
+name = "[17.5]";
 width = 550;
 }
 );
@@ -13490,7 +13490,7 @@ unicode = 0147;
 },
 {
 glyphname = Ncommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:51:35 +0000";
 layers = (
 {
 components = (
@@ -13556,7 +13556,7 @@ transform = "{1, 0, 0, 1, 143, 0}";
 }
 );
 layerId = "1A5C2AE2-6DD1-46B0-9C81-6332811D3842";
-name = "[16]";
+name = "[17.5]";
 width = 703;
 },
 {
@@ -13571,7 +13571,7 @@ transform = "{1, 0, 0, 1, 158, 0}";
 }
 );
 layerId = "C1DE7296-9BB8-4AD7-BF44-9BE8DAB7113D";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -13586,7 +13586,7 @@ transform = "{1, 0, 0, 1, 151, 0}";
 }
 );
 layerId = "51A4EFFA-550A-4D96-9C5A-D6EFF1A88A93";
-name = "[16]";
+name = "[17.5]";
 width = 707;
 },
 {
@@ -13601,7 +13601,7 @@ transform = "{1, 0, 0, 1, 157, 0}";
 }
 );
 layerId = "FBA383E9-6277-4D96-B152-431C26EB0833";
-name = "[16]";
+name = "[17.5]";
 width = 742;
 }
 );
@@ -17794,7 +17794,7 @@ unicode = 0158;
 },
 {
 glyphname = Rcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:51:50 +0000";
 layers = (
 {
 components = (
@@ -17860,7 +17860,7 @@ transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
 layerId = "50990B10-C771-4D20-9AA6-7AF26608DF12";
-name = "[16]";
+name = "[17.5]";
 width = 599;
 },
 {
@@ -17875,7 +17875,7 @@ transform = "{1, 0, 0, 1, 132, 0}";
 }
 );
 layerId = "B47E1107-B1D1-41D6-8951-D880CD6D070E";
-name = "[16]";
+name = "[17.5]";
 width = 665;
 },
 {
@@ -17890,7 +17890,7 @@ transform = "{1, 0, 0, 1, 114, 0}";
 }
 );
 layerId = "06C34D3A-ADE2-4208-8640-395ABE0DA756";
-name = "[16]";
+name = "[17.5]";
 width = 586;
 },
 {
@@ -17905,7 +17905,7 @@ transform = "{1, 0, 0, 1, 126, 0}";
 }
 );
 layerId = "16F9A318-9476-4299-AB47-3004F5AC9FA0";
-name = "[16]";
+name = "[17.5]";
 width = 634;
 }
 );
@@ -18411,7 +18411,7 @@ unicode = 015C;
 },
 {
 glyphname = Scommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:52:02 +0000";
 layers = (
 {
 components = (
@@ -18477,7 +18477,7 @@ transform = "{1, 0, 0, 1, 91, 0}";
 }
 );
 layerId = "7F5E356A-3B88-4CD3-AED0-8BC00E486F0C";
-name = "[16]";
+name = "[17.5]";
 width = 601;
 },
 {
@@ -18492,7 +18492,7 @@ transform = "{1, 0, 0, 1, 102, 0}";
 }
 );
 layerId = "13007A30-0B75-4D75-955C-C91ED3E225F2";
-name = "[16]";
+name = "[17.5]";
 width = 631;
 },
 {
@@ -18507,7 +18507,7 @@ transform = "{1, 0, 0, 1, 67, 0}";
 }
 );
 layerId = "0621CA71-9874-48D0-BBC0-BB4B6BE3E3AE";
-name = "[16]";
+name = "[17.5]";
 width = 564;
 },
 {
@@ -18522,7 +18522,7 @@ transform = "{1, 0, 0, 1, 68, 0}";
 }
 );
 layerId = "E4633C7E-F503-4B55-BDFA-4522273697C5";
-name = "[16]";
+name = "[17.5]";
 width = 590;
 }
 );
@@ -19094,7 +19094,7 @@ unicode = 0162;
 },
 {
 glyphname = Tcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:52:09 +0000";
 layers = (
 {
 components = (
@@ -19160,7 +19160,7 @@ transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
 layerId = "6357D479-1221-4BE4-97BD-015A8568AB63";
-name = "[16]";
+name = "[17.5]";
 width = 572;
 },
 {
@@ -19175,7 +19175,7 @@ transform = "{1, 0, 0, 1, 100, 0}";
 }
 );
 layerId = "2E86BC68-E649-44E5-9D18-42265DFA73AB";
-name = "[16]";
+name = "[17.5]";
 width = 630;
 },
 {
@@ -19190,7 +19190,7 @@ transform = "{1, 0, 0, 1, 62, 0}";
 }
 );
 layerId = "65998243-796F-4FCB-9D50-3F9660831E42";
-name = "[16]";
+name = "[17.5]";
 width = 538;
 },
 {
@@ -19205,7 +19205,7 @@ transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
 layerId = "57074FB0-4AB6-4EF1-A1D9-1A2221812C89";
-name = "[16]";
+name = "[17.5]";
 width = 588;
 }
 );
@@ -23192,7 +23192,7 @@ rightKerningGroup = G.alt;
 },
 {
 glyphname = Gcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:52:48 +0000";
 layers = (
 {
 components = (
@@ -23258,7 +23258,7 @@ transform = "{1, 0, 0, 1, 166, 0}";
 }
 );
 layerId = "37A85EC5-F651-4CA9-A7A2-886E234440A0";
-name = "[16]";
+name = "[17.5]";
 width = 736;
 },
 {
@@ -23273,7 +23273,7 @@ transform = "{1, 0, 0, 1, 158, 0}";
 }
 );
 layerId = "16451619-4A2D-4818-9B01-93643E01FA6A";
-name = "[16]";
+name = "[17.5]";
 width = 782;
 },
 {
@@ -23288,7 +23288,7 @@ transform = "{1, 0, 0, 1, 225, 0}";
 }
 );
 layerId = "692AAFD1-5A0D-458A-B4D6-8FFE9E64DCA6";
-name = "[16]";
+name = "[17.5]";
 width = 812;
 },
 {
@@ -23303,7 +23303,7 @@ transform = "{1, 0, 0, 1, 227, 0}";
 }
 );
 layerId = "F2A5AB39-2541-427B-ACA7-EA13857C99DF";
-name = "[16]";
+name = "[17.5]";
 width = 830;
 }
 );
@@ -24507,7 +24507,7 @@ rightKerningGroup = K;
 },
 {
 glyphname = Kcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:52:58 +0000";
 layers = (
 {
 components = (
@@ -24573,7 +24573,7 @@ transform = "{1, 0, 0, 1, 102, 0}";
 }
 );
 layerId = "378724B4-7503-4598-B6D2-297E6DDF2550";
-name = "[16]";
+name = "[17.5]";
 width = 606;
 },
 {
@@ -24588,7 +24588,7 @@ transform = "{1, 0, 0, 1, 120, 0}";
 }
 );
 layerId = "14066C61-3CC1-4CB5-B298-0E82DDC98E17";
-name = "[16]";
+name = "[17.5]";
 width = 668;
 },
 {
@@ -24603,7 +24603,7 @@ transform = "{1, 0, 0, 1, 121, 0}";
 }
 );
 layerId = "592DE6A3-233F-4BFB-B0C2-7CD4CC6D5AF0";
-name = "[16]";
+name = "[17.5]";
 width = 615;
 },
 {
@@ -24618,7 +24618,7 @@ transform = "{1, 0, 0, 1, 139, 0}";
 }
 );
 layerId = "F0D914C7-194D-4E73-8C75-ADE7AF4CBF6A";
-name = "[16]";
+name = "[17.5]";
 width = 672;
 }
 );
@@ -25591,7 +25591,7 @@ rightKerningGroup = R.alt;
 },
 {
 glyphname = Rcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:53:50 +0000";
 layers = (
 {
 components = (
@@ -25657,7 +25657,7 @@ transform = "{1, 0, 0, 1, 80, 0}";
 }
 );
 layerId = "9A115C77-C654-4FAA-851A-619FA2E7D85E";
-name = "[16]";
+name = "[17.5]";
 width = 584;
 },
 {
@@ -25672,7 +25672,7 @@ transform = "{1, 0, 0, 1, 112, 0}";
 }
 );
 layerId = "E93DE8DF-81FB-4397-AB47-4BE28E96E461";
-name = "[16]";
+name = "[17.5]";
 width = 658;
 },
 {
@@ -25687,7 +25687,7 @@ transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
 layerId = "3E80446A-9A16-46B2-A072-9AC573E72E50";
-name = "[16]";
+name = "[17.5]";
 width = 573;
 },
 {
@@ -25702,7 +25702,7 @@ transform = "{1, 0, 0, 1, 129, 0}";
 }
 );
 layerId = "73D67B05-2800-48AD-B0E9-204DDFB5FAD6";
-name = "[16]";
+name = "[17.5]";
 width = 641;
 }
 );
@@ -33981,7 +33981,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:54:53 +0000";
 layers = (
 {
 components = (
@@ -34047,7 +34047,7 @@ transform = "{1, 0, 0, 1, 113, 0}";
 }
 );
 layerId = "C986094D-FB92-4670-9341-CC314AF91422";
-name = "[16]";
+name = "[17.5]";
 width = 591;
 },
 {
@@ -34062,7 +34062,7 @@ transform = "{1, 0, 0, 1, 100, 0}";
 }
 );
 layerId = "A2359FAF-4D57-4080-97A8-8E8DDD57E1AC";
-name = "[16]";
+name = "[17.5]";
 width = 612;
 },
 {
@@ -34077,7 +34077,7 @@ transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
 layerId = "F19F9ADE-6C48-498E-93D0-5FF6C72CDCF2";
-name = "[16]";
+name = "[17.5]";
 width = 597;
 },
 {
@@ -34092,7 +34092,7 @@ transform = "{1, 0, 0, 1, 74, 0}";
 }
 );
 layerId = "A59A82D9-83E4-4133-8DAD-EF574F57B54F";
-name = "[16]";
+name = "[17.5]";
 width = 624;
 }
 );
@@ -36792,7 +36792,7 @@ unicode = 006B;
 },
 {
 glyphname = kcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:55:06 +0000";
 layers = (
 {
 components = (
@@ -36858,7 +36858,7 @@ transform = "{1, 0, 0, 1, 58, 0}";
 }
 );
 layerId = "108E1F88-22D4-417D-B028-48C6DBD60633";
-name = "[16]";
+name = "[17.5]";
 width = 499;
 },
 {
@@ -36873,7 +36873,7 @@ transform = "{1, 0, 0, 1, 78, 0}";
 }
 );
 layerId = "B667CDED-082D-4538-87A3-B7B5E8DE3668";
-name = "[16]";
+name = "[17.5]";
 width = 571;
 },
 {
@@ -36888,7 +36888,7 @@ transform = "{1, 0, 0, 1, 73, 0}";
 }
 );
 layerId = "CEDB6431-0918-460F-B88A-8A83988BE3B0";
-name = "[16]";
+name = "[17.5]";
 width = 507;
 },
 {
@@ -36903,7 +36903,7 @@ transform = "{1, 0, 0, 1, 90, 0}";
 }
 );
 layerId = "B800DFB8-5052-445B-AB63-97FF6EF53147";
-name = "[16]";
+name = "[17.5]";
 width = 561;
 }
 );
@@ -37291,7 +37291,7 @@ unicode = 013E;
 },
 {
 glyphname = lcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:55:21 +0000";
 layers = (
 {
 components = (
@@ -37357,7 +37357,7 @@ transform = "{1, 0, 0, 1, -94, 0}";
 }
 );
 layerId = "5942A91D-30BB-4DC0-A9DB-D0B184DB600B";
-name = "[16]";
+name = "[17.5]";
 width = 230;
 },
 {
@@ -37372,7 +37372,7 @@ transform = "{1, 0, 0, 1, -76, 0}";
 }
 );
 layerId = "F753EEA3-B05F-45C0-941B-20C430E489AE";
-name = "[16]";
+name = "[17.5]";
 width = 279;
 },
 {
@@ -37387,7 +37387,7 @@ transform = "{1, 0, 0, 1, -98, 0}";
 }
 );
 layerId = "4E07C6D1-8BD4-4290-8378-E7DA74EBC30D";
-name = "[16]";
+name = "[17.5]";
 width = 212;
 },
 {
@@ -37402,7 +37402,7 @@ transform = "{1, 0, 0, 1, -85, 0}";
 }
 );
 layerId = "28384D27-7485-42F5-8CFB-772E32A8808B";
-name = "[16]";
+name = "[17.5]";
 width = 260;
 }
 );
@@ -38191,7 +38191,7 @@ unicode = 0148;
 },
 {
 glyphname = ncommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:55:40 +0000";
 layers = (
 {
 components = (
@@ -38257,7 +38257,7 @@ transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
 layerId = "8A780C72-FF49-4BD2-B90E-1416BA149131";
-name = "[16]";
+name = "[17.5]";
 width = 566;
 },
 {
@@ -38272,7 +38272,7 @@ transform = "{1, 0, 0, 1, 93, 0}";
 }
 );
 layerId = "42342C28-ACA5-40BE-B078-E70BC6846F39";
-name = "[16]";
+name = "[17.5]";
 width = 613;
 },
 {
@@ -38287,7 +38287,7 @@ transform = "{1, 0, 0, 1, 87, 0}";
 }
 );
 layerId = "5CED3097-7C25-42F5-B6D8-4C472CCD8D86";
-name = "[16]";
+name = "[17.5]";
 width = 561;
 },
 {
@@ -38302,7 +38302,7 @@ transform = "{1, 0, 0, 1, 88, 0}";
 }
 );
 layerId = "0711C44B-0677-4DF6-B3A8-B9571451D31D";
-name = "[16]";
+name = "[17.5]";
 width = 600;
 }
 );
@@ -42685,7 +42685,7 @@ unicode = 0159;
 },
 {
 glyphname = rcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:56:01 +0000";
 layers = (
 {
 components = (
@@ -42751,7 +42751,7 @@ transform = "{1, 0, 0, 1, -94, 0}";
 }
 );
 layerId = "9F8A7E3F-3CD0-4C57-BAD9-2FB2407CF14B";
-name = "[16]";
+name = "[17.5]";
 width = 379;
 },
 {
@@ -42766,7 +42766,7 @@ transform = "{1, 0, 0, 1, -77, 0}";
 }
 );
 layerId = "E2EFC0B0-4F03-4C3C-9DED-EEEE7BAC2446";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -42781,7 +42781,7 @@ transform = "{1, 0, 0, 1, -98, 0}";
 }
 );
 layerId = "D98F466B-7E3A-4C39-9329-A16E8B3CA17A";
-name = "[16]";
+name = "[17.5]";
 width = 375;
 },
 {
@@ -42796,7 +42796,7 @@ transform = "{1, 0, 0, 1, -85, 0}";
 }
 );
 layerId = "DC48BC3A-76D4-4B85-A1A0-4EE630631B42";
-name = "[16]";
+name = "[17.5]";
 width = 427;
 }
 );
@@ -43303,7 +43303,7 @@ unicode = 015D;
 },
 {
 glyphname = scommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:56:18 +0000";
 layers = (
 {
 components = (
@@ -43369,7 +43369,7 @@ transform = "{1, 0, 0, 1, 39, 0}";
 }
 );
 layerId = "AB0031F2-7049-463D-91AE-8D8FBF97BE04";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 },
 {
@@ -43384,7 +43384,7 @@ transform = "{1, 0, 0, 1, 47, 0}";
 }
 );
 layerId = "977EB906-7634-463D-B30C-EF4DF8FFAC20";
-name = "[16]";
+name = "[17.5]";
 width = 525;
 },
 {
@@ -43399,7 +43399,7 @@ transform = "{1, 0, 0, 1, 30, 0}";
 }
 );
 layerId = "FF670552-95BC-4AE9-B3CC-4008EA2EFAD2";
-name = "[16]";
+name = "[17.5]";
 width = 468;
 },
 {
@@ -43414,7 +43414,7 @@ transform = "{1, 0, 0, 1, 37, 0}";
 }
 );
 layerId = "45C43496-7286-45FC-93A2-88F655218743";
-name = "[16]";
+name = "[17.5]";
 width = 498;
 }
 );
@@ -44709,7 +44709,7 @@ unicode = 0163;
 },
 {
 glyphname = tcommaaccent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:56:47 +0000";
 layers = (
 {
 components = (
@@ -44775,7 +44775,7 @@ transform = "{1, 0, 0, 1, 20, 0}";
 }
 );
 layerId = "7A5161C6-1434-4462-82C6-194128B425BA";
-name = "[16]";
+name = "[17.5]";
 width = 360;
 },
 {
@@ -44790,7 +44790,7 @@ transform = "{1, 0, 0, 1, 53, 0}";
 }
 );
 layerId = "2497F46A-60BA-4FF7-9B68-6FA28975254B";
-name = "[16]";
+name = "[17.5]";
 width = 415;
 },
 {
@@ -44805,7 +44805,7 @@ transform = "{1, 0, 0, 1, 32, 0}";
 }
 );
 layerId = "C74ADF34-D770-4FAE-8C10-66EF8E89C4A0";
-name = "[16]";
+name = "[17.5]";
 width = 366;
 },
 {
@@ -44820,7 +44820,7 @@ transform = "{1, 0, 0, 1, 51, 0}";
 }
 );
 layerId = "85687F78-7432-438C-B807-EC13B9B41420";
-name = "[16]";
+name = "[17.5]";
 width = 418;
 }
 );
@@ -47298,7 +47298,7 @@ unicode = 0078;
 },
 {
 glyphname = y;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:57:03 +0000";
 layers = (
 {
 anchors = (
@@ -47499,7 +47499,7 @@ nodes = (
 );
 };
 layerId = "9CEDEC86-539A-4538-9F97-4229BDF89D06";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -47633,7 +47633,7 @@ nodes = (
 );
 };
 layerId = "66380BC1-AB15-4E31-B125-A9CE735104B1";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -47665,7 +47665,7 @@ position = "{293, 510}";
 );
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "5DC58DF7-0192-4137-9DEF-4B406140B6E4";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -47697,7 +47697,7 @@ position = "{326, 510}";
 );
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "7AF395A9-C765-477B-AA17-959E67CCFCE8";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -47723,7 +47723,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:57:15 +0000";
 layers = (
 {
 components = (
@@ -47789,7 +47789,7 @@ transform = "{1, 0, 0, 1, 95, 0}";
 }
 );
 layerId = "653CD1B6-60AA-42D5-A881-F5B6A5EDD30E";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47804,7 +47804,7 @@ transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
 layerId = "CBF09902-F099-438B-835D-44E55015C31A";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47819,7 +47819,7 @@ transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
 layerId = "7DEA64DB-86E4-48FB-A437-DF62ACEBE774";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47834,7 +47834,7 @@ transform = "{1, 0, 0, 1, 96, 0}";
 }
 );
 layerId = "BB25D150-B65F-4140-BCA9-4E8CCD59A2E3";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -47844,7 +47844,7 @@ unicode = 00FD;
 },
 {
 glyphname = ycircumflex;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:57:43 +0000";
 layers = (
 {
 components = (
@@ -47910,7 +47910,7 @@ transform = "{1, 0, 0, 1, 59, 0}";
 }
 );
 layerId = "D073EA83-59C1-4B9A-8C47-A094D8756938";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47925,7 +47925,7 @@ transform = "{1, 0, 0, 1, 74, 0}";
 }
 );
 layerId = "AFE12B09-070D-4B09-A6BC-1E4EA32E9732";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47940,7 +47940,7 @@ transform = "{1, 0, 0, 1, 66, 0}";
 }
 );
 layerId = "A78B78D4-2DBE-43E7-9C87-63A8EEC8D7A4";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47955,7 +47955,7 @@ transform = "{1, 0, 0, 1, 70, 0}";
 }
 );
 layerId = "4557221B-93A6-4A0A-86AA-6EC803DB3082";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -47965,7 +47965,7 @@ unicode = 0177;
 },
 {
 glyphname = ydieresis;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:57:58 +0000";
 layers = (
 {
 components = (
@@ -48031,7 +48031,7 @@ transform = "{1, 0, 0, 1, 60, 0}";
 }
 );
 layerId = "C1E5E0FB-F7E0-42FE-8015-B9BE791EC5EA";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -48046,7 +48046,7 @@ transform = "{1, 0, 0, 1, 76, 0}";
 }
 );
 layerId = "85A2BCD6-1117-4540-A026-18ED2E159077";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -48061,7 +48061,7 @@ transform = "{1, 0, 0, 1, 72, 0}";
 }
 );
 layerId = "C19699E9-9CB5-403F-BE61-1E409285E0BA";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -48076,7 +48076,7 @@ transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
 layerId = "BA874B32-C3BF-41E7-B39A-ABBB08BE8829";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -48086,7 +48086,7 @@ unicode = 00FF;
 },
 {
 glyphname = ydotbelow;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:58:14 +0000";
 layers = (
 {
 components = (
@@ -48152,7 +48152,7 @@ transform = "{1, 0, 0, 1, 271, 0}";
 }
 );
 layerId = "E55945B7-CF19-4409-8696-3EFAF839B21C";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -48167,7 +48167,7 @@ transform = "{1, 0, 0, 1, 318, 0}";
 }
 );
 layerId = "6144E4CF-0845-491A-907C-8612711218ED";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -48182,7 +48182,7 @@ transform = "{1, 0, 0, 1, 265, 0}";
 }
 );
 layerId = "E71D505E-F608-45A2-ADC7-044DB023C675";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -48197,7 +48197,7 @@ transform = "{1, 0, 0, 1, 314, 0}";
 }
 );
 layerId = "8E39961A-CA8E-4A03-972D-317BCE3D04DA";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -48206,7 +48206,7 @@ unicode = 1EF5;
 },
 {
 glyphname = ygrave;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:58:23 +0000";
 layers = (
 {
 components = (
@@ -48272,7 +48272,7 @@ transform = "{1, 0, 0, 1, 15, 0}";
 }
 );
 layerId = "7C8236E8-C074-42AC-A85C-4AA8DA2B54B5";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -48287,7 +48287,7 @@ transform = "{1, 0, 0, 1, 39, 0}";
 }
 );
 layerId = "93B25316-8F12-499B-9637-2CE83C75EA15";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -48302,7 +48302,7 @@ transform = "{1, 0, 0, 1, 64, 0}";
 }
 );
 layerId = "D4B4079A-9902-4BB8-9D78-8689DBADEF7C";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -48317,7 +48317,7 @@ transform = "{1, 0, 0, 1, 64, 0}";
 }
 );
 layerId = "DF528A44-E241-4562-A2EC-02A45FA06DBF";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -48327,7 +48327,7 @@ unicode = 1EF3;
 },
 {
 glyphname = yhookabove;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:58:34 +0000";
 layers = (
 {
 components = (
@@ -48393,7 +48393,7 @@ transform = "{1, 0, 0, 1, 156, 0}";
 }
 );
 layerId = "4B11BC1F-D64C-4826-90FE-10CD08DDE7A4";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -48408,7 +48408,7 @@ transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
 layerId = "96AF22C5-F4EA-4CC3-8CA4-518707C8EC11";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -48423,7 +48423,7 @@ transform = "{1, 0, 0, 1, 148, 0}";
 }
 );
 layerId = "233A592D-23BF-44F1-B290-B9C2016A1F99";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -48438,7 +48438,7 @@ transform = "{1, 0, 0, 1, 171, 0}";
 }
 );
 layerId = "531A6E67-1C96-43C7-B8DB-8BF495DAD4D3";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -48448,7 +48448,7 @@ unicode = 1EF7;
 },
 {
 glyphname = ytilde;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:58:45 +0000";
 layers = (
 {
 components = (
@@ -48514,7 +48514,7 @@ transform = "{1, 0, 0, 1, 56, 0}";
 }
 );
 layerId = "58261655-CB83-4615-8233-B3DA41A5FD8E";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -48529,7 +48529,7 @@ transform = "{1, 0, 0, 1, 94, 0}";
 }
 );
 layerId = "9FAECC24-A8C2-4A23-8E90-4E0A7658825E";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -48544,7 +48544,7 @@ transform = "{1, 0, 0, 1, 68, 0}";
 }
 );
 layerId = "23CE22FA-3AA3-4291-B83E-0A32D90AEF36";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -48559,7 +48559,7 @@ transform = "{1, 0, 0, 1, 92, 0}";
 }
 );
 layerId = "F26DF861-5337-42D2-B644-5524B0611B3C";
-name = "[16]";
+name = "[17.5]";
 width = 579;
 }
 );
@@ -52194,7 +52194,7 @@ rightKerningGroup = k;
 },
 {
 glyphname = kcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:59:26 +0000";
 layers = (
 {
 components = (
@@ -52260,7 +52260,7 @@ transform = "{1, 0, 0, 1, 44, 0}";
 }
 );
 layerId = "E38980F6-613E-4F7A-ACAB-E929BCD509EE";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -52275,7 +52275,7 @@ transform = "{1, 0, 0, 1, 68, 0}";
 }
 );
 layerId = "5A8B37AE-7395-47C7-9656-0348CB351DEE";
-name = "[16]";
+name = "[17.5]";
 width = 551;
 },
 {
@@ -52290,7 +52290,7 @@ transform = "{1, 0, 0, 1, 52, 0}";
 }
 );
 layerId = "CD849922-5331-4025-BD6B-1D8A4F4AD9C6";
-name = "[16]";
+name = "[17.5]";
 width = 489;
 },
 {
@@ -52305,7 +52305,7 @@ transform = "{1, 0, 0, 1, 74, 0}";
 }
 );
 layerId = "CFCB4111-E40C-4F29-AE45-0DA8459EA28A";
-name = "[16]";
+name = "[17.5]";
 width = 541;
 }
 );
@@ -52915,7 +52915,7 @@ rightKerningGroup = r;
 },
 {
 glyphname = rcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:59:41 +0000";
 layers = (
 {
 components = (
@@ -52981,7 +52981,7 @@ transform = "{1, 0, 0, 1, -94, 0}";
 }
 );
 layerId = "4E26C464-7B7F-4F89-9B0F-723CF73B5709";
-name = "[16]";
+name = "[17.5]";
 width = 379;
 },
 {
@@ -52996,7 +52996,7 @@ transform = "{1, 0, 0, 1, -77, 0}";
 }
 );
 layerId = "590E67B0-1086-4656-9666-30AF1D35F8A8";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -53011,7 +53011,7 @@ transform = "{1, 0, 0, 1, -99, 0}";
 }
 );
 layerId = "5BB7325F-7AEC-4590-9846-3856BC582024";
-name = "[16]";
+name = "[17.5]";
 width = 369;
 },
 {
@@ -53026,7 +53026,7 @@ transform = "{1, 0, 0, 1, -86, 0}";
 }
 );
 layerId = "D36F13CA-3E81-464C-BAA1-7FC86204F303";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 }
 );
@@ -53785,7 +53785,7 @@ rightKerningGroup = t.alt;
 },
 {
 glyphname = tcommaaccent.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 16:59:54 +0000";
 layers = (
 {
 anchors = (
@@ -53941,7 +53941,7 @@ transform = "{1, 0, 0, 1, -31, 0}";
 }
 );
 layerId = "5CBAD77F-C137-4515-B45B-E8A393F6B1DA";
-name = "[16]";
+name = "[17.5]";
 width = 364;
 },
 {
@@ -53974,7 +53974,7 @@ transform = "{1, 0, 0, 1, -20, 0}";
 }
 );
 layerId = "83884165-12AE-4461-AACE-CFF714703148";
-name = "[16]";
+name = "[17.5]";
 width = 405;
 },
 {
@@ -54007,7 +54007,7 @@ transform = "{1, 0, 0, 1, -28, 0}";
 }
 );
 layerId = "333FA142-4DD0-465C-8406-56FF3AEC0E68";
-name = "[16]";
+name = "[17.5]";
 width = 355;
 },
 {
@@ -54040,7 +54040,7 @@ transform = "{1, 0, 0, 1, -21, 0}";
 }
 );
 layerId = "41F01EB8-43F6-43C5-9773-8FF305E6EA08";
-name = "[16]";
+name = "[17.5]";
 width = 401;
 }
 );
@@ -71684,7 +71684,7 @@ rightKerningGroup = f.sc;
 },
 {
 glyphname = g.sc;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:00:20 +0000";
 layers = (
 {
 anchors = (
@@ -71911,7 +71911,7 @@ position = "{372, 580}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "2A572E80-D3A4-4572-BE8D-678E3C3AF9A2";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -71965,7 +71965,7 @@ position = "{390, 580}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "DF7BF0CA-C768-461F-BE3C-6EECD94E5324";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -72019,7 +72019,7 @@ position = "{397, 580}";
 );
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "AC08742A-7D06-4E7A-BBB8-C80B99325691";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -72073,7 +72073,7 @@ position = "{401, 580}";
 );
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "93126EC6-7C10-4E1E-B329-C402AE9AB839";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -87133,7 +87133,7 @@ source = x;
 },
 {
 glyphname = y.sc.lc.ss04;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:00:48 +0000";
 layers = (
 {
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
@@ -87212,7 +87212,7 @@ width = 373;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "32566885-2606-418F-9782-841C3DD0CDBD";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -87331,7 +87331,7 @@ width = 379;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "0C4E56AE-FDE9-4DB6-919D-1D12EE9A6782";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -87376,7 +87376,7 @@ nodes = (
 );
 };
 layerId = "B38EA031-3C75-4094-A216-EB3D8EB34916";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -87403,7 +87403,7 @@ width = 340;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "4AC89AB0-85BC-4832-B563-2B2ECCA4FC12";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -88648,7 +88648,7 @@ source = F;
 },
 {
 glyphname = g.sc.ss04;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:02 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -88821,7 +88821,7 @@ width = 504;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "B18D7CFB-AB63-43F5-A86E-4F422619FD63";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -88865,7 +88865,7 @@ width = 504;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "6699F21F-11DD-43F9-A5FB-C8561A750CD1";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -88909,7 +88909,7 @@ width = 521;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "8C5A687E-6B18-47BE-B55F-558042B6D1E7";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -88953,7 +88953,7 @@ width = 486;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "6B682527-A825-4EFB-9F3D-9A154B885E40";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -205712,7 +205712,7 @@ unicode = 0030;
 },
 {
 glyphname = one;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:19 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -205785,42 +205785,6 @@ nodes = (
 width = 371;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"243 0 LINE",
-"368 708 LINE",
-"314 708 LINE",
-"104 573 LINE",
-"102 483 LINE",
-"262 586 LINE",
-"159 0 LINE"
-);
-}
-);
-};
-layerId = "B43AF161-C1A2-48F1-9EB6-591F60DFC54D";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"243 0 LINE",
-"368 708 LINE",
-"314 708 LINE",
-"91 564 LINE",
-"131 501 LINE",
-"262 586 LINE",
-"159 0 LINE"
-);
-}
-);
-width = 373;
-},
-{
 background = {
 paths = (
 {
@@ -205853,42 +205817,6 @@ nodes = (
 }
 );
 width = 426;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"296 0 LINE",
-"421 708 LINE",
-"321 708 LINE",
-"104 569 LINE",
-"98 430 LINE",
-"259 534 LINE",
-"165 0 LINE"
-);
-}
-);
-};
-layerId = "03E1104B-13D1-4F26-B0D5-BF11A13BFDBC";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"296 0 LINE",
-"421 708 LINE",
-"321 708 LINE",
-"76 551 LINE",
-"137 455 LINE",
-"259 534 LINE",
-"165 0 LINE"
-);
-}
-);
-width = 428;
 }
 );
 unicode = 0031;
@@ -206673,7 +206601,7 @@ unicode = 0035;
 },
 {
 glyphname = six;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:25 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -206923,157 +206851,6 @@ nodes = (
 }
 );
 width = 576;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"398 -16 OFFCURVE",
-"504 100 OFFCURVE",
-"504 244 CURVE SMOOTH",
-"504 355 OFFCURVE",
-"426 444 OFFCURVE",
-"327 444 CURVE SMOOTH",
-"288 444 OFFCURVE",
-"256 433 OFFCURVE",
-"239 421 CURVE",
-"236 423 LINE",
-"479 716 LINE",
-"380 716 LINE",
-"148 436 LINE SMOOTH",
-"78 351 OFFCURVE",
-"36 283 OFFCURVE",
-"36 189 CURVE SMOOTH",
-"36 77 OFFCURVE",
-"124 -16 OFFCURVE",
-"244 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"175 65 OFFCURVE",
-"122 121 OFFCURVE",
-"122 196 CURVE SMOOTH",
-"122 287 OFFCURVE",
-"186 368 OFFCURVE",
-"289 368 CURVE SMOOTH",
-"369 368 OFFCURVE",
-"418 316 OFFCURVE",
-"418 235 CURVE SMOOTH",
-"418 135 OFFCURVE",
-"352 65 OFFCURVE",
-"254 65 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "F5C163DB-6F7C-44B5-9A45-849AD1AB2AA5";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"399 -16 OFFCURVE",
-"510 91 OFFCURVE",
-"510 238 CURVE SMOOTH",
-"510 354 OFFCURVE",
-"427 434 OFFCURVE",
-"321 434 CURVE SMOOTH",
-"254 434 OFFCURVE",
-"201 414 OFFCURVE",
-"161 374 CURVE",
-"159 376 LINE",
-"242 511 OFFCURVE",
-"345 589 OFFCURVE",
-"440 653 CURVE",
-"399 713 LINE",
-"297 643 OFFCURVE",
-"205 563 OFFCURVE",
-"133 470 CURVE SMOOTH",
-"70 388 OFFCURVE",
-"35 309 OFFCURVE",
-"35 215 CURVE SMOOTH",
-"35 74 OFFCURVE",
-"126 -16 OFFCURVE",
-"249 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"182 65 OFFCURVE",
-"123 116 OFFCURVE",
-"123 198 CURVE SMOOTH",
-"123 287 OFFCURVE",
-"192 358 OFFCURVE",
-"291 358 CURVE SMOOTH",
-"371 358 OFFCURVE",
-"424 308 OFFCURVE",
-"424 229 CURVE SMOOTH",
-"424 137 OFFCURVE",
-"357 65 OFFCURVE",
-"259 65 CURVE SMOOTH"
-);
-}
-);
-width = 557;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "12D6C268-1343-4E65-AEA0-55D9562D1EE6";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"421 -16 OFFCURVE",
-"529 95 OFFCURVE",
-"529 246 CURVE SMOOTH",
-"529 364 OFFCURVE",
-"441 443 OFFCURVE",
-"345 443 CURVE SMOOTH",
-"304 443 OFFCURVE",
-"255 439 OFFCURVE",
-"209 405 CURVE",
-"204 410 LINE",
-"251 483 OFFCURVE",
-"367 572 OFFCURVE",
-"467 617 CURVE",
-"411 719 LINE",
-"307 657 OFFCURVE",
-"199 586 OFFCURVE",
-"126 489 CURVE SMOOTH",
-"63 408 OFFCURVE",
-"32 321 OFFCURVE",
-"32 222 CURVE SMOOTH",
-"32 87 OFFCURVE",
-"119 -16 OFFCURVE",
-"255 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"211 104 OFFCURVE",
-"167 146 OFFCURVE",
-"167 203 CURVE SMOOTH",
-"167 280 OFFCURVE",
-"221 333 OFFCURVE",
-"296 333 CURVE SMOOTH",
-"355 333 OFFCURVE",
-"398 293 OFFCURVE",
-"398 234 CURVE SMOOTH",
-"398 156 OFFCURVE",
-"342 104 OFFCURVE",
-"270 104 CURVE SMOOTH"
-);
-}
-);
-width = 578;
 }
 );
 unicode = 0036;
@@ -207472,7 +207249,7 @@ unicode = 0038;
 },
 {
 glyphname = nine;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:30 +0000";
 layers = (
 {
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
@@ -207677,168 +207454,13 @@ nodes = (
 }
 );
 width = 579;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"293 56 OFFCURVE",
-"383 139 OFFCURVE",
-"456 235 CURVE SMOOTH",
-"521 318 OFFCURVE",
-"557 395 OFFCURVE",
-"557 492 CURVE SMOOTH",
-"557 627 OFFCURVE",
-"469 716 OFFCURVE",
-"345 716 CURVE SMOOTH",
-"190 716 OFFCURVE",
-"84 609 OFFCURVE",
-"84 466 CURVE SMOOTH",
-"84 346 OFFCURVE",
-"174 266 OFFCURVE",
-"279 266 CURVE SMOOTH",
-"334 266 OFFCURVE",
-"368 286 OFFCURVE",
-"399 316 CURVE",
-"401 314 LINE",
-"348 199 OFFCURVE",
-"248 115 OFFCURVE",
-"146 43 CURVE",
-"195 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 342 OFFCURVE",
-"170 395 OFFCURVE",
-"170 473 CURVE SMOOTH",
-"170 566 OFFCURVE",
-"239 635 OFFCURVE",
-"337 635 CURVE SMOOTH",
-"414 635 OFFCURVE",
-"472 582 OFFCURVE",
-"472 506 CURVE SMOOTH",
-"472 413 OFFCURVE",
-"405 342 OFFCURVE",
-"305 342 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "7F91D71D-9767-47FE-BB8A-E7AE566B6CA9";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"296 56 OFFCURVE",
-"385 134 OFFCURVE",
-"458 230 CURVE SMOOTH",
-"523 313 OFFCURVE",
-"557 395 OFFCURVE",
-"557 492 CURVE SMOOTH",
-"557 627 OFFCURVE",
-"469 716 OFFCURVE",
-"345 716 CURVE SMOOTH",
-"190 716 OFFCURVE",
-"84 609 OFFCURVE",
-"84 466 CURVE SMOOTH",
-"84 346 OFFCURVE",
-"174 266 OFFCURVE",
-"279 266 CURVE SMOOTH",
-"334 266 OFFCURVE",
-"383 284 OFFCURVE",
-"433 334 CURVE",
-"435 332 LINE",
-"349 202 OFFCURVE",
-"252 115 OFFCURVE",
-"146 43 CURVE",
-"195 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 342 OFFCURVE",
-"170 395 OFFCURVE",
-"170 473 CURVE SMOOTH",
-"170 566 OFFCURVE",
-"239 635 OFFCURVE",
-"337 635 CURVE SMOOTH",
-"414 635 OFFCURVE",
-"472 582 OFFCURVE",
-"472 506 CURVE SMOOTH",
-"472 413 OFFCURVE",
-"405 342 OFFCURVE",
-"305 342 CURVE SMOOTH"
-);
-}
-);
-width = 564;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "23DD18FF-E7BD-42D4-BF57-DBA48C048E76";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"296 41 OFFCURVE",
-"391 113 OFFCURVE",
-"465 202 CURVE SMOOTH",
-"535 286 OFFCURVE",
-"578 372 OFFCURVE",
-"578 476 CURVE SMOOTH",
-"578 615 OFFCURVE",
-"491 716 OFFCURVE",
-"355 716 CURVE SMOOTH",
-"189 716 OFFCURVE",
-"81 605 OFFCURVE",
-"81 458 CURVE SMOOTH",
-"81 337 OFFCURVE",
-"177 258 OFFCURVE",
-"271 258 CURVE SMOOTH",
-"329 258 OFFCURVE",
-"361 271 OFFCURVE",
-"391 290 CURVE",
-"395 285 LINE",
-"340 209 OFFCURVE",
-"239 132 OFFCURVE",
-"131 68 CURVE",
-"199 -19 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"255 367 OFFCURVE",
-"212 407 OFFCURVE",
-"212 468 CURVE SMOOTH",
-"212 545 OFFCURVE",
-"268 596 OFFCURVE",
-"342 596 CURVE SMOOTH",
-"399 596 OFFCURVE",
-"443 554 OFFCURVE",
-"443 496 CURVE SMOOTH",
-"443 420 OFFCURVE",
-"389 367 OFFCURVE",
-"314 367 CURVE SMOOTH"
-);
-}
-);
-width = 585;
 }
 );
 unicode = 0039;
 },
 {
 glyphname = one.sansSerifCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:35 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -208026,114 +207648,6 @@ nodes = (
 "305 361 LINE",
 "397 428 LINE",
 "397 169 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"268 69 OFFCURVE",
-"138 200 OFFCURVE",
-"138 358 CURVE SMOOTH",
-"138 517 OFFCURVE",
-"268 647 OFFCURVE",
-"426 647 CURVE SMOOTH",
-"586 647 OFFCURVE",
-"715 517 OFFCURVE",
-"715 358 CURVE SMOOTH",
-"715 200 OFFCURVE",
-"586 69 OFFCURVE",
-"426 69 CURVE SMOOTH"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "600AF563-13BD-4FA1-88E4-6A4CD76F9BD3";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"467 172 LINE",
-"467 547 LINE",
-"411 547 LINE",
-"300 464 LINE",
-"339 415 LINE",
-"402 461 LINE",
-"402 172 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"254 44 OFFCURVE",
-"111 187 OFFCURVE",
-"111 358 CURVE SMOOTH",
-"111 532 OFFCURVE",
-"254 672 OFFCURVE",
-"425 672 CURVE SMOOTH",
-"600 672 OFFCURVE",
-"739 532 OFFCURVE",
-"739 358 CURVE SMOOTH",
-"739 187 OFFCURVE",
-"600 44 OFFCURVE",
-"425 44 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "15672E0A-000C-41A0-ACDF-708F27F93421";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"486 172 LINE",
-"486 547 LINE",
-"405 547 LINE",
-"291 456 LINE",
-"344 387 LINE",
-"397 430 LINE",
-"397 172 LINE"
 );
 },
 {
@@ -209403,7 +208917,7 @@ unicode = 2784;
 },
 {
 glyphname = six.sansSerifCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:44 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -209728,174 +209242,6 @@ nodes = (
 "281 223 OFFCURVE",
 "337 163 OFFCURVE",
 "424 163 CURVE SMOOTH"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "B0E8A30C-5AE7-4903-8ACD-AF48FFF802ED";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"254 44 OFFCURVE",
-"111 187 OFFCURVE",
-"111 358 CURVE SMOOTH",
-"111 532 OFFCURVE",
-"254 672 OFFCURVE",
-"425 672 CURVE SMOOTH",
-"600 672 OFFCURVE",
-"739 532 OFFCURVE",
-"739 358 CURVE SMOOTH",
-"739 187 OFFCURVE",
-"600 44 OFFCURVE",
-"425 44 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"378 223 OFFCURVE",
-"353 254 OFFCURVE",
-"353 291 CURVE SMOOTH",
-"353 328 OFFCURVE",
-"379 358 OFFCURVE",
-"419 358 CURVE SMOOTH",
-"460 358 OFFCURVE",
-"485 328 OFFCURVE",
-"485 291 CURVE SMOOTH",
-"485 254 OFFCURVE",
-"460 223 OFFCURVE",
-"419 223 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"492 164 OFFCURVE",
-"552 219 OFFCURVE",
-"552 290 CURVE SMOOTH",
-"552 359 OFFCURVE",
-"501 414 OFFCURVE",
-"434 414 CURVE SMOOTH",
-"421 414 OFFCURVE",
-"409 411 OFFCURVE",
-"403 408 CURVE",
-"490 528 LINE",
-"438 563 LINE",
-"438 563 OFFCURVE",
-"354 444 OFFCURVE",
-"329 407 CURVE SMOOTH",
-"303 369 OFFCURVE",
-"286 336 OFFCURVE",
-"286 290 CURVE SMOOTH",
-"286 218 OFFCURVE",
-"345 164 OFFCURVE",
-"420 164 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "34DEFAA4-0ADD-4FB4-B90B-FD8A5FA004E3";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"268 69 OFFCURVE",
-"138 200 OFFCURVE",
-"138 358 CURVE SMOOTH",
-"138 517 OFFCURVE",
-"268 647 OFFCURVE",
-"426 647 CURVE SMOOTH",
-"586 647 OFFCURVE",
-"715 517 OFFCURVE",
-"715 358 CURVE SMOOTH",
-"715 200 OFFCURVE",
-"586 69 OFFCURVE",
-"426 69 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"391 240 OFFCURVE",
-"369 263 OFFCURVE",
-"369 296 CURVE SMOOTH",
-"369 328 OFFCURVE",
-"391 351 OFFCURVE",
-"422 351 CURVE SMOOTH",
-"454 351 OFFCURVE",
-"477 328 OFFCURVE",
-"477 296 CURVE SMOOTH",
-"477 263 OFFCURVE",
-"454 240 OFFCURVE",
-"422 240 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"506 164 OFFCURVE",
-"565 224 OFFCURVE",
-"565 296 CURVE SMOOTH",
-"565 366 OFFCURVE",
-"510 422 OFFCURVE",
-"449 422 CURVE SMOOTH",
-"441 422 OFFCURVE",
-"433 421 OFFCURVE",
-"428 418 CURVE",
-"504 514 LINE",
-"436 563 LINE",
-"436 563 OFFCURVE",
-"354 452 OFFCURVE",
-"327 413 CURVE SMOOTH",
-"300 376 OFFCURVE",
-"282 342 OFFCURVE",
-"282 298 CURVE SMOOTH",
-"282 224 OFFCURVE",
-"338 164 OFFCURVE",
-"423 164 CURVE SMOOTH"
 );
 }
 );
@@ -210562,92 +209908,8 @@ unicode = 2787;
 },
 {
 glyphname = nine.sansSerifCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:52 +0000";
 layers = (
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "06A1516A-0EA5-4A67-8462-96DEC5DF035F";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"254 44 OFFCURVE",
-"111 187 OFFCURVE",
-"111 358 CURVE SMOOTH",
-"111 532 OFFCURVE",
-"254 672 OFFCURVE",
-"425 672 CURVE SMOOTH",
-"600 672 OFFCURVE",
-"739 532 OFFCURVE",
-"739 358 CURVE SMOOTH",
-"739 187 OFFCURVE",
-"600 44 OFFCURVE",
-"425 44 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 167 OFFCURVE",
-"490 277 OFFCURVE",
-"515 314 CURVE SMOOTH",
-"541 352 OFFCURVE",
-"558 385 OFFCURVE",
-"558 431 CURVE SMOOTH",
-"558 503 OFFCURVE",
-"500 557 OFFCURVE",
-"424 557 CURVE SMOOTH",
-"353 557 OFFCURVE",
-"292 502 OFFCURVE",
-"292 431 CURVE SMOOTH",
-"292 363 OFFCURVE",
-"343 307 OFFCURVE",
-"411 307 CURVE SMOOTH",
-"423 307 OFFCURVE",
-"435 310 OFFCURVE",
-"441 313 CURVE",
-"363 204 LINE",
-"413 167 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"385 363 OFFCURVE",
-"359 394 OFFCURVE",
-"359 430 CURVE SMOOTH",
-"359 467 OFFCURVE",
-"385 498 OFFCURVE",
-"425 498 CURVE SMOOTH",
-"466 498 OFFCURVE",
-"491 467 OFFCURVE",
-"491 430 CURVE SMOOTH",
-"491 394 OFFCURVE",
-"466 363 OFFCURVE",
-"425 363 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
 {
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
@@ -210975,90 +210237,6 @@ nodes = (
 }
 );
 width = 835;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "585150C1-ECC4-44DB-AC7F-CAA167C7E6D8";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"268 69 OFFCURVE",
-"138 200 OFFCURVE",
-"138 358 CURVE SMOOTH",
-"138 517 OFFCURVE",
-"268 647 OFFCURVE",
-"426 647 CURVE SMOOTH",
-"586 647 OFFCURVE",
-"715 517 OFFCURVE",
-"715 358 CURVE SMOOTH",
-"715 200 OFFCURVE",
-"586 69 OFFCURVE",
-"426 69 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 158 OFFCURVE",
-"495 269 OFFCURVE",
-"522 308 CURVE SMOOTH",
-"548 346 OFFCURVE",
-"567 379 OFFCURVE",
-"567 423 CURVE SMOOTH",
-"567 497 OFFCURVE",
-"511 557 OFFCURVE",
-"426 557 CURVE SMOOTH",
-"343 557 OFFCURVE",
-"284 497 OFFCURVE",
-"284 425 CURVE SMOOTH",
-"284 355 OFFCURVE",
-"339 299 OFFCURVE",
-"400 299 CURVE SMOOTH",
-"408 299 OFFCURVE",
-"416 300 OFFCURVE",
-"421 303 CURVE",
-"345 207 LINE",
-"413 158 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"395 370 OFFCURVE",
-"372 393 OFFCURVE",
-"372 425 CURVE SMOOTH",
-"372 458 OFFCURVE",
-"395 481 OFFCURVE",
-"427 481 CURVE SMOOTH",
-"458 481 OFFCURVE",
-"480 458 OFFCURVE",
-"480 425 CURVE SMOOTH",
-"480 393 OFFCURVE",
-"458 370 OFFCURVE",
-"427 370 CURVE SMOOTH"
-);
-}
-);
-width = 853;
 }
 );
 leftKerningGroup = circle;
@@ -211067,7 +210245,7 @@ unicode = 2788;
 },
 {
 glyphname = one.sansSerifBlackCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:01:56 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -211175,43 +210353,6 @@ nodes = (
 width = 851;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "5A82B52F-1DA1-413B-A96F-457C4ABC532B";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"406 462 LINE",
-"343 416 LINE",
-"304 465 LINE",
-"415 548 LINE",
-"471 548 LINE",
-"471 173 LINE",
-"406 173 LINE"
-);
-}
-);
-width = 851;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -211241,43 +210382,6 @@ nodes = (
 "483 549 LINE",
 "483 171 LINE",
 "394 171 LINE"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "F78456A3-5996-40E2-9561-50F26137A118";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"394 431 LINE",
-"341 388 LINE",
-"288 457 LINE",
-"402 548 LINE",
-"483 548 LINE",
-"483 173 LINE",
-"394 173 LINE"
 );
 }
 );
@@ -212258,7 +211362,7 @@ unicode = 278E;
 },
 {
 glyphname = six.sansSerifBlackCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:03 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -212450,71 +211554,6 @@ nodes = (
 width = 851;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "9B14A2DE-C95E-4958-9C94-C1CF65564EF0";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"462 224 OFFCURVE",
-"487 255 OFFCURVE",
-"487 292 CURVE SMOOTH",
-"487 329 OFFCURVE",
-"462 359 OFFCURVE",
-"421 359 CURVE SMOOTH",
-"381 359 OFFCURVE",
-"355 329 OFFCURVE",
-"355 292 CURVE SMOOTH",
-"355 255 OFFCURVE",
-"380 224 OFFCURVE",
-"421 224 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"347 165 OFFCURVE",
-"288 219 OFFCURVE",
-"288 291 CURVE SMOOTH",
-"288 337 OFFCURVE",
-"305 370 OFFCURVE",
-"331 408 CURVE",
-"440 564 LINE",
-"492 529 LINE",
-"405 409 LINE",
-"411 412 OFFCURVE",
-"423 415 OFFCURVE",
-"436 415 CURVE SMOOTH",
-"503 415 OFFCURVE",
-"554 360 OFFCURVE",
-"554 291 CURVE SMOOTH",
-"554 220 OFFCURVE",
-"494 165 OFFCURVE",
-"422 165 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -212572,71 +211611,6 @@ nodes = (
 "565 224 OFFCURVE",
 "507 163 OFFCURVE",
 "422 163 CURVE SMOOTH"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "8276C6BF-3235-4931-B05F-54B2538308F7";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"453 241 OFFCURVE",
-"476 264 OFFCURVE",
-"476 297 CURVE SMOOTH",
-"476 329 OFFCURVE",
-"453 352 OFFCURVE",
-"421 352 CURVE SMOOTH",
-"390 352 OFFCURVE",
-"368 329 OFFCURVE",
-"368 297 CURVE SMOOTH",
-"368 264 OFFCURVE",
-"390 241 OFFCURVE",
-"421 241 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"337 165 OFFCURVE",
-"281 225 OFFCURVE",
-"281 299 CURVE SMOOTH",
-"281 343 OFFCURVE",
-"299 377 OFFCURVE",
-"326 414 CURVE",
-"435 564 LINE",
-"503 515 LINE",
-"427 419 LINE",
-"432 422 OFFCURVE",
-"440 423 OFFCURVE",
-"448 423 CURVE SMOOTH",
-"509 423 OFFCURVE",
-"564 367 OFFCURVE",
-"564 297 CURVE SMOOTH",
-"564 225 OFFCURVE",
-"505 165 OFFCURVE",
-"422 165 CURVE SMOOTH"
 );
 }
 );
@@ -213167,7 +212141,7 @@ unicode = 2791;
 },
 {
 glyphname = nine.sansSerifBlackCircled;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:10 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -213359,71 +212333,6 @@ nodes = (
 width = 851;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "04CC2B94-7788-44C2-A71A-F8826A6D30C2";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"360 203 LINE",
-"438 312 LINE",
-"432 309 OFFCURVE",
-"420 306 OFFCURVE",
-"408 306 CURVE SMOOTH",
-"340 306 OFFCURVE",
-"289 362 OFFCURVE",
-"289 430 CURVE SMOOTH",
-"289 501 OFFCURVE",
-"350 556 OFFCURVE",
-"421 556 CURVE SMOOTH",
-"497 556 OFFCURVE",
-"555 502 OFFCURVE",
-"555 430 CURVE SMOOTH",
-"555 384 OFFCURVE",
-"538 351 OFFCURVE",
-"512 313 CURVE",
-"410 166 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"463 362 OFFCURVE",
-"488 393 OFFCURVE",
-"488 429 CURVE SMOOTH",
-"488 466 OFFCURVE",
-"463 497 OFFCURVE",
-"422 497 CURVE SMOOTH",
-"382 497 OFFCURVE",
-"356 466 OFFCURVE",
-"356 429 CURVE SMOOTH",
-"356 393 OFFCURVE",
-"382 362 OFFCURVE",
-"422 362 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -213481,71 +212390,6 @@ nodes = (
 "368 390 OFFCURVE",
 "392 367 OFFCURVE",
 "424 367 CURVE SMOOTH"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "C5D9841C-AEAE-430A-A259-F96DA879C449";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"343 206 LINE",
-"419 302 LINE",
-"414 299 OFFCURVE",
-"406 298 OFFCURVE",
-"398 298 CURVE SMOOTH",
-"337 298 OFFCURVE",
-"282 354 OFFCURVE",
-"282 424 CURVE SMOOTH",
-"282 496 OFFCURVE",
-"341 556 OFFCURVE",
-"424 556 CURVE SMOOTH",
-"509 556 OFFCURVE",
-"565 496 OFFCURVE",
-"565 422 CURVE SMOOTH",
-"565 378 OFFCURVE",
-"546 345 OFFCURVE",
-"520 307 CURVE",
-"411 157 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"456 369 OFFCURVE",
-"478 392 OFFCURVE",
-"478 424 CURVE SMOOTH",
-"478 457 OFFCURVE",
-"456 480 OFFCURVE",
-"425 480 CURVE SMOOTH",
-"393 480 OFFCURVE",
-"370 457 OFFCURVE",
-"370 424 CURVE SMOOTH",
-"370 392 OFFCURVE",
-"393 369 OFFCURVE",
-"425 369 CURVE SMOOTH"
 );
 }
 );
@@ -213794,7 +212638,7 @@ rightKerningGroup = zero;
 },
 {
 glyphname = one.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:15 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -213903,80 +212747,12 @@ nodes = (
 }
 );
 width = 571;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"424 0 LINE",
-"438 81 LINE",
-"275 81 LINE",
-"387 716 LINE",
-"334 716 LINE",
-"126 582 LINE",
-"110 489 LINE",
-"283 600 LINE",
-"191 81 LINE",
-"28 81 LINE",
-"14 0 LINE"
-);
-}
-);
-};
-layerId = "894E61A6-E4AA-4EAE-8852-69A09123B266";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"421 0 LINE",
-"435 81 LINE",
-"273 81 LINE",
-"384 708 LINE",
-"330 708 LINE",
-"98 564 LINE",
-"134 496 LINE",
-"279 585 LINE",
-"189 81 LINE",
-"28 81 LINE",
-"13 0 LINE"
-);
-}
-);
-width = 515;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "A3C75048-9253-42BB-9A2B-B0DD18C0C0F7";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"465 0 LINE",
-"486 120 LINE",
-"326 120 LINE",
-"429 708 LINE",
-"329 708 LINE",
-"87 551 LINE",
-"136 450 LINE",
-"267 535 LINE",
-"195 120 LINE",
-"33 120 LINE",
-"12 0 LINE"
-);
-}
-);
-width = 565;
 }
 );
 },
 {
 glyphname = six.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:19 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -214181,113 +212957,6 @@ nodes = (
 }
 );
 width = 591;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "2D1857B6-C024-4D20-81D0-DAB0038433D3";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"404 -16 OFFCURVE",
-"516 91 OFFCURVE",
-"516 238 CURVE SMOOTH",
-"516 354 OFFCURVE",
-"432 434 OFFCURVE",
-"326 434 CURVE SMOOTH",
-"279 434 OFFCURVE",
-"226 424 OFFCURVE",
-"170 377 CURVE",
-"168 379 LINE",
-"231 496 OFFCURVE",
-"339 579 OFFCURVE",
-"447 654 CURVE",
-"397 705 LINE",
-"297 638 OFFCURVE",
-"210 566 OFFCURVE",
-"140 475 CURVE SMOOTH",
-"76 393 OFFCURVE",
-"40 309 OFFCURVE",
-"40 215 CURVE SMOOTH",
-"40 74 OFFCURVE",
-"131 -16 OFFCURVE",
-"254 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"187 65 OFFCURVE",
-"128 116 OFFCURVE",
-"128 198 CURVE SMOOTH",
-"128 287 OFFCURVE",
-"197 358 OFFCURVE",
-"296 358 CURVE SMOOTH",
-"376 358 OFFCURVE",
-"429 308 OFFCURVE",
-"429 229 CURVE SMOOTH",
-"429 137 OFFCURVE",
-"362 65 OFFCURVE",
-"264 65 CURVE SMOOTH"
-);
-}
-);
-visible = 1;
-width = 567;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "ABAF3479-1D98-45D0-9586-81A34D1B9135";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"428 -16 OFFCURVE",
-"537 95 OFFCURVE",
-"537 246 CURVE SMOOTH",
-"537 364 OFFCURVE",
-"448 443 OFFCURVE",
-"352 443 CURVE SMOOTH",
-"308 443 OFFCURVE",
-"257 428 OFFCURVE",
-"228 407 CURVE",
-"223 412 LINE",
-"277 490 OFFCURVE",
-"371 567 OFFCURVE",
-"481 625 CURVE",
-"409 709 LINE",
-"308 650 OFFCURVE",
-"216 582 OFFCURVE",
-"145 489 CURVE SMOOTH",
-"82 408 OFFCURVE",
-"40 321 OFFCURVE",
-"40 222 CURVE SMOOTH",
-"40 87 OFFCURVE",
-"126 -16 OFFCURVE",
-"263 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"218 104 OFFCURVE",
-"174 146 OFFCURVE",
-"174 203 CURVE SMOOTH",
-"174 280 OFFCURVE",
-"229 333 OFFCURVE",
-"303 333 CURVE SMOOTH",
-"363 333 OFFCURVE",
-"406 293 OFFCURVE",
-"406 234 CURVE SMOOTH",
-"406 156 OFFCURVE",
-"349 104 OFFCURVE",
-"278 104 CURVE SMOOTH"
-);
-}
-);
-width = 586;
 }
 );
 },
@@ -214389,7 +213058,7 @@ rightKerningGroup = seven;
 },
 {
 glyphname = nine.alt;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:24 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -214594,112 +213263,6 @@ nodes = (
 }
 );
 width = 574;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "900D0C79-B4CD-4C15-AFD1-19CA665D216E";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"299 62 OFFCURVE",
-"386 134 OFFCURVE",
-"456 225 CURVE SMOOTH",
-"519 307 OFFCURVE",
-"556 391 OFFCURVE",
-"556 485 CURVE SMOOTH",
-"556 626 OFFCURVE",
-"465 716 OFFCURVE",
-"342 716 CURVE SMOOTH",
-"192 716 OFFCURVE",
-"80 609 OFFCURVE",
-"80 462 CURVE SMOOTH",
-"80 346 OFFCURVE",
-"164 266 OFFCURVE",
-"270 266 CURVE SMOOTH",
-"317 266 OFFCURVE",
-"370 276 OFFCURVE",
-"426 323 CURVE",
-"428 321 LINE",
-"365 204 OFFCURVE",
-"257 121 OFFCURVE",
-"149 46 CURVE",
-"199 -5 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"220 342 OFFCURVE",
-"167 392 OFFCURVE",
-"167 471 CURVE SMOOTH",
-"167 563 OFFCURVE",
-"234 635 OFFCURVE",
-"332 635 CURVE SMOOTH",
-"409 635 OFFCURVE",
-"468 584 OFFCURVE",
-"468 502 CURVE SMOOTH",
-"468 413 OFFCURVE",
-"399 342 OFFCURVE",
-"300 342 CURVE SMOOTH"
-);
-}
-);
-width = 562;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "65BE47ED-9C72-4C86-9287-970F1FC54F41";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"301 50 OFFCURVE",
-"395 130 OFFCURVE",
-"465 224 CURVE SMOOTH",
-"529 304 OFFCURVE",
-"570 379 OFFCURVE",
-"570 476 CURVE SMOOTH",
-"570 615 OFFCURVE",
-"484 716 OFFCURVE",
-"347 716 CURVE SMOOTH",
-"182 716 OFFCURVE",
-"73 605 OFFCURVE",
-"73 455 CURVE SMOOTH",
-"73 337 OFFCURVE",
-"165 258 OFFCURVE",
-"259 258 CURVE SMOOTH",
-"314 258 OFFCURVE",
-"344 266 OFFCURVE",
-"385 297 CURVE",
-"390 292 LINE",
-"301 190 OFFCURVE",
-"229 131 OFFCURVE",
-"121 71 CURVE",
-"200 -9 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"247 367 OFFCURVE",
-"204 407 OFFCURVE",
-"204 467 CURVE SMOOTH",
-"204 545 OFFCURVE",
-"261 596 OFFCURVE",
-"332 596 CURVE SMOOTH",
-"392 596 OFFCURVE",
-"436 554 OFFCURVE",
-"436 496 CURVE SMOOTH",
-"436 420 OFFCURVE",
-"381 367 OFFCURVE",
-"306 367 CURVE SMOOTH"
-);
-}
-);
-width = 571;
 }
 );
 },
@@ -214943,7 +213506,7 @@ rightMetricsKey = zero.cap;
 },
 {
 glyphname = one.alt.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:29 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -215032,80 +213595,12 @@ nodes = (
 }
 );
 width = 568;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"421 0 LINE",
-"435 81 LINE",
-"273 81 LINE",
-"385 716 LINE",
-"331 716 LINE",
-"121 581 LINE",
-"118 489 LINE",
-"280 593 LINE",
-"189 81 LINE",
-"26 81 LINE",
-"12 0 LINE"
-);
-}
-);
-};
-layerId = "D5A3DD23-10C4-4D52-BB22-7DE3A9ED6D32";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"421 0 LINE",
-"435 81 LINE",
-"273 81 LINE",
-"385 716 LINE",
-"331 716 LINE",
-"100 568 LINE",
-"135 500 LINE",
-"280 593 LINE",
-"189 81 LINE",
-"26 81 LINE",
-"12 0 LINE"
-);
-}
-);
-width = 505;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "C01D9E02-E1D9-4225-820B-1B89AFFDA616";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"468.999 0 LINE",
-"490 120 LINE",
-"327 120 LINE",
-"432 716 LINE",
-"332 716 LINE",
-"81 557 LINE",
-"130 455 LINE",
-"270 543 LINE",
-"196 120 LINE",
-"32 120 LINE",
-"11 0 LINE"
-);
-}
-);
-width = 568;
 }
 );
 },
 {
 glyphname = six.alt.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:33 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -215400,203 +213895,6 @@ nodes = (
 }
 );
 width = 592;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"398 -16 OFFCURVE",
-"504 102 OFFCURVE",
-"504 249 CURVE SMOOTH",
-"504 363 OFFCURVE",
-"426 454 OFFCURVE",
-"327 454 CURVE SMOOTH",
-"288 454 OFFCURVE",
-"256 443 OFFCURVE",
-"239 431 CURVE",
-"236 433 LINE",
-"479 716 LINE",
-"380 716 LINE",
-"148 446 LINE SMOOTH",
-"78 363 OFFCURVE",
-"36 292 OFFCURVE",
-"36 194 CURVE SMOOTH",
-"36 79 OFFCURVE",
-"124 -16 OFFCURVE",
-"244 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"175 65 OFFCURVE",
-"122 123 OFFCURVE",
-"122 201 CURVE SMOOTH",
-"122 297 OFFCURVE",
-"186 378 OFFCURVE",
-"289 378 CURVE SMOOTH",
-"369 378 OFFCURVE",
-"418 324 OFFCURVE",
-"418 240 CURVE SMOOTH",
-"418 137 OFFCURVE",
-"352 65 OFFCURVE",
-"254 65 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "5EDC84BA-AE4A-4201-B91A-0022B7A96345";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"397 -16 OFFCURVE",
-"511 104 OFFCURVE",
-"511 249 CURVE SMOOTH",
-"511 368 OFFCURVE",
-"428 455 OFFCURVE",
-"323 455 CURVE SMOOTH",
-"269 455 OFFCURVE",
-"210 438 OFFCURVE",
-"171 403 CURVE",
-"169 405 LINE",
-"242 517 OFFCURVE",
-"357 616 OFFCURVE",
-"455 681 CURVE",
-"398 724 LINE",
-"285 648 OFFCURVE",
-"195 567 OFFCURVE",
-"125 471 CURVE SMOOTH",
-"65 391 OFFCURVE",
-"31 305 OFFCURVE",
-"31 211 CURVE SMOOTH",
-"31 80 OFFCURVE",
-"115 -16 OFFCURVE",
-"247 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"175 65 OFFCURVE",
-"119 120 OFFCURVE",
-"119 199 CURVE SMOOTH",
-"119 298 OFFCURVE",
-"190 379 OFFCURVE",
-"292 379 CURVE SMOOTH",
-"371 379 OFFCURVE",
-"424 322 OFFCURVE",
-"424 236 CURVE SMOOTH",
-"424 138 OFFCURVE",
-"347 65 OFFCURVE",
-"254 65 CURVE SMOOTH"
-);
-}
-);
-visible = 1;
-width = 556;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"412 -16 OFFCURVE",
-"527 95 OFFCURVE",
-"527 255 CURVE SMOOTH",
-"527 373 OFFCURVE",
-"450 455 OFFCURVE",
-"360 455 CURVE SMOOTH",
-"338 455 OFFCURVE",
-"319 453 OFFCURVE",
-"305 448 CURVE",
-"300 453 LINE",
-"537 716 LINE",
-"375 716 LINE",
-"159 469 LINE SMOOTH",
-"81 377 OFFCURVE",
-"32 314 OFFCURVE",
-"32 211 CURVE SMOOTH",
-"32 88 OFFCURVE",
-"116 -16 OFFCURVE",
-"252 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"215 104 OFFCURVE",
-"167 147 OFFCURVE",
-"167 209 CURVE SMOOTH",
-"167 288 OFFCURVE",
-"218 345 OFFCURVE",
-"294 345 CURVE SMOOTH",
-"356 345 OFFCURVE",
-"395 304 OFFCURVE",
-"395 241 CURVE SMOOTH",
-"395 161 OFFCURVE",
-"343 104 OFFCURVE",
-"269 104 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "8295C305-000A-4FBD-A009-2F5E35B5EE9E";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"411 -16 OFFCURVE",
-"537 102 OFFCURVE",
-"537 255 CURVE SMOOTH",
-"537 375 OFFCURVE",
-"450 455 OFFCURVE",
-"351 455 CURVE SMOOTH",
-"303 455 OFFCURVE",
-"254 441 OFFCURVE",
-"229 418 CURVE",
-"224 423 LINE",
-"288 503 OFFCURVE",
-"417 603 OFFCURVE",
-"499 646 CURVE",
-"411 725 LINE",
-"316 669 OFFCURVE",
-"223 603 OFFCURVE",
-"152 521 CURVE SMOOTH",
-"69 425 OFFCURVE",
-"30 326 OFFCURVE",
-"30 225 CURVE SMOOTH",
-"30 82 OFFCURVE",
-"115 -16 OFFCURVE",
-"258 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"210 104 OFFCURVE",
-"166 147 OFFCURVE",
-"166 207 CURVE SMOOTH",
-"166 284 OFFCURVE",
-"225 345 OFFCURVE",
-"306 345 CURVE SMOOTH",
-"365 345 OFFCURVE",
-"406 302 OFFCURVE",
-"406 244 CURVE SMOOTH",
-"406 163 OFFCURVE",
-"347 104 OFFCURVE",
-"270 104 CURVE SMOOTH"
-);
-}
-);
-width = 586;
 }
 );
 },
@@ -215698,7 +213996,7 @@ rightKerningGroup = seven.cap;
 },
 {
 glyphname = nine.alt.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:38 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -216007,216 +214305,6 @@ nodes = (
 }
 );
 width = 592;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"285 47 OFFCURVE",
-"368 118 OFFCURVE",
-"431 201 CURVE SMOOTH",
-"487 275 OFFCURVE",
-"528 359 OFFCURVE",
-"545 452 CURVE SMOOTH",
-"561 538 OFFCURVE",
-"552 597 OFFCURVE",
-"524 646 CURVE SMOOTH",
-"494 699 OFFCURVE",
-"438 732 OFFCURVE",
-"361 732 CURVE SMOOTH",
-"228 732 OFFCURVE",
-"113 630 OFFCURVE",
-"89 494 CURVE SMOOTH",
-"66 362 OFFCURVE",
-"142 261 OFFCURVE",
-"258 261 CURVE SMOOTH",
-"328 261 OFFCURVE",
-"383 289 OFFCURVE",
-"420 327 CURVE",
-"422 325 LINE",
-"369 208 OFFCURVE",
-"267 119 OFFCURVE",
-"142 49 CURVE",
-"179 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"210 337 OFFCURVE",
-"157 399 OFFCURVE",
-"174 494 CURVE SMOOTH",
-"191 589 OFFCURVE",
-"266 651 OFFCURVE",
-"347 651 CURVE SMOOTH",
-"428 651 OFFCURVE",
-"480 589 OFFCURVE",
-"463 494 CURVE SMOOTH",
-"446 399 OFFCURVE",
-"372 337 OFFCURVE",
-"291 337 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "AFECFD2B-F1CD-4A2C-B13D-56E5DECE31B6";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"272 63 OFFCURVE",
-"356 139 OFFCURVE",
-"432 232 CURVE SMOOTH",
-"501 316 OFFCURVE",
-"547 410 OFFCURVE",
-"547 508 CURVE SMOOTH",
-"547 644 OFFCURVE",
-"463 732 OFFCURVE",
-"334 732 CURVE SMOOTH",
-"182 732 OFFCURVE",
-"67 613 OFFCURVE",
-"67 468 CURVE SMOOTH",
-"67 352 OFFCURVE",
-"149 262 OFFCURVE",
-"253 262 CURVE SMOOTH",
-"318 262 OFFCURVE",
-"352 280 OFFCURVE",
-"391 309 CURVE",
-"393 307 LINE",
-"310 193 OFFCURVE",
-"220 114 OFFCURVE",
-"112 35 CURVE",
-"181 -8 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"208 338 OFFCURVE",
-"154 398 OFFCURVE",
-"154 480 CURVE SMOOTH",
-"154 582 OFFCURVE",
-"234 651 OFFCURVE",
-"326 651 CURVE SMOOTH",
-"407 651 OFFCURVE",
-"461 591 OFFCURVE",
-"461 517 CURVE SMOOTH",
-"461 420 OFFCURVE",
-"392 338 OFFCURVE",
-"289 338 CURVE SMOOTH"
-);
-}
-);
-width = 566;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"295 34 OFFCURVE",
-"392 110 OFFCURVE",
-"462 201 CURVE SMOOTH",
-"520 277 OFFCURVE",
-"559 361 OFFCURVE",
-"574 450 CURVE SMOOTH",
-"588 532 OFFCURVE",
-"579 601 OFFCURVE",
-"545 648 CURVE SMOOTH",
-"507 700 OFFCURVE",
-"447 732 OFFCURVE",
-"364 732 CURVE SMOOTH",
-"232 732 OFFCURVE",
-"100 630 OFFCURVE",
-"76 491 CURVE SMOOTH",
-"52 352 OFFCURVE",
-"143 261 OFFCURVE",
-"262 261 CURVE SMOOTH",
-"311 261 OFFCURVE",
-"369 282 OFFCURVE",
-"401 320 CURVE",
-"407 315 LINE",
-"348 211 OFFCURVE",
-"246 133 OFFCURVE",
-"126 85 CURVE",
-"174 -17 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"235 371 OFFCURVE",
-"192 416 OFFCURVE",
-"206 491 CURVE SMOOTH",
-"220 566 OFFCURVE",
-"278 612 OFFCURVE",
-"343 612 CURVE SMOOTH",
-"408 612 OFFCURVE",
-"451 566 OFFCURVE",
-"438 491 CURVE SMOOTH",
-"425 416 OFFCURVE",
-"365 371 OFFCURVE",
-"300 371 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "F8A86C93-776E-4088-AF0C-1951AC701757";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"304 57 OFFCURVE",
-"383 123 OFFCURVE",
-"456 218 CURVE SMOOTH",
-"532 316 OFFCURVE",
-"571 407 OFFCURVE",
-"571 504 CURVE SMOOTH",
-"571 630 OFFCURVE",
-"488 732 OFFCURVE",
-"346 732 CURVE SMOOTH",
-"191 732 OFFCURVE",
-"65 619 OFFCURVE",
-"65 464 CURVE SMOOTH",
-"65 345 OFFCURVE",
-"158 261 OFFCURVE",
-"249 261 CURVE SMOOTH",
-"298 261 OFFCURVE",
-"326 271 OFFCURVE",
-"367 295 CURVE",
-"372 290 LINE",
-"291 194 OFFCURVE",
-"215 132 OFFCURVE",
-"93 59 CURVE",
-"190 -9 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"238 371 OFFCURVE",
-"197 415 OFFCURVE",
-"197 477 CURVE SMOOTH",
-"197 558 OFFCURVE",
-"258 612 OFFCURVE",
-"333 612 CURVE SMOOTH",
-"391 612 OFFCURVE",
-"436 570 OFFCURVE",
-"436 510 CURVE SMOOTH",
-"436 433 OFFCURVE",
-"381 371 OFFCURVE",
-"303 371 CURVE SMOOTH"
-);
-}
-);
-width = 587;
 }
 );
 },
@@ -216390,7 +214478,7 @@ rightKerningGroup = zero.cap;
 },
 {
 glyphname = one.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:43 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -216447,26 +214535,6 @@ nodes = (
 width = 371;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "B589B2CC-F1B5-4DA2-87D2-AAC0DFB423DC";
-name = "[14]";
-paths = (
-{
-closed = 1;
-nodes = (
-"245 0 LINE",
-"371 716 LINE",
-"317 716 LINE",
-"90 571 LINE",
-"127 504 LINE",
-"264 592 LINE",
-"160 0 LINE"
-);
-}
-);
-width = 380;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -216483,42 +214551,6 @@ nodes = (
 }
 );
 width = 426;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"299 0 LINE",
-"425 716 LINE",
-"326 716 LINE",
-"100 571 LINE",
-"148 470 LINE",
-"264 545 LINE",
-"168 0 LINE"
-);
-}
-);
-};
-layerId = "5CA2688A-E6D3-480D-A94A-FF843BC0ED83";
-name = "[14]";
-paths = (
-{
-closed = 1;
-nodes = (
-"299 0 LINE",
-"425 716 LINE",
-"326 716 LINE",
-"79 559 LINE",
-"127 456 LINE",
-"264 545 LINE",
-"168 0 LINE"
-);
-}
-);
-width = 434;
 }
 );
 },
@@ -217216,7 +215248,7 @@ width = 591;
 },
 {
 glyphname = six.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:48 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -217466,157 +215498,6 @@ nodes = (
 }
 );
 width = 598;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"412 -16 OFFCURVE",
-"518 100 OFFCURVE",
-"518 244 CURVE SMOOTH",
-"518 355 OFFCURVE",
-"440 444 OFFCURVE",
-"341 444 CURVE SMOOTH",
-"302 444 OFFCURVE",
-"270 433 OFFCURVE",
-"253 421 CURVE",
-"250 423 LINE",
-"493 716 LINE",
-"394 716 LINE",
-"162 436 LINE SMOOTH",
-"92 351 OFFCURVE",
-"50 283 OFFCURVE",
-"50 189 CURVE SMOOTH",
-"50 77 OFFCURVE",
-"138 -16 OFFCURVE",
-"258 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"189 65 OFFCURVE",
-"136 121 OFFCURVE",
-"136 196 CURVE SMOOTH",
-"136 287 OFFCURVE",
-"200 368 OFFCURVE",
-"303 368 CURVE SMOOTH",
-"383 368 OFFCURVE",
-"432 316 OFFCURVE",
-"432 235 CURVE SMOOTH",
-"432 135 OFFCURVE",
-"366 65 OFFCURVE",
-"268 65 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "006EBE7E-0058-42F5-BBEB-4578F5BC5AC6";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"407 -16 OFFCURVE",
-"521 104 OFFCURVE",
-"521 249 CURVE SMOOTH",
-"521 368 OFFCURVE",
-"437 455 OFFCURVE",
-"333 455 CURVE SMOOTH",
-"268 455 OFFCURVE",
-"216 434 OFFCURVE",
-"184 406 CURVE",
-"182 408 LINE",
-"254 517 OFFCURVE",
-"357 605 OFFCURVE",
-"459 673 CURVE",
-"415 732 LINE",
-"299 653 OFFCURVE",
-"205 565 OFFCURVE",
-"132 466 CURVE SMOOTH",
-"73 386 OFFCURVE",
-"41 299 OFFCURVE",
-"41 211 CURVE SMOOTH",
-"41 80 OFFCURVE",
-"124 -16 OFFCURVE",
-"257 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"185 65 OFFCURVE",
-"129 120 OFFCURVE",
-"129 199 CURVE SMOOTH",
-"129 298 OFFCURVE",
-"200 379 OFFCURVE",
-"302 379 CURVE SMOOTH",
-"381 379 OFFCURVE",
-"434 322 OFFCURVE",
-"434 236 CURVE SMOOTH",
-"434 138 OFFCURVE",
-"357 65 OFFCURVE",
-"264 65 CURVE SMOOTH"
-);
-}
-);
-width = 570;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "CEDC577D-A7B9-4B17-B0C4-6FDCD5C1180B";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"421 -16 OFFCURVE",
-"547 102 OFFCURVE",
-"547 255 CURVE SMOOTH",
-"547 375 OFFCURVE",
-"463 455 OFFCURVE",
-"367 455 CURVE SMOOTH",
-"325 455 OFFCURVE",
-"278 448 OFFCURVE",
-"239 418 CURVE",
-"234 423 LINE",
-"294 497 OFFCURVE",
-"393 580 OFFCURVE",
-"491 637 CURVE",
-"429 733 LINE",
-"328 669 OFFCURVE",
-"234 597 OFFCURVE",
-"161 512 CURVE SMOOTH",
-"78 416 OFFCURVE",
-"40 326 OFFCURVE",
-"40 225 CURVE SMOOTH",
-"40 82 OFFCURVE",
-"126 -16 OFFCURVE",
-"268 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"221 104 OFFCURVE",
-"177 147 OFFCURVE",
-"177 207 CURVE SMOOTH",
-"177 284 OFFCURVE",
-"236 345 OFFCURVE",
-"316 345 CURVE SMOOTH",
-"376 345 OFFCURVE",
-"416 302 OFFCURVE",
-"416 244 CURVE SMOOTH",
-"416 163 OFFCURVE",
-"358 104 OFFCURVE",
-"280 104 CURVE SMOOTH"
-);
-}
-);
-width = 595;
 }
 );
 },
@@ -218900,7 +216781,7 @@ width = 397;
 },
 {
 glyphname = one.numerator;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:02:56 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -218973,26 +216854,6 @@ nodes = (
 width = 250;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "272330F1-D2AC-4347-B456-F999D62BCC2D";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"215 341 LINE",
-"281 716 LINE",
-"225 716 LINE",
-"97 631 LINE",
-"127 579 LINE",
-"200 627 LINE",
-"150 341 LINE"
-);
-}
-);
-width = 262;
-},
-{
 background = {
 paths = (
 {
@@ -219025,26 +216886,6 @@ nodes = (
 }
 );
 width = 275;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "5231FC35-5330-4FB4-8A5E-C430D1096BA7";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"224 341 LINE",
-"290 716 LINE",
-"209 716 LINE",
-"72 623 LINE",
-"114 552 LINE",
-"179 594 LINE",
-"135 341 LINE"
-);
-}
-);
-width = 274;
 }
 );
 leftKerningGroup = one.superior;
@@ -219814,7 +217655,7 @@ width = 336;
 },
 {
 glyphname = six.numerator;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:01 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -220111,206 +217952,6 @@ nodes = (
 }
 );
 width = 340;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"244 330 OFFCURVE",
-"314 384 OFFCURVE",
-"327 456 CURVE SMOOTH",
-"339 525 OFFCURVE",
-"305 580 OFFCURVE",
-"238 580 CURVE SMOOTH",
-"199 580 OFFCURVE",
-"161 565 OFFCURVE",
-"137 536 CURVE",
-"160 596 OFFCURVE",
-"221 643 OFFCURVE",
-"291 675 CURVE",
-"271 722 LINE",
-"223 703 OFFCURVE",
-"176 671 OFFCURVE",
-"139 631 CURVE SMOOTH",
-"103 592 OFFCURVE",
-"74 545 OFFCURVE",
-"64 486 CURVE SMOOTH",
-"47 384 OFFCURVE",
-"96 330 OFFCURVE",
-"172 330 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"141 389 OFFCURVE",
-"121 420 OFFCURVE",
-"128 457 CURVE SMOOTH",
-"135 494 OFFCURVE",
-"165 524 OFFCURVE",
-"206 524 CURVE SMOOTH",
-"247 524 OFFCURVE",
-"266 494 OFFCURVE",
-"260 457 CURVE SMOOTH",
-"254 420 OFFCURVE",
-"223 389 OFFCURVE",
-"182 389 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "25AF920D-9236-4927-9CE3-6D04494E728C";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"263 336 OFFCURVE",
-"329 397 OFFCURVE",
-"329 480 CURVE SMOOTH",
-"329 536 OFFCURVE",
-"293 586 OFFCURVE",
-"227 586 CURVE SMOOTH",
-"201 586 OFFCURVE",
-"176 580 OFFCURVE",
-"152 561 CURVE",
-"189 610 OFFCURVE",
-"258 653 OFFCURVE",
-"297 679 CURVE",
-"266 727 LINE",
-"213 693 OFFCURVE",
-"167 658 OFFCURVE",
-"126 613 CURVE SMOOTH",
-"77 560 OFFCURVE",
-"60 508 OFFCURVE",
-"60 460 CURVE SMOOTH",
-"60 383 OFFCURVE",
-"112 336 OFFCURVE",
-"177 336 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"149 395 OFFCURVE",
-"127 422 OFFCURVE",
-"127 454 CURVE SMOOTH",
-"127 496 OFFCURVE",
-"158 530 OFFCURVE",
-"203 530 CURVE SMOOTH",
-"240 530 OFFCURVE",
-"261 503 OFFCURVE",
-"261 471 CURVE SMOOTH",
-"261 429 OFFCURVE",
-"228 395 OFFCURVE",
-"186 395 CURVE SMOOTH"
-);
-}
-);
-width = 317;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"265 330 OFFCURVE",
-"334 391 OFFCURVE",
-"347 463 CURVE SMOOTH",
-"360 534 OFFCURVE",
-"321 591 OFFCURVE",
-"257 591 CURVE SMOOTH",
-"228 591 OFFCURVE",
-"194 584 OFFCURVE",
-"169 563 CURVE",
-"189 602 OFFCURVE",
-"247 640 OFFCURVE",
-"309 657 CURVE",
-"293 723 LINE",
-"229 706 OFFCURVE",
-"170 672 OFFCURVE",
-"129 623 CURVE SMOOTH",
-"97 585 OFFCURVE",
-"74 539 OFFCURVE",
-"64 483 CURVE SMOOTH",
-"47 388 OFFCURVE",
-"100 330 OFFCURVE",
-"180 330 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"161 406 OFFCURVE",
-"142 429 OFFCURVE",
-"148 463 CURVE SMOOTH",
-"154 497 OFFCURVE",
-"181 520 OFFCURVE",
-"213 520 CURVE SMOOTH",
-"245 520 OFFCURVE",
-"265 497 OFFCURVE",
-"259 463 CURVE SMOOTH",
-"253 429 OFFCURVE",
-"225 406 OFFCURVE",
-"193 406 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "6A8BF144-F6D3-4A19-92C9-D03E86424E44";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"280 336 OFFCURVE",
-"345 401 OFFCURVE",
-"345 485 CURVE SMOOTH",
-"345 544 OFFCURVE",
-"305 591 OFFCURVE",
-"249 591 CURVE SMOOTH",
-"233 591 OFFCURVE",
-"206 586 OFFCURVE",
-"187 575 CURVE",
-"215 607 OFFCURVE",
-"266 639 OFFCURVE",
-"310 663 CURVE",
-"274 727 LINE",
-"216 694 OFFCURVE",
-"166 660 OFFCURVE",
-"124 615 CURVE SMOOTH",
-"81 568 OFFCURVE",
-"61 516 OFFCURVE",
-"61 461 CURVE SMOOTH",
-"61 387 OFFCURVE",
-"110 336 OFFCURVE",
-"187 336 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"168 412 OFFCURVE",
-"148 431 OFFCURVE",
-"148 459 CURVE SMOOTH",
-"148 495 OFFCURVE",
-"174 520 OFFCURVE",
-"209 520 CURVE SMOOTH",
-"236 520 OFFCURVE",
-"256 501 OFFCURVE",
-"256 473 CURVE SMOOTH",
-"256 437 OFFCURVE",
-"230 412 OFFCURVE",
-"195 412 CURVE SMOOTH"
-);
-}
-);
-width = 331;
 }
 );
 },
@@ -221159,7 +218800,7 @@ widthMetricsKey = "=600";
 {
 color = 4;
 glyphname = one.tf;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:06 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -221216,26 +218857,6 @@ nodes = (
 width = 600;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "386D0D94-A26B-434D-89DA-4FAC03B50A15";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"364 0 LINE",
-"490 716 LINE",
-"437 716 LINE",
-"147 555 LINE",
-"179 485 LINE",
-"385 599 LINE",
-"280 0 LINE"
-);
-}
-);
-width = 600;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -221247,42 +218868,6 @@ nodes = (
 "144 574 LINE",
 "118 425 LINE",
 "349 546 LINE",
-"253 0 LINE"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"384 0 LINE",
-"510 716 LINE",
-"411 716 LINE",
-"119 552 LINE",
-"169 447 LINE",
-"350 550 LINE",
-"253 0 LINE"
-);
-}
-);
-};
-layerId = "0F9CF3C9-0A75-46E4-81B6-61F0905CE56A";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"384 0 LINE",
-"510 716 LINE",
-"411 716 LINE",
-"119 552 LINE",
-"173 443 LINE",
-"349 545 LINE",
 "253 0 LINE"
 );
 }
@@ -221999,7 +219584,7 @@ widthMetricsKey = "=600";
 {
 color = 4;
 glyphname = six.tf;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:12 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -222200,161 +219785,6 @@ nodes = (
 "417 155 OFFCURVE",
 "360 104 OFFCURVE",
 "291 104 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"434 -16 OFFCURVE",
-"536 103 OFFCURVE",
-"536 245 CURVE SMOOTH",
-"536 359 OFFCURVE",
-"450 434 OFFCURVE",
-"343 434 CURVE SMOOTH",
-"261 434 OFFCURVE",
-"198 401 OFFCURVE",
-"160 354 CURVE",
-"157 356 LINE",
-"194 507 OFFCURVE",
-"332 601 OFFCURVE",
-"463 660 CURVE",
-"431 726 LINE",
-"305 676 OFFCURVE",
-"203 599 OFFCURVE",
-"138 501 CURVE SMOOTH",
-"87 424 OFFCURVE",
-"59 335 OFFCURVE",
-"59 237 CURVE SMOOTH",
-"59 75 OFFCURVE",
-"146 -16 OFFCURVE",
-"271 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"203 65 OFFCURVE",
-"147 112 OFFCURVE",
-"147 200 CURVE SMOOTH",
-"147 289 OFFCURVE",
-"218 358 OFFCURVE",
-"320 358 CURVE SMOOTH",
-"399 358 OFFCURVE",
-"449 312 OFFCURVE",
-"449 235 CURVE SMOOTH",
-"449 143 OFFCURVE",
-"387 65 OFFCURVE",
-"284 65 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "A57EF459-20C8-4435-B807-D17D94F8F68C";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"432 -16 OFFCURVE",
-"537 102 OFFCURVE",
-"537 245 CURVE SMOOTH",
-"537 361 OFFCURVE",
-"451 444 OFFCURVE",
-"347 444 CURVE SMOOTH",
-"274 444 OFFCURVE",
-"218 419 OFFCURVE",
-"183 385 CURVE",
-"181 387 LINE",
-"247 487 OFFCURVE",
-"369 595 OFFCURVE",
-"493 663 CURVE",
-"455 729 LINE",
-"340 662 OFFCURVE",
-"237 578 OFFCURVE",
-"170 498 CURVE SMOOTH",
-"92 406 OFFCURVE",
-"54 309 OFFCURVE",
-"54 212 CURVE SMOOTH",
-"54 78 OFFCURVE",
-"138 -16 OFFCURVE",
-"268 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"197 65 OFFCURVE",
-"142 117 OFFCURVE",
-"142 197 CURVE SMOOTH",
-"142 291 OFFCURVE",
-"215 368 OFFCURVE",
-"317 368 CURVE SMOOTH",
-"398 368 OFFCURVE",
-"449 311 OFFCURVE",
-"449 233 CURVE SMOOTH",
-"449 136 OFFCURVE",
-"374 65 OFFCURVE",
-"280 65 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "FA464B58-A803-4316-9F26-B020A9574107";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"428 -16 OFFCURVE",
-"550 98 OFFCURVE",
-"550 253 CURVE SMOOTH",
-"550 370 OFFCURVE",
-"458 450 OFFCURVE",
-"360 450 CURVE SMOOTH",
-"321 450 OFFCURVE",
-"268 437 OFFCURVE",
-"240 415 CURVE",
-"235 420 LINE",
-"297 508 OFFCURVE",
-"391 580 OFFCURVE",
-"510 634 CURVE",
-"454 733 LINE",
-"338 677 OFFCURVE",
-"236 597 OFFCURVE",
-"159 504 CURVE SMOOTH",
-"86 415 OFFCURVE",
-"46 323 OFFCURVE",
-"46 222 CURVE SMOOTH",
-"46 90 OFFCURVE",
-"128 -16 OFFCURVE",
-"273 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"225 104 OFFCURVE",
-"183 147 OFFCURVE",
-"183 205 CURVE SMOOTH",
-"183 283 OFFCURVE",
-"240 340 OFFCURVE",
-"317 340 CURVE SMOOTH",
-"377 340 OFFCURVE",
-"418 300 OFFCURVE",
-"418 240 CURVE SMOOTH",
-"418 157 OFFCURVE",
-"357 104 OFFCURVE",
-"287 104 CURVE SMOOTH"
 );
 }
 );
@@ -222758,7 +220188,7 @@ widthMetricsKey = "=600";
 {
 color = 4;
 glyphname = nine.tf;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:17 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -222959,161 +220389,6 @@ nodes = (
 "446 431 OFFCURVE",
 "391 381 OFFCURVE",
 "316 381 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"203 726 OFFCURVE",
-"101 607 OFFCURVE",
-"101 465 CURVE SMOOTH",
-"101 351 OFFCURVE",
-"187 276 OFFCURVE",
-"294 276 CURVE SMOOTH",
-"376 276 OFFCURVE",
-"439 309 OFFCURVE",
-"477 356 CURVE",
-"480 354 LINE",
-"443 203 OFFCURVE",
-"305 109 OFFCURVE",
-"174 50 CURVE",
-"206 -16 LINE",
-"332 34 OFFCURVE",
-"434 111 OFFCURVE",
-"499 209 CURVE SMOOTH",
-"550 286 OFFCURVE",
-"578 375 OFFCURVE",
-"578 473 CURVE SMOOTH",
-"578 635 OFFCURVE",
-"491 726 OFFCURVE",
-"366 726 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"434 645 OFFCURVE",
-"490 598 OFFCURVE",
-"490 510 CURVE SMOOTH",
-"490 421 OFFCURVE",
-"419 352 OFFCURVE",
-"317 352 CURVE SMOOTH",
-"238 352 OFFCURVE",
-"188 398 OFFCURVE",
-"188 475 CURVE SMOOTH",
-"188 567 OFFCURVE",
-"250 645 OFFCURVE",
-"353 645 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "01012347-6576-4695-BC95-F4818D7C842C";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"308 60 OFFCURVE",
-"404 147 OFFCURVE",
-"482 247 CURVE SMOOTH",
-"543 326 OFFCURVE",
-"581 411 OFFCURVE",
-"581 510 CURVE SMOOTH",
-"581 638 OFFCURVE",
-"499 732 OFFCURVE",
-"368 732 CURVE SMOOTH",
-"207 732 OFFCURVE",
-"100 612 OFFCURVE",
-"100 471 CURVE SMOOTH",
-"100 353 OFFCURVE",
-"191 272 OFFCURVE",
-"295 272 CURVE SMOOTH",
-"361 272 OFFCURVE",
-"404 293 OFFCURVE",
-"439 324 CURVE",
-"442 322 LINE",
-"369 214 OFFCURVE",
-"273 118 OFFCURVE",
-"160 45 CURVE",
-"205 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"241 348 OFFCURVE",
-"187 405 OFFCURVE",
-"187 482 CURVE SMOOTH",
-"187 580 OFFCURVE",
-"264 651 OFFCURVE",
-"359 651 CURVE SMOOTH",
-"442 651 OFFCURVE",
-"496 597 OFFCURVE",
-"496 523 CURVE SMOOTH",
-"496 426 OFFCURVE",
-"425 348 OFFCURVE",
-"322 348 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "317D32D9-D259-4AAC-A324-B585F2C78941";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"302 46 OFFCURVE",
-"394 124 OFFCURVE",
-"471 217 CURVE SMOOTH",
-"548 309 OFFCURVE",
-"591 390 OFFCURVE",
-"591 495 CURVE SMOOTH",
-"591 627 OFFCURVE",
-"509 732 OFFCURVE",
-"364 732 CURVE SMOOTH",
-"206 732 OFFCURVE",
-"88 618 OFFCURVE",
-"88 467 CURVE SMOOTH",
-"88 345 OFFCURVE",
-"183 266 OFFCURVE",
-"274 266 CURVE SMOOTH",
-"323 266 OFFCURVE",
-"357 276 OFFCURVE",
-"398 305 CURVE",
-"403 300 LINE",
-"324 210 OFFCURVE",
-"235 135 OFFCURVE",
-"132 72 CURVE",
-"197 -17 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"261 376 OFFCURVE",
-"219 417 OFFCURVE",
-"219 478 CURVE SMOOTH",
-"219 560 OFFCURVE",
-"281 612 OFFCURVE",
-"352 612 CURVE SMOOTH",
-"412 612 OFFCURVE",
-"454 570 OFFCURVE",
-"454 512 CURVE SMOOTH",
-"454 434 OFFCURVE",
-"398 376 OFFCURVE",
-"320 376 CURVE SMOOTH"
 );
 }
 );
@@ -225116,7 +222391,7 @@ rightKerningGroup = zero.sc;
 },
 {
 glyphname = one.sc;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:24 +0000";
 layers = (
 {
 background = {
@@ -225237,78 +222512,6 @@ nodes = (
 }
 );
 width = 370;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"209 0 LINE",
-"310 580 LINE",
-"254 580 LINE",
-"78 468 LINE",
-"73 378 LINE",
-"208 465 LINE",
-"127 0 LINE"
-);
-}
-);
-};
-layerId = "A2BB372D-1261-47C3-A78E-36EF3A74C47C";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"209 0 LINE",
-"310 580 LINE",
-"254 580 LINE",
-"64 459 LINE",
-"95 392 LINE",
-"208 465 LINE",
-"127 0 LINE"
-);
-}
-);
-width = 326;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"256 0 LINE",
-"358 580 LINE",
-"259 580 LINE",
-"75 464 LINE",
-"69 330 LINE",
-"204 417 LINE",
-"130 0 LINE"
-);
-}
-);
-};
-layerId = "8A495C68-14B3-4B65-B7B6-C32C4F175F16";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"256 0 LINE",
-"358 580 LINE",
-"259 580 LINE",
-"54 451 LINE",
-"99 349 LINE",
-"204 417 LINE",
-"130 0 LINE"
-);
-}
-);
-width = 380;
 }
 );
 },
@@ -226010,7 +223213,7 @@ width = 497;
 },
 {
 glyphname = six.sc;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:30 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -226215,112 +223418,6 @@ nodes = (
 }
 );
 width = 488;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "CC5105C6-E6EB-4658-9228-5234B7682C96";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"330 -16 OFFCURVE",
-"436 75 OFFCURVE",
-"436 202 CURVE SMOOTH",
-"436 292 OFFCURVE",
-"369 364 OFFCURVE",
-"277 364 CURVE SMOOTH",
-"228 364 OFFCURVE",
-"181 348 OFFCURVE",
-"146 317 CURVE",
-"143 319 LINE",
-"197 400 OFFCURVE",
-"289 477 OFFCURVE",
-"385 540 CURVE",
-"341 596 LINE",
-"260 539 OFFCURVE",
-"182 475 OFFCURVE",
-"117 400 CURVE SMOOTH",
-"61 334 OFFCURVE",
-"26 256 OFFCURVE",
-"26 174 CURVE SMOOTH",
-"26 62 OFFCURVE",
-"99 -16 OFFCURVE",
-"209 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"156 60 OFFCURVE",
-"111 103 OFFCURVE",
-"111 162 CURVE SMOOTH",
-"111 238 OFFCURVE",
-"168 293 OFFCURVE",
-"246 293 CURVE SMOOTH",
-"308 293 OFFCURVE",
-"352 252 OFFCURVE",
-"352 193 CURVE SMOOTH",
-"352 114 OFFCURVE",
-"288 60 OFFCURVE",
-"216 60 CURVE SMOOTH"
-);
-}
-);
-width = 488;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "52B109AE-7D41-4F68-A0DF-D635FF57E14F";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"364 -16 OFFCURVE",
-"460 73 OFFCURVE",
-"460 202 CURVE SMOOTH",
-"460 301 OFFCURVE",
-"393 369 OFFCURVE",
-"309 369 CURVE SMOOTH",
-"271 369 OFFCURVE",
-"228 356 OFFCURVE",
-"204 335 CURVE",
-"199 340 LINE",
-"243 399 OFFCURVE",
-"335 462 OFFCURVE",
-"419 506 CURVE",
-"361 596 LINE",
-"268 548 OFFCURVE",
-"185 488 OFFCURVE",
-"122 412 CURVE SMOOTH",
-"64 342 OFFCURVE",
-"29 265 OFFCURVE",
-"29 180 CURVE SMOOTH",
-"29 70 OFFCURVE",
-"105 -16 OFFCURVE",
-"226 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"192 97 OFFCURVE",
-"162 130 OFFCURVE",
-"162 172 CURVE SMOOTH",
-"162 225 OFFCURVE",
-"200 266 OFFCURVE",
-"259 266 CURVE SMOOTH",
-"305 266 OFFCURVE",
-"335 234 OFFCURVE",
-"335 192 CURVE SMOOTH",
-"335 134 OFFCURVE",
-"292 97 OFFCURVE",
-"239 97 CURVE SMOOTH"
-);
-}
-);
-width = 512;
 }
 );
 },
@@ -226712,7 +223809,7 @@ width = 474;
 },
 {
 glyphname = nine.sc;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:35 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -226917,112 +224014,6 @@ nodes = (
 }
 );
 width = 488;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "C64EA640-F847-4FCF-AD93-210E5C9852B4";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"239 42 OFFCURVE",
-"315 104 OFFCURVE",
-"380 179 CURVE SMOOTH",
-"437 244 OFFCURVE",
-"472 324 OFFCURVE",
-"472 406 CURVE SMOOTH",
-"472 519 OFFCURVE",
-"400 596 OFFCURVE",
-"290 596 CURVE SMOOTH",
-"169 596 OFFCURVE",
-"63 507 OFFCURVE",
-"63 380 CURVE SMOOTH",
-"63 290 OFFCURVE",
-"132 217 OFFCURVE",
-"222 217 CURVE SMOOTH",
-"277 217 OFFCURVE",
-"328 237 OFFCURVE",
-"355 264 CURVE",
-"357 261 LINE",
-"302 182 OFFCURVE",
-"221 105 OFFCURVE",
-"113 40 CURVE",
-"157 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"191 287 OFFCURVE",
-"147 328 OFFCURVE",
-"147 388 CURVE SMOOTH",
-"147 467 OFFCURVE",
-"210 520 OFFCURVE",
-"283 520 CURVE SMOOTH",
-"342 520 OFFCURVE",
-"388 478 OFFCURVE",
-"388 419 CURVE SMOOTH",
-"388 342 OFFCURVE",
-"330 287 OFFCURVE",
-"252 287 CURVE SMOOTH"
-);
-}
-);
-width = 488;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "CC3F4943-AD2E-4DB1-983C-B0A4D9A7A668";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"256 33 OFFCURVE",
-"331 92 OFFCURVE",
-"395 171 CURVE SMOOTH",
-"452 241 OFFCURVE",
-"494 316 OFFCURVE",
-"494 400 CURVE SMOOTH",
-"494 511 OFFCURVE",
-"418 596 OFFCURVE",
-"297 596 CURVE SMOOTH",
-"157 596 OFFCURVE",
-"64 507 OFFCURVE",
-"64 378 CURVE SMOOTH",
-"64 280 OFFCURVE",
-"138 212 OFFCURVE",
-"214 212 CURVE SMOOTH",
-"252 212 OFFCURVE",
-"289 225 OFFCURVE",
-"312 246 CURVE",
-"318 241 LINE",
-"267 172 OFFCURVE",
-"194 114 OFFCURVE",
-"104 70 CURVE",
-"163 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"217 314 OFFCURVE",
-"188 345 OFFCURVE",
-"188 388 CURVE SMOOTH",
-"188 445 OFFCURVE",
-"230 483 OFFCURVE",
-"285 483 CURVE SMOOTH",
-"330 483 OFFCURVE",
-"362 451 OFFCURVE",
-"362 408 CURVE SMOOTH",
-"362 356 OFFCURVE",
-"323 314 OFFCURVE",
-"264 314 CURVE SMOOTH"
-);
-}
-);
-width = 512;
 }
 );
 },
@@ -227966,110 +224957,8 @@ width = 376;
 },
 {
 glyphname = six.sc.ss04;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:40 +0000";
 layers = (
-{
-layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
-paths = (
-{
-closed = 1;
-nodes = (
-"233 -8 OFFCURVE",
-"313 66 OFFCURVE",
-"313 158 CURVE SMOOTH",
-"313 231 OFFCURVE",
-"259 283 OFFCURVE",
-"202 283 CURVE SMOOTH",
-"185 283 OFFCURVE",
-"167 278 OFFCURVE",
-"155 272 CURVE",
-"153 274 LINE",
-"195 322 OFFCURVE",
-"238 369 OFFCURVE",
-"280 417 CURVE",
-"235 455 LINE",
-"179 391 OFFCURVE",
-"127 331 OFFCURVE",
-"85 284 CURVE SMOOTH",
-"31 223 OFFCURVE",
-"5 184 OFFCURVE",
-"5 122 CURVE SMOOTH",
-"5 54 OFFCURVE",
-"55 -8 OFFCURVE",
-"143 -8 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"104 55 OFFCURVE",
-"72 87 OFFCURVE",
-"72 129 CURVE SMOOTH",
-"72 181 OFFCURVE",
-"113 228 OFFCURVE",
-"172 228 CURVE SMOOTH",
-"216 228 OFFCURVE",
-"247 195 OFFCURVE",
-"247 152 CURVE SMOOTH",
-"247 94 OFFCURVE",
-"200 55 OFFCURVE",
-"148 55 CURVE SMOOTH"
-);
-}
-);
-width = 358;
-},
-{
-layerId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
-paths = (
-{
-closed = 1;
-nodes = (
-"243 -8 OFFCURVE",
-"325 63 OFFCURVE",
-"325 161 CURVE SMOOTH",
-"325 231 OFFCURVE",
-"273 283 OFFCURVE",
-"217 283 CURVE SMOOTH",
-"205 283 OFFCURVE",
-"195 281 OFFCURVE",
-"185 276 CURVE",
-"183 278 LINE",
-"221 319 OFFCURVE",
-"260 361 OFFCURVE",
-"298 402 CURVE",
-"234 455 LINE",
-"129 340 OFFCURVE",
-"130 339 OFFCURVE",
-"84 289 CURVE SMOOTH",
-"36 235 OFFCURVE",
-"5 189 OFFCURVE",
-"5 127 CURVE SMOOTH",
-"5 54 OFFCURVE",
-"56 -8 OFFCURVE",
-"148.008 -8 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"125 79 OFFCURVE",
-"100 103 OFFCURVE",
-"100 135 CURVE SMOOTH",
-"100 173 OFFCURVE",
-"131 204 OFFCURVE",
-"174 204 CURVE SMOOTH",
-"207 204 OFFCURVE",
-"231 181 OFFCURVE",
-"231 149 CURVE SMOOTH",
-"231 106 OFFCURVE",
-"195 79 OFFCURVE",
-"157 79 CURVE SMOOTH"
-);
-}
-);
-width = 370;
-},
 {
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 paths = (
@@ -228173,110 +225062,106 @@ nodes = (
 width = 363;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "6A3853E0-992E-4E6D-8A85-693C014DAF1D";
-name = "{16}";
+layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 paths = (
 {
 closed = 1;
 nodes = (
-"236 -8 OFFCURVE",
-"309 64 OFFCURVE",
-"309 156 CURVE SMOOTH",
-"309 228 OFFCURVE",
-"255 278 OFFCURVE",
-"193 278 CURVE SMOOTH",
-"158 278 OFFCURVE",
-"120 266 OFFCURVE",
-"100 247 CURVE",
-"98 249 LINE",
-"132 312 OFFCURVE",
-"200 363 OFFCURVE",
-"269 402 CURVE",
-"239 454 LINE",
-"171 414 OFFCURVE",
-"110 364 OFFCURVE",
-"68 308 CURVE SMOOTH",
-"26 254 OFFCURVE",
-"4 197 OFFCURVE",
-"4 136 CURVE SMOOTH",
-"4 53 OFFCURVE",
+"233 -8 OFFCURVE",
+"313 66 OFFCURVE",
+"313 158 CURVE SMOOTH",
+"313 231 OFFCURVE",
+"259 283 OFFCURVE",
+"202 283 CURVE SMOOTH",
+"185 283 OFFCURVE",
+"167 278 OFFCURVE",
+"155 272 CURVE",
+"153 274 LINE",
+"195 322 OFFCURVE",
+"238 369 OFFCURVE",
+"280 417 CURVE",
+"235 455 LINE",
+"179 391 OFFCURVE",
+"127 331 OFFCURVE",
+"85 284 CURVE SMOOTH",
+"31 223 OFFCURVE",
+"5 184 OFFCURVE",
+"5 122 CURVE SMOOTH",
+"5 54 OFFCURVE",
 "55 -8 OFFCURVE",
-"140 -8 CURVE SMOOTH"
+"143 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
 "104 55 OFFCURVE",
-"72 84 OFFCURVE",
-"72 127 CURVE SMOOTH",
-"72 180 OFFCURVE",
-"110 222 OFFCURVE",
-"170 222 CURVE SMOOTH",
-"213 222 OFFCURVE",
-"242 192 OFFCURVE",
-"242 150 CURVE SMOOTH",
-"242 94 OFFCURVE",
+"72 87 OFFCURVE",
+"72 129 CURVE SMOOTH",
+"72 181 OFFCURVE",
+"113 228 OFFCURVE",
+"172 228 CURVE SMOOTH",
+"216 228 OFFCURVE",
+"247 195 OFFCURVE",
+"247 152 CURVE SMOOTH",
+"247 94 OFFCURVE",
 "200 55 OFFCURVE",
 "148 55 CURVE SMOOTH"
 );
 }
 );
-width = 355;
+width = 358;
 },
 {
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "C6C1199B-4FA1-465D-8C8E-44BF9B2863C4";
-name = "{16}";
+layerId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 paths = (
 {
 closed = 1;
 nodes = (
-"243 -9 OFFCURVE",
-"319 60 OFFCURVE",
-"319 160 CURVE SMOOTH",
-"319 231 OFFCURVE",
-"261 281 OFFCURVE",
-"202 281 CURVE SMOOTH",
-"181 281 OFFCURVE",
-"146 273 OFFCURVE",
-"127 257 CURVE",
-"124 260 LINE",
-"159 307 OFFCURVE",
-"219 351 OFFCURVE",
-"285 385 CURVE",
-"246 456 LINE",
-"150 396 OFFCURVE",
-"107 363 OFFCURVE",
-"61 303 CURVE SMOOTH",
-"22 254 OFFCURVE",
-"1 201 OFFCURVE",
-"1 141 CURVE SMOOTH",
-"1 59 OFFCURVE",
-"52 -9 OFFCURVE",
-"144.004 -9 CURVE SMOOTH"
+"243 -8 OFFCURVE",
+"325 63 OFFCURVE",
+"325 161 CURVE SMOOTH",
+"325 231 OFFCURVE",
+"273 283 OFFCURVE",
+"217 283 CURVE SMOOTH",
+"205 283 OFFCURVE",
+"195 281 OFFCURVE",
+"185 276 CURVE",
+"183 278 LINE",
+"221 319 OFFCURVE",
+"260 361 OFFCURVE",
+"298 402 CURVE",
+"234 455 LINE",
+"129 340 OFFCURVE",
+"130 339 OFFCURVE",
+"84 289 CURVE SMOOTH",
+"36 235 OFFCURVE",
+"5 189 OFFCURVE",
+"5 127 CURVE SMOOTH",
+"5 54 OFFCURVE",
+"56 -8 OFFCURVE",
+"148.008 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"122 77 OFFCURVE",
-"99 102 OFFCURVE",
-"99 131 CURVE SMOOTH",
-"99 174 OFFCURVE",
-"130 203 OFFCURVE",
-"171 203 CURVE SMOOTH",
-"201 203 OFFCURVE",
-"225 181 OFFCURVE",
-"225 149 CURVE SMOOTH",
-"225 103 OFFCURVE",
-"190 77 OFFCURVE",
-"155 77 CURVE SMOOTH"
+"125 79 OFFCURVE",
+"100 103 OFFCURVE",
+"100 135 CURVE SMOOTH",
+"100 173 OFFCURVE",
+"131 204 OFFCURVE",
+"174 204 CURVE SMOOTH",
+"207 204 OFFCURVE",
+"231 181 OFFCURVE",
+"231 149 CURVE SMOOTH",
+"231 106 OFFCURVE",
+"195 79 OFFCURVE",
+"157 79 CURVE SMOOTH"
 );
 }
 );
-width = 367;
+width = 370;
 }
 );
 },
@@ -228666,7 +225551,7 @@ width = 357;
 },
 {
 glyphname = nine.sc.ss04;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:03:46 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -228871,112 +225756,6 @@ nodes = (
 }
 );
 width = 371;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "029B5361-CF2F-4301-823C-55745D24E004";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"177 38 OFFCURVE",
-"229 76 OFFCURVE",
-"273 135 CURVE SMOOTH",
-"315 192 OFFCURVE",
-"339 249 OFFCURVE",
-"339 312 CURVE SMOOTH",
-"339 393 OFFCURVE",
-"288 455 OFFCURVE",
-"203 455 CURVE SMOOTH",
-"103 455 OFFCURVE",
-"34 382 OFFCURVE",
-"34 292 CURVE SMOOTH",
-"34 217 OFFCURVE",
-"96 168 OFFCURVE",
-"156 168 CURVE SMOOTH",
-"200 168 OFFCURVE",
-"226 182 OFFCURVE",
-"245 201 CURVE",
-"247 199 LINE",
-"209 131 OFFCURVE",
-"146 85 OFFCURVE",
-"72 41 CURVE",
-"104 -8 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"130 224 OFFCURVE",
-"100 255 OFFCURVE",
-"100 298 CURVE SMOOTH",
-"100 353 OFFCURVE",
-"143 393 OFFCURVE",
-"196 393 CURVE SMOOTH",
-"241 393 OFFCURVE",
-"271 363 OFFCURVE",
-"271 322 CURVE SMOOTH",
-"271 267 OFFCURVE",
-"231 224 OFFCURVE",
-"174 224 CURVE SMOOTH"
-);
-}
-);
-width = 360;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "A18E1410-7A8E-40DB-8CA3-BA062EB69734";
-name = "{16}";
-paths = (
-{
-closed = 1;
-nodes = (
-"192 43 OFFCURVE",
-"229 69 OFFCURVE",
-"278 126 CURVE SMOOTH",
-"322 177 OFFCURVE",
-"352 240 OFFCURVE",
-"352 306 CURVE SMOOTH",
-"352 386 OFFCURVE",
-"300 455 OFFCURVE",
-"209 455 CURVE SMOOTH",
-"109 455 OFFCURVE",
-"33 387 OFFCURVE",
-"33 289 CURVE SMOOTH",
-"33 215 OFFCURVE",
-"92 165 OFFCURVE",
-"150 165 CURVE SMOOTH",
-"185 165 OFFCURVE",
-"205 175 OFFCURVE",
-"224 190 CURVE",
-"228 187 LINE",
-"189 139 OFFCURVE",
-"128 92 OFFCURVE",
-"60 56 CURVE",
-"106 -10 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"150 243 OFFCURVE",
-"127 265 OFFCURVE",
-"127 298 CURVE SMOOTH",
-"127 343 OFFCURVE",
-"163 368 OFFCURVE",
-"199 368 CURVE SMOOTH",
-"231 368 OFFCURVE",
-"254 347 OFFCURVE",
-"254 316 CURVE SMOOTH",
-"254 272 OFFCURVE",
-"223 243 OFFCURVE",
-"181 243 CURVE SMOOTH"
-);
-}
-);
-width = 372;
 }
 );
 },
@@ -233066,7 +229845,7 @@ unicode = 002E;
 },
 {
 glyphname = comma;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:04:03 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -233116,7 +229895,7 @@ width = 258;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "2D9E1345-579C-4A4B-A5C0-2536CF0D4D75";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233159,7 +229938,7 @@ width = 294;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "1927BD9E-74A1-47DE-8246-3ED6A612CCE3";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233187,7 +229966,7 @@ width = 294;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "7788A5FB-9A1B-4B7F-B7B7-23FD97E92CC7";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233215,7 +229994,7 @@ width = 224;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "0DED3AAF-5110-4C09-A109-207B32E55E16";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233416,7 +230195,7 @@ unicode = 003A;
 },
 {
 glyphname = semicolon;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:04:14 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -233517,7 +230296,7 @@ width = 258;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "FE248D9D-42DE-4A1C-9464-5545E7673CB7";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233594,7 +230373,7 @@ width = 294;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "F113844C-9072-476B-AE08-595C8BDB91A2";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233639,7 +230418,7 @@ width = 294;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "030C8941-3829-481E-B72E-CF4CA9422116";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233684,7 +230463,7 @@ width = 246;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "160DECA7-5423-4C6F-BC58-F5976B7D1BE2";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -239712,7 +236491,7 @@ rightKerningGroup = dash.cap;
 },
 {
 glyphname = quotesinglbase;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:04:43 +0000";
 layers = (
 {
 components = (
@@ -239755,7 +236534,7 @@ transform = "{1, 0, 0, 1, -100, -611}";
 }
 );
 layerId = "42E9D93C-1757-4DFE-8DAD-035BCB5D19AE";
-name = "[16]";
+name = "[17.5]";
 width = 292;
 },
 {
@@ -239779,7 +236558,7 @@ transform = "{1, 0, 0, 1, -100, -567}";
 }
 );
 layerId = "43E6225E-B8D2-4953-8994-2F9158EBCCE7";
-name = "[16]";
+name = "[17.5]";
 width = 342;
 },
 {
@@ -239791,7 +236570,7 @@ transform = "{1, 0, 0, 1, -82, -611}";
 }
 );
 layerId = "E20FCB1D-ED69-4E77-B70A-1D8D7886E812";
-name = "[16]";
+name = "[17.5]";
 width = 224;
 },
 {
@@ -239803,7 +236582,7 @@ transform = "{1, 0, 0, 1, -93, -567}";
 }
 );
 layerId = "3A2BCFDB-732E-41A7-8F40-EB9A93945922";
-name = "[16]";
+name = "[17.5]";
 width = 269;
 }
 );
@@ -239813,7 +236592,7 @@ unicode = 201A;
 },
 {
 glyphname = quotedblbase;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:04:53 +0000";
 layers = (
 {
 components = (
@@ -239874,7 +236653,7 @@ transform = "{1, 0, 0, 1, 57, -611}";
 }
 );
 layerId = "BAAAB0DE-5491-454A-A7BD-41147D97E397";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -239908,7 +236687,7 @@ transform = "{1, 0, 0, 1, 96, -567}";
 }
 );
 layerId = "7302A723-C4CC-48E9-9D42-092D116F820A";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -239924,7 +236703,7 @@ transform = "{1, 0, 0, 1, 61, -611}";
 }
 );
 layerId = "95124273-C919-42A4-A4EA-C552ECFA0F71";
-name = "[16]";
+name = "[17.5]";
 width = 392;
 },
 {
@@ -239940,7 +236719,7 @@ transform = "{1, 0, 0, 1, 110, -567}";
 }
 );
 layerId = "42871BD5-D992-4818-AEA8-C3AB0C71ACC3";
-name = "[16]";
+name = "[17.5]";
 width = 479;
 }
 );
@@ -239950,7 +236729,7 @@ unicode = 201E;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:05:02 +0000";
 layers = (
 {
 components = (
@@ -240008,7 +236787,7 @@ transform = "{1, 0, 0, 1, 163, 0}";
 }
 );
 layerId = "46C09F87-6511-496A-B54D-EF77A9BFA1DD";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -240041,7 +236820,7 @@ transform = "{1, 0, 0, 1, 202, 0}";
 }
 );
 layerId = "5F1D78CD-B4AF-4D55-8BD1-0C14A8E121F4";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -240056,7 +236835,7 @@ transform = "{1, 0, 0, 1, 169, 0}";
 }
 );
 layerId = "C46AEE92-F901-4BF9-ABB1-A3FAE72851CF";
-name = "[16]";
+name = "[17.5]";
 width = 392;
 },
 {
@@ -240071,7 +236850,7 @@ transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
 layerId = "AECB67CF-71D1-411B-8B4E-A6774DC87E4E";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 }
 );
@@ -240081,7 +236860,7 @@ unicode = 201C;
 },
 {
 glyphname = quotedblright;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:05:19 +0000";
 layers = (
 {
 components = (
@@ -240139,7 +236918,7 @@ transform = "{1, 0, 0, 1, 200, 0}";
 }
 );
 layerId = "9D6FEE49-755F-48BD-9E8C-B59BD80FBAFC";
-name = "[16]";
+name = "[17.5]";
 width = 483;
 },
 {
@@ -240172,7 +236951,7 @@ transform = "{1, 0, 0, 1, 226, 0}";
 }
 );
 layerId = "2E824B51-BCEB-43C7-9CBE-7AC6E1D772C1";
-name = "[16]";
+name = "[17.5]";
 width = 554;
 },
 {
@@ -240188,7 +236967,7 @@ transform = "{1, 0, 0, 1, 199, 0}";
 }
 );
 layerId = "19EB7691-6A42-4F01-A134-8E37B6543EB7";
-name = "[16]";
+name = "[17.5]";
 width = 392;
 },
 {
@@ -240203,7 +236982,7 @@ transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
 layerId = "BC580D2A-B1B0-48A7-A3B2-44BEF6DED8E4";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 }
 );
@@ -240213,7 +236992,7 @@ unicode = 201D;
 },
 {
 glyphname = quoteleft;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:05:32 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -240263,7 +237042,7 @@ width = 292;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "4267E51F-C952-4E7A-A095-016EFE113653";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240306,7 +237085,7 @@ width = 342;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "ED9088B7-4266-4BCF-A709-77366B9B40B0";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240334,7 +237113,7 @@ width = 335;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "786ED6B1-C31F-46FF-BFDD-1A39E29E155B";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240362,7 +237141,7 @@ width = 224;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "8E825427-4710-4E45-83B3-28D6BE7D6D20";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240394,7 +237173,7 @@ unicode = 2018;
 },
 {
 glyphname = quoteright;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:05:42 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -240444,7 +237223,7 @@ width = 292;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "9F9248C5-7B36-4391-AAA6-D165325D0BD8";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240487,7 +237266,7 @@ width = 342;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "A24FA929-4747-4846-9529-658F1256D276";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240515,7 +237294,7 @@ width = 335;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "4B6D386F-C5BD-491A-833E-9A7A5086A07C";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -240543,7 +237322,7 @@ width = 228;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "02A8E116-2F7D-4548-88D2-AF089E3510D4";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -241686,7 +238465,7 @@ unicode = 0387;
 },
 {
 glyphname = questiongreek;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:05:56 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -241819,7 +238598,7 @@ width = 294;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "8260AA8F-6F23-49F5-8777-1FF5C1BA7667";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -241864,7 +238643,7 @@ width = 258;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "33A7BB1C-F8C9-42F1-886F-75D0D5F48C1E";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -241909,7 +238688,7 @@ width = 294;
 {
 associatedMasterId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
 layerId = "B5932BF1-F476-4668-A187-2621A48AF2BB";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -241954,7 +238733,7 @@ width = 246;
 {
 associatedMasterId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 layerId = "92AF5635-5097-4094-906B-D512DF342465";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -257890,7 +254669,7 @@ unicode = 00B5;
 },
 {
 glyphname = percent;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:13 +0000";
 layers = (
 {
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
@@ -257974,91 +254753,6 @@ nodes = (
 }
 );
 width = 864;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "C3FD4D45-B934-43BF-BA92-4190074294F9";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"770 692 LINE",
-"720 730 LINE",
-"120 21 LINE",
-"172 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"359 373 OFFCURVE",
-"443 461 OFFCURVE",
-"443 577 CURVE SMOOTH",
-"443 665 OFFCURVE",
-"383 724 OFFCURVE",
-"291 724 CURVE SMOOTH",
-"176 724 OFFCURVE",
-"91 641 OFFCURVE",
-"91 526 CURVE SMOOTH",
-"91 434 OFFCURVE",
-"154 373 OFFCURVE",
-"243 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"199 435 OFFCURVE",
-"159 471 OFFCURVE",
-"159 533 CURVE SMOOTH",
-"159 605 OFFCURVE",
-"212 662 OFFCURVE",
-"283 662 CURVE SMOOTH",
-"336 662 OFFCURVE",
-"374 628 OFFCURVE",
-"374 568 CURVE SMOOTH",
-"374 495 OFFCURVE",
-"321 435 OFFCURVE",
-"249 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"713 -16 OFFCURVE",
-"797 72 OFFCURVE",
-"797 188 CURVE SMOOTH",
-"797 276 OFFCURVE",
-"737 335 OFFCURVE",
-"645 335 CURVE SMOOTH",
-"530 335 OFFCURVE",
-"445 252 OFFCURVE",
-"445 137 CURVE SMOOTH",
-"445 45 OFFCURVE",
-"509 -16 OFFCURVE",
-"598 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"553 46 OFFCURVE",
-"514 82 OFFCURVE",
-"514 144 CURVE SMOOTH",
-"514 216 OFFCURVE",
-"567 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"690 273 OFFCURVE",
-"729 239 OFFCURVE",
-"729 179 CURVE SMOOTH",
-"729 106 OFFCURVE",
-"675 46 OFFCURVE",
-"603 46 CURVE SMOOTH"
-);
-}
-);
-width = 855;
 },
 {
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
@@ -258227,172 +254921,6 @@ nodes = (
 width = 827;
 },
 {
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"818 698 LINE",
-"712 712 LINE",
-"120 10 LINE",
-"226 -5 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"764 -16 OFFCURVE",
-"848 69 OFFCURVE",
-"848 183 CURVE SMOOTH",
-"848 271 OFFCURVE",
-"785 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "C6973291-F34E-4CED-AD09-A1101C10AAE7";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"764 -16 OFFCURVE",
-"848 69 OFFCURVE",
-"848 183 CURVE SMOOTH",
-"848 271 OFFCURVE",
-"785 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-}
-);
-width = 906;
-},
-{
 layerId = "E3D0AE35-FDA8-40C5-B77D-1233E980F611";
 paths = (
 {
@@ -258481,7 +255009,7 @@ unicode = 0025;
 },
 {
 glyphname = pertenthousand;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:16 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -259046,149 +255574,6 @@ nodes = (
 width = 1430;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "53F5CAC1-62DC-4365-8B03-98E4C648F940";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"770 692 LINE",
-"720 730 LINE",
-"120 21 LINE",
-"172 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"553 46 OFFCURVE",
-"513 82 OFFCURVE",
-"513 144 CURVE SMOOTH",
-"513 216 OFFCURVE",
-"566 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"690 273 OFFCURVE",
-"728 239 OFFCURVE",
-"728 179 CURVE SMOOTH",
-"728 106 OFFCURVE",
-"675 46 OFFCURVE",
-"603 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"359 373 OFFCURVE",
-"443 461 OFFCURVE",
-"443 577 CURVE SMOOTH",
-"443 665 OFFCURVE",
-"383 724 OFFCURVE",
-"291 724 CURVE SMOOTH",
-"176 724 OFFCURVE",
-"91 641 OFFCURVE",
-"91 526 CURVE SMOOTH",
-"91 434 OFFCURVE",
-"154 373 OFFCURVE",
-"243 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"199 435 OFFCURVE",
-"159 471 OFFCURVE",
-"159 533 CURVE SMOOTH",
-"159 605 OFFCURVE",
-"212 662 OFFCURVE",
-"283 662 CURVE SMOOTH",
-"336 662 OFFCURVE",
-"374 628 OFFCURVE",
-"374 568 CURVE SMOOTH",
-"374 495 OFFCURVE",
-"321 435 OFFCURVE",
-"249 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"661 -16 OFFCURVE",
-"715 13 OFFCURVE",
-"750 59 CURVE",
-"774 13 OFFCURVE",
-"821 -16 OFFCURVE",
-"880 -16 CURVE SMOOTH",
-"944 -16 OFFCURVE",
-"998 12 OFFCURVE",
-"1033 58 CURVE",
-"1057 12 OFFCURVE",
-"1104 -16 OFFCURVE",
-"1162 -16 CURVE SMOOTH",
-"1277 -16 OFFCURVE",
-"1362 72 OFFCURVE",
-"1362 188 CURVE SMOOTH",
-"1362 276 OFFCURVE",
-"1301 335 OFFCURVE",
-"1210 335 CURVE SMOOTH",
-"1147 335 OFFCURVE",
-"1091 308 OFFCURVE",
-"1057 264 CURVE",
-"1032 309 OFFCURVE",
-"987 335 OFFCURVE",
-"928 335 CURVE SMOOTH",
-"864 335 OFFCURVE",
-"808 308 OFFCURVE",
-"774 263 CURVE",
-"750 308 OFFCURVE",
-"705 335 OFFCURVE",
-"645 335 CURVE SMOOTH",
-"530 335 OFFCURVE",
-"445 252 OFFCURVE",
-"445 137 CURVE SMOOTH",
-"445 45 OFFCURVE",
-"508 -16 OFFCURVE",
-"597 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"835 46 OFFCURVE",
-"796 82 OFFCURVE",
-"796 144 CURVE SMOOTH",
-"796 216 OFFCURVE",
-"849 273 OFFCURVE",
-"920 273 CURVE SMOOTH",
-"972 273 OFFCURVE",
-"1011 239 OFFCURVE",
-"1011 179 CURVE SMOOTH",
-"1011 106 OFFCURVE",
-"958 46 OFFCURVE",
-"886 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1118 46 OFFCURVE",
-"1078 82 OFFCURVE",
-"1078 144 CURVE SMOOTH",
-"1078 216 OFFCURVE",
-"1131 273 OFFCURVE",
-"1202 273 CURVE SMOOTH",
-"1255 273 OFFCURVE",
-"1293 239 OFFCURVE",
-"1293 179 CURVE SMOOTH",
-"1293 106 OFFCURVE",
-"1240 46 OFFCURVE",
-"1168 46 CURVE SMOOTH"
-);
-}
-);
-width = 1420;
-},
-{
 background = {
 paths = (
 {
@@ -259472,157 +255857,6 @@ nodes = (
 }
 );
 width = 1434;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-components = (
-{
-name = perthousand;
-transform = "{1, 0, 0, 1, 2, 0}";
-}
-);
-};
-layerId = "B0EDCBF1-BF06-49CB-8092-50677A50D3E9";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"703 -16 OFFCURVE",
-"748 5 OFFCURVE",
-"779 40 CURVE",
-"806 7 OFFCURVE",
-"850 -16 OFFCURVE",
-"900 -16 CURVE SMOOTH",
-"955 -16 OFFCURVE",
-"1002 5 OFFCURVE",
-"1033 40 CURVE",
-"1062 6 OFFCURVE",
-"1105 -16 OFFCURVE",
-"1154 -16 CURVE SMOOTH",
-"1273 -16 OFFCURVE",
-"1357 69 OFFCURVE",
-"1357 183 CURVE SMOOTH",
-"1357 271 OFFCURVE",
-"1295 335 OFFCURVE",
-"1199 335 CURVE SMOOTH",
-"1139 335 OFFCURVE",
-"1089 310 OFFCURVE",
-"1059 280 CURVE",
-"1034 313 OFFCURVE",
-"994 335 OFFCURVE",
-"944 335 CURVE SMOOTH",
-"886 335 OFFCURVE",
-"837 310 OFFCURVE",
-"805 279 CURVE",
-"777 314 OFFCURVE",
-"739 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"875 82 OFFCURVE",
-"848 108 OFFCURVE",
-"848 149 CURVE SMOOTH",
-"848 196 OFFCURVE",
-"878 237 OFFCURVE",
-"931 237 CURVE SMOOTH",
-"968 237 OFFCURVE",
-"994 211 OFFCURVE",
-"994 171 CURVE SMOOTH",
-"994 124 OFFCURVE",
-"963 82 OFFCURVE",
-"910 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1129 82 OFFCURVE",
-"1101 108 OFFCURVE",
-"1101 149 CURVE SMOOTH",
-"1101 196 OFFCURVE",
-"1132 237 OFFCURVE",
-"1186 237 CURVE SMOOTH",
-"1222 237 OFFCURVE",
-"1248 211 OFFCURVE",
-"1248 171 CURVE SMOOTH",
-"1248 124 OFFCURVE",
-"1218 82 OFFCURVE",
-"1165 82 CURVE SMOOTH"
-);
-}
-);
-width = 1415;
 }
 );
 leftKerningGroup = percent;
@@ -259632,7 +255866,7 @@ unicode = 2031;
 },
 {
 glyphname = perthousand;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:20 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -260081,120 +256315,6 @@ nodes = (
 width = 1147;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "98F738D7-4301-4469-864D-386BB6996C98";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"769 692 LINE",
-"719 730 LINE",
-"119 21 LINE",
-"171 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"558 46 OFFCURVE",
-"518 81 OFFCURVE",
-"518 145 CURVE SMOOTH",
-"518 218 OFFCURVE",
-"572 276 OFFCURVE",
-"643 276 CURVE SMOOTH",
-"697 276 OFFCURVE",
-"736 243 OFFCURVE",
-"736 182 CURVE SMOOTH",
-"736 108 OFFCURVE",
-"682 46 OFFCURVE",
-"609 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"362 378 OFFCURVE",
-"446 467 OFFCURVE",
-"446 585 CURVE SMOOTH",
-"446 674 OFFCURVE",
-"386 732 OFFCURVE",
-"293 732 CURVE SMOOTH",
-"177 732 OFFCURVE",
-"92 649 OFFCURVE",
-"92 532 CURVE SMOOTH",
-"92 438 OFFCURVE",
-"156 378 OFFCURVE",
-"246 378 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 440 OFFCURVE",
-"160 475 OFFCURVE",
-"160 539 CURVE SMOOTH",
-"160 612 OFFCURVE",
-"214 670 OFFCURVE",
-"285 670 CURVE SMOOTH",
-"339 670 OFFCURVE",
-"378 637 OFFCURVE",
-"378 576 CURVE SMOOTH",
-"378 502 OFFCURVE",
-"324 440 OFFCURVE",
-"251 440 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"667 -16 OFFCURVE",
-"721 12 OFFCURVE",
-"756 57 CURVE",
-"781 11 OFFCURVE",
-"828 -16 OFFCURVE",
-"887 -16 CURVE SMOOTH",
-"1003 -16 OFFCURVE",
-"1087 73 OFFCURVE",
-"1087 191 CURVE SMOOTH",
-"1087 280 OFFCURVE",
-"1027 338 OFFCURVE",
-"934 338 CURVE SMOOTH",
-"870 338 OFFCURVE",
-"816 312 OFFCURVE",
-"781 268 CURVE",
-"757 312 OFFCURVE",
-"711 338 OFFCURVE",
-"651 338 CURVE SMOOTH",
-"535 338 OFFCURVE",
-"450 255 OFFCURVE",
-"450 138 CURVE SMOOTH",
-"450 44 OFFCURVE",
-"514 -16 OFFCURVE",
-"604 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"841 46 OFFCURVE",
-"801 81 OFFCURVE",
-"801 145 CURVE SMOOTH",
-"801 218 OFFCURVE",
-"855 276 OFFCURVE",
-"926 276 CURVE SMOOTH",
-"980 276 OFFCURVE",
-"1019 243 OFFCURVE",
-"1019 182 CURVE SMOOTH",
-"1019 108 OFFCURVE",
-"965 46 OFFCURVE",
-"892 46 CURVE SMOOTH"
-);
-}
-);
-width = 1145;
-},
-{
 background = {
 paths = (
 {
@@ -260415,120 +256535,6 @@ nodes = (
 }
 );
 width = 1178;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "1AF360A2-3796-497E-B921-DD02AAEBF549";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"703 -16 OFFCURVE",
-"748 5 OFFCURVE",
-"779 40 CURVE",
-"806 7 OFFCURVE",
-"850 -16 OFFCURVE",
-"900 -16 CURVE SMOOTH",
-"1019 -16 OFFCURVE",
-"1103 69 OFFCURVE",
-"1103 183 CURVE SMOOTH",
-"1103 271 OFFCURVE",
-"1040 335 OFFCURVE",
-"944 335 CURVE SMOOTH",
-"886 335 OFFCURVE",
-"837 310 OFFCURVE",
-"805 279 CURVE",
-"777 314 OFFCURVE",
-"739 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"875 82 OFFCURVE",
-"848 108 OFFCURVE",
-"848 149 CURVE SMOOTH",
-"848 196 OFFCURVE",
-"878 237 OFFCURVE",
-"931 237 CURVE SMOOTH",
-"968 237 OFFCURVE",
-"994 211 OFFCURVE",
-"994 171 CURVE SMOOTH",
-"994 124 OFFCURVE",
-"963 82 OFFCURVE",
-"910 82 CURVE SMOOTH"
-);
-}
-);
-width = 1161;
 }
 );
 leftKerningGroup = percent;
@@ -260538,7 +256544,7 @@ unicode = 2030;
 },
 {
 glyphname = percent.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:23 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -260790,172 +256796,6 @@ nodes = (
 width = 864;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"682 682 LINE",
-"629 718 LINE",
-"169 34 LINE",
-"222 -2 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 381 OFFCURVE",
-"387 454 OFFCURVE",
-"387 557 CURVE SMOOTH",
-"387 659 OFFCURVE",
-"313 732 OFFCURVE",
-"214 732 CURVE SMOOTH",
-"115 732 OFFCURVE",
-"41 659 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 454 OFFCURVE",
-"115 381 OFFCURVE",
-"214 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"153 443 OFFCURVE",
-"109 486 OFFCURVE",
-"109 557 CURVE SMOOTH",
-"109 628 OFFCURVE",
-"153 670 OFFCURVE",
-"214 670 CURVE SMOOTH",
-"275 670 OFFCURVE",
-"319 628 OFFCURVE",
-"319 557 CURVE SMOOTH",
-"319 486 OFFCURVE",
-"275 443 OFFCURVE",
-"214 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"736 -16 OFFCURVE",
-"810 57 OFFCURVE",
-"810 160 CURVE SMOOTH",
-"810 262 OFFCURVE",
-"736 335 OFFCURVE",
-"637 335 CURVE SMOOTH",
-"538 335 OFFCURVE",
-"464 262 OFFCURVE",
-"464 160 CURVE SMOOTH",
-"464 57 OFFCURVE",
-"538 -16 OFFCURVE",
-"637 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 46 OFFCURVE",
-"532 89 OFFCURVE",
-"532 160 CURVE SMOOTH",
-"532 231 OFFCURVE",
-"576 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"637 46 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "06A44434-8A60-45D1-968F-755EF2C8BDA2";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"770 692 LINE",
-"720 730 LINE",
-"120 21 LINE",
-"172 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"359 373 OFFCURVE",
-"443 461 OFFCURVE",
-"443 577 CURVE SMOOTH",
-"443 665 OFFCURVE",
-"383 724 OFFCURVE",
-"291 724 CURVE SMOOTH",
-"176 724 OFFCURVE",
-"91 641 OFFCURVE",
-"91 526 CURVE SMOOTH",
-"91 434 OFFCURVE",
-"154 373 OFFCURVE",
-"243 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"199 435 OFFCURVE",
-"159 471 OFFCURVE",
-"159 533 CURVE SMOOTH",
-"159 605 OFFCURVE",
-"212 662 OFFCURVE",
-"283 662 CURVE SMOOTH",
-"336 662 OFFCURVE",
-"374 628 OFFCURVE",
-"374 568 CURVE SMOOTH",
-"374 495 OFFCURVE",
-"321 435 OFFCURVE",
-"249 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"713 -16 OFFCURVE",
-"797 72 OFFCURVE",
-"797 188 CURVE SMOOTH",
-"797 276 OFFCURVE",
-"737 335 OFFCURVE",
-"645 335 CURVE SMOOTH",
-"530 335 OFFCURVE",
-"445 252 OFFCURVE",
-"445 137 CURVE SMOOTH",
-"445 45 OFFCURVE",
-"509 -16 OFFCURVE",
-"598 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"553 46 OFFCURVE",
-"514 82 OFFCURVE",
-"514 144 CURVE SMOOTH",
-"514 216 OFFCURVE",
-"567 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"690 273 OFFCURVE",
-"729 239 OFFCURVE",
-"729 179 CURVE SMOOTH",
-"729 106 OFFCURVE",
-"675 46 OFFCURVE",
-"603 46 CURVE SMOOTH"
-);
-}
-);
-width = 851;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -261037,179 +256877,13 @@ nodes = (
 }
 );
 width = 923;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"714 667 LINE",
-"635 720 LINE",
-"186 49 LINE",
-"264 -4 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 381 OFFCURVE",
-"400 460 OFFCURVE",
-"400 557 CURVE SMOOTH",
-"400 653 OFFCURVE",
-"331 732 OFFCURVE",
-"221 732 CURVE SMOOTH",
-"111 732 OFFCURVE",
-"41 653 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 460 OFFCURVE",
-"111 381 OFFCURVE",
-"221 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 479 OFFCURVE",
-"149 507 OFFCURVE",
-"149 557 CURVE SMOOTH",
-"149 606 OFFCURVE",
-"181 634 OFFCURVE",
-"221 634 CURVE SMOOTH",
-"261 634 OFFCURVE",
-"292 606 OFFCURVE",
-"292 557 CURVE SMOOTH",
-"292 507 OFFCURVE",
-"261 479 OFFCURVE",
-"221 479 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"789 -16 OFFCURVE",
-"858 63 OFFCURVE",
-"858 160 CURVE SMOOTH",
-"858 256 OFFCURVE",
-"789 335 OFFCURVE",
-"679 335 CURVE SMOOTH",
-"569 335 OFFCURVE",
-"499 256 OFFCURVE",
-"499 160 CURVE SMOOTH",
-"499 63 OFFCURVE",
-"569 -16 OFFCURVE",
-"679 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"639 82 OFFCURVE",
-"607 110 OFFCURVE",
-"607 160 CURVE SMOOTH",
-"607 209 OFFCURVE",
-"639 237 OFFCURVE",
-"679 237 CURVE SMOOTH",
-"719 237 OFFCURVE",
-"750 209 OFFCURVE",
-"750 160 CURVE SMOOTH",
-"750 110 OFFCURVE",
-"719 82 OFFCURVE",
-"679 82 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "F6F330B1-F1ED-4F08-B40D-8073ADEDDE29";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"764 -16 OFFCURVE",
-"848 69 OFFCURVE",
-"848 183 CURVE SMOOTH",
-"848 271 OFFCURVE",
-"785 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-}
-);
-width = 899;
 }
 );
 leftKerningGroup = percent.cap;
 },
 {
 glyphname = pertenthousand.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:26 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -261635,149 +257309,6 @@ nodes = (
 width = 1430;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "5D9B5A9E-16DF-41C2-8733-AF1DB4E1A1AA";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"770 692 LINE",
-"720 730 LINE",
-"120 21 LINE",
-"172 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"553 46 OFFCURVE",
-"513 82 OFFCURVE",
-"513 144 CURVE SMOOTH",
-"513 216 OFFCURVE",
-"566 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"690 273 OFFCURVE",
-"728 239 OFFCURVE",
-"728 179 CURVE SMOOTH",
-"728 106 OFFCURVE",
-"675 46 OFFCURVE",
-"603 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"359 373 OFFCURVE",
-"443 461 OFFCURVE",
-"443 577 CURVE SMOOTH",
-"443 665 OFFCURVE",
-"383 724 OFFCURVE",
-"291 724 CURVE SMOOTH",
-"176 724 OFFCURVE",
-"91 641 OFFCURVE",
-"91 526 CURVE SMOOTH",
-"91 434 OFFCURVE",
-"154 373 OFFCURVE",
-"243 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"199 435 OFFCURVE",
-"159 471 OFFCURVE",
-"159 533 CURVE SMOOTH",
-"159 605 OFFCURVE",
-"212 662 OFFCURVE",
-"283 662 CURVE SMOOTH",
-"336 662 OFFCURVE",
-"374 628 OFFCURVE",
-"374 568 CURVE SMOOTH",
-"374 495 OFFCURVE",
-"321 435 OFFCURVE",
-"249 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"661 -16 OFFCURVE",
-"715 13 OFFCURVE",
-"750 59 CURVE",
-"774 13 OFFCURVE",
-"821 -16 OFFCURVE",
-"880 -16 CURVE SMOOTH",
-"944 -16 OFFCURVE",
-"998 12 OFFCURVE",
-"1033 58 CURVE",
-"1057 12 OFFCURVE",
-"1104 -16 OFFCURVE",
-"1162 -16 CURVE SMOOTH",
-"1277 -16 OFFCURVE",
-"1362 72 OFFCURVE",
-"1362 188 CURVE SMOOTH",
-"1362 276 OFFCURVE",
-"1301 335 OFFCURVE",
-"1210 335 CURVE SMOOTH",
-"1147 335 OFFCURVE",
-"1091 308 OFFCURVE",
-"1057 264 CURVE",
-"1032 309 OFFCURVE",
-"987 335 OFFCURVE",
-"928 335 CURVE SMOOTH",
-"864 335 OFFCURVE",
-"808 308 OFFCURVE",
-"774 263 CURVE",
-"750 308 OFFCURVE",
-"705 335 OFFCURVE",
-"645 335 CURVE SMOOTH",
-"530 335 OFFCURVE",
-"445 252 OFFCURVE",
-"445 137 CURVE SMOOTH",
-"445 45 OFFCURVE",
-"508 -16 OFFCURVE",
-"597 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"835 46 OFFCURVE",
-"796 82 OFFCURVE",
-"796 144 CURVE SMOOTH",
-"796 216 OFFCURVE",
-"849 273 OFFCURVE",
-"920 273 CURVE SMOOTH",
-"972 273 OFFCURVE",
-"1011 239 OFFCURVE",
-"1011 179 CURVE SMOOTH",
-"1011 106 OFFCURVE",
-"958 46 OFFCURVE",
-"886 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1118 46 OFFCURVE",
-"1078 82 OFFCURVE",
-"1078 144 CURVE SMOOTH",
-"1078 216 OFFCURVE",
-"1131 273 OFFCURVE",
-"1202 273 CURVE SMOOTH",
-"1255 273 OFFCURVE",
-"1293 239 OFFCURVE",
-"1293 179 CURVE SMOOTH",
-"1293 106 OFFCURVE",
-"1240 46 OFFCURVE",
-"1168 46 CURVE SMOOTH"
-);
-}
-);
-width = 1416;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -261917,149 +257448,6 @@ nodes = (
 }
 );
 width = 1435;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "1421A787-D401-4ACB-B28F-34ADEDBCC62D";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"703 -16 OFFCURVE",
-"748 5 OFFCURVE",
-"779 40 CURVE",
-"806 7 OFFCURVE",
-"850 -16 OFFCURVE",
-"900 -16 CURVE SMOOTH",
-"955 -16 OFFCURVE",
-"1002 5 OFFCURVE",
-"1033 40 CURVE",
-"1062 6 OFFCURVE",
-"1105 -16 OFFCURVE",
-"1154 -16 CURVE SMOOTH",
-"1273 -16 OFFCURVE",
-"1357 69 OFFCURVE",
-"1357 183 CURVE SMOOTH",
-"1357 271 OFFCURVE",
-"1295 335 OFFCURVE",
-"1199 335 CURVE SMOOTH",
-"1139 335 OFFCURVE",
-"1089 310 OFFCURVE",
-"1059 280 CURVE",
-"1034 313 OFFCURVE",
-"994 335 OFFCURVE",
-"944 335 CURVE SMOOTH",
-"886 335 OFFCURVE",
-"837 310 OFFCURVE",
-"805 279 CURVE",
-"777 314 OFFCURVE",
-"739 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"875 82 OFFCURVE",
-"848 108 OFFCURVE",
-"848 149 CURVE SMOOTH",
-"848 196 OFFCURVE",
-"878 237 OFFCURVE",
-"931 237 CURVE SMOOTH",
-"968 237 OFFCURVE",
-"994 211 OFFCURVE",
-"994 171 CURVE SMOOTH",
-"994 124 OFFCURVE",
-"963 82 OFFCURVE",
-"910 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1129 82 OFFCURVE",
-"1101 108 OFFCURVE",
-"1101 149 CURVE SMOOTH",
-"1101 196 OFFCURVE",
-"1132 237 OFFCURVE",
-"1186 237 CURVE SMOOTH",
-"1222 237 OFFCURVE",
-"1248 211 OFFCURVE",
-"1248 171 CURVE SMOOTH",
-"1248 124 OFFCURVE",
-"1218 82 OFFCURVE",
-"1165 82 CURVE SMOOTH"
-);
-}
-);
-width = 1408;
 }
 );
 leftKerningGroup = percent.cap;
@@ -262068,7 +257456,7 @@ rightMetricsKey = percent.cap;
 },
 {
 glyphname = perthousand.cap;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:30 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -262407,120 +257795,6 @@ nodes = (
 width = 1147;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "D4A1FD59-C32E-4C70-8525-58A656460494";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"769 692 LINE",
-"719 730 LINE",
-"119 21 LINE",
-"171 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"558 46 OFFCURVE",
-"518 81 OFFCURVE",
-"518 145 CURVE SMOOTH",
-"518 218 OFFCURVE",
-"572 276 OFFCURVE",
-"643 276 CURVE SMOOTH",
-"697 276 OFFCURVE",
-"736 243 OFFCURVE",
-"736 182 CURVE SMOOTH",
-"736 108 OFFCURVE",
-"682 46 OFFCURVE",
-"609 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"362 378 OFFCURVE",
-"446 467 OFFCURVE",
-"446 585 CURVE SMOOTH",
-"446 674 OFFCURVE",
-"386 732 OFFCURVE",
-"293 732 CURVE SMOOTH",
-"177 732 OFFCURVE",
-"92 649 OFFCURVE",
-"92 532 CURVE SMOOTH",
-"92 438 OFFCURVE",
-"156 378 OFFCURVE",
-"246 378 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 440 OFFCURVE",
-"160 475 OFFCURVE",
-"160 539 CURVE SMOOTH",
-"160 612 OFFCURVE",
-"214 670 OFFCURVE",
-"285 670 CURVE SMOOTH",
-"339 670 OFFCURVE",
-"378 637 OFFCURVE",
-"378 576 CURVE SMOOTH",
-"378 502 OFFCURVE",
-"324 440 OFFCURVE",
-"251 440 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"667 -16 OFFCURVE",
-"721 12 OFFCURVE",
-"756 57 CURVE",
-"781 11 OFFCURVE",
-"828 -16 OFFCURVE",
-"887 -16 CURVE SMOOTH",
-"1003 -16 OFFCURVE",
-"1087 73 OFFCURVE",
-"1087 191 CURVE SMOOTH",
-"1087 280 OFFCURVE",
-"1027 338 OFFCURVE",
-"934 338 CURVE SMOOTH",
-"870 338 OFFCURVE",
-"816 312 OFFCURVE",
-"781 268 CURVE",
-"757 312 OFFCURVE",
-"711 338 OFFCURVE",
-"651 338 CURVE SMOOTH",
-"535 338 OFFCURVE",
-"450 255 OFFCURVE",
-"450 138 CURVE SMOOTH",
-"450 44 OFFCURVE",
-"514 -16 OFFCURVE",
-"604 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"841 46 OFFCURVE",
-"801 81 OFFCURVE",
-"801 145 CURVE SMOOTH",
-"801 218 OFFCURVE",
-"855 276 OFFCURVE",
-"926 276 CURVE SMOOTH",
-"980 276 OFFCURVE",
-"1019 243 OFFCURVE",
-"1019 182 CURVE SMOOTH",
-"1019 108 OFFCURVE",
-"965 46 OFFCURVE",
-"892 46 CURVE SMOOTH"
-);
-}
-);
-width = 1141;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -262631,120 +257905,6 @@ nodes = (
 }
 );
 width = 1179;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "776BC227-27F0-45D1-A3BC-CCB6231794B5";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"800 676 LINE",
-"729 732 LINE",
-"143 37 LINE",
-"217 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"619 82 OFFCURVE",
-"592 108 OFFCURVE",
-"592 149 CURVE SMOOTH",
-"592 196 OFFCURVE",
-"623 237 OFFCURVE",
-"676 237 CURVE SMOOTH",
-"713 237 OFFCURVE",
-"739 211 OFFCURVE",
-"739 171 CURVE SMOOTH",
-"739 124 OFFCURVE",
-"709 82 OFFCURVE",
-"655 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"371 373 OFFCURVE",
-"455 458 OFFCURVE",
-"455 572 CURVE SMOOTH",
-"455 660 OFFCURVE",
-"392 724 OFFCURVE",
-"297 724 CURVE SMOOTH",
-"166 724 OFFCURVE",
-"90 636 OFFCURVE",
-"90 528 CURVE SMOOTH",
-"90 441 OFFCURVE",
-"157 373 OFFCURVE",
-"252 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 471 OFFCURVE",
-"199 497 OFFCURVE",
-"199 538 CURVE SMOOTH",
-"199 585 OFFCURVE",
-"230 626 OFFCURVE",
-"283 626 CURVE SMOOTH",
-"320 626 OFFCURVE",
-"346 600 OFFCURVE",
-"346 560 CURVE SMOOTH",
-"346 513 OFFCURVE",
-"316 471 OFFCURVE",
-"262 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"703 -16 OFFCURVE",
-"748 5 OFFCURVE",
-"779 40 CURVE",
-"806 7 OFFCURVE",
-"850 -16 OFFCURVE",
-"900 -16 CURVE SMOOTH",
-"1019 -16 OFFCURVE",
-"1103 69 OFFCURVE",
-"1103 183 CURVE SMOOTH",
-"1103 271 OFFCURVE",
-"1040 335 OFFCURVE",
-"944 335 CURVE SMOOTH",
-"886 335 OFFCURVE",
-"837 310 OFFCURVE",
-"805 279 CURVE",
-"777 314 OFFCURVE",
-"739 335 OFFCURVE",
-"690 335 CURVE SMOOTH",
-"559 335 OFFCURVE",
-"483 247 OFFCURVE",
-"483 139 CURVE SMOOTH",
-"483 52 OFFCURVE",
-"550 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"875 82 OFFCURVE",
-"848 108 OFFCURVE",
-"848 149 CURVE SMOOTH",
-"848 196 OFFCURVE",
-"878 237 OFFCURVE",
-"931 237 CURVE SMOOTH",
-"968 237 OFFCURVE",
-"994 211 OFFCURVE",
-"994 171 CURVE SMOOTH",
-"994 124 OFFCURVE",
-"963 82 OFFCURVE",
-"910 82 CURVE SMOOTH"
-);
-}
-);
-width = 1154;
 }
 );
 leftKerningGroup = percent.cap;
@@ -263392,7 +258552,7 @@ widthMetricsKey = "=600";
 {
 color = 4;
 glyphname = percent.tf;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:37 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -263644,172 +258804,6 @@ nodes = (
 width = 600;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"669 700 LINE",
-"598 710 LINE",
-"15 8 LINE",
-"87 -2 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"304 443 OFFCURVE",
-"367 510 OFFCURVE",
-"367 599 CURVE SMOOTH",
-"367 674 OFFCURVE",
-"316 724 OFFCURVE",
-"243 724 CURVE SMOOTH",
-"144 724 OFFCURVE",
-"81 659 OFFCURVE",
-"81 569 CURVE SMOOTH",
-"81 491 OFFCURVE",
-"140 443 OFFCURVE",
-"207 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"540 -16 OFFCURVE",
-"602 51 OFFCURVE",
-"602 140 CURVE SMOOTH",
-"602 215 OFFCURVE",
-"551 265 OFFCURVE",
-"478 265 CURVE SMOOTH",
-"379 265 OFFCURVE",
-"316 200 OFFCURVE",
-"316 110 CURVE SMOOTH",
-"316 32 OFFCURVE",
-"375 -16 OFFCURVE",
-"442 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"410 43 OFFCURVE",
-"380 71 OFFCURVE",
-"380 117 CURVE SMOOTH",
-"380 171 OFFCURVE",
-"419 206 OFFCURVE",
-"470 206 CURVE SMOOTH",
-"510 206 OFFCURVE",
-"538 179 OFFCURVE",
-"538 135 CURVE SMOOTH",
-"538 84 OFFCURVE",
-"504 43 OFFCURVE",
-"450 43 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"175 502 OFFCURVE",
-"145 530 OFFCURVE",
-"145 576 CURVE SMOOTH",
-"145 630 OFFCURVE",
-"184 665 OFFCURVE",
-"235 665 CURVE SMOOTH",
-"274 665 OFFCURVE",
-"303 638 OFFCURVE",
-"303 594 CURVE SMOOTH",
-"303 543 OFFCURVE",
-"269 502 OFFCURVE",
-"214 502 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "9E50384D-20CF-4723-AE02-D192F71B1A68";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"638 693 LINE",
-"589 729 LINE",
-"0 20 LINE",
-"51 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"287 443 OFFCURVE",
-"350 510 OFFCURVE",
-"350 599 CURVE SMOOTH",
-"350 674 OFFCURVE",
-"299 724 OFFCURVE",
-"226 724 CURVE SMOOTH",
-"127 724 OFFCURVE",
-"64 659 OFFCURVE",
-"64 569 CURVE SMOOTH",
-"64 491 OFFCURVE",
-"123 443 OFFCURVE",
-"190 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"507 -16 OFFCURVE",
-"569 51 OFFCURVE",
-"569 140 CURVE SMOOTH",
-"569 215 OFFCURVE",
-"518 265 OFFCURVE",
-"445 265 CURVE SMOOTH",
-"346 265 OFFCURVE",
-"283 200 OFFCURVE",
-"283 110 CURVE SMOOTH",
-"283 32 OFFCURVE",
-"342 -16 OFFCURVE",
-"409 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"377 43 OFFCURVE",
-"347 71 OFFCURVE",
-"347 117 CURVE SMOOTH",
-"347 171 OFFCURVE",
-"386 206 OFFCURVE",
-"437 206 CURVE SMOOTH",
-"477 206 OFFCURVE",
-"505 179 OFFCURVE",
-"505 135 CURVE SMOOTH",
-"505 84 OFFCURVE",
-"471 43 OFFCURVE",
-"417 43 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"158 502 OFFCURVE",
-"128 530 OFFCURVE",
-"128 576 CURVE SMOOTH",
-"128 630 OFFCURVE",
-"167 665 OFFCURVE",
-"218 665 CURVE SMOOTH",
-"257 665 OFFCURVE",
-"286 638 OFFCURVE",
-"286 594 CURVE SMOOTH",
-"286 543 OFFCURVE",
-"252 502 OFFCURVE",
-"197 502 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 paths = (
 {
@@ -263887,172 +258881,6 @@ nodes = (
 "270 557 OFFCURVE",
 "242 529 OFFCURVE",
 "199 529 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"641 678 LINE",
-"569 732 LINE",
-"-10 28 LINE",
-"69 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"289 441 OFFCURVE",
-"355 509 OFFCURVE",
-"355 601 CURVE SMOOTH",
-"355 671 OFFCURVE",
-"303 724 OFFCURVE",
-"228 724 CURVE SMOOTH",
-"125 724 OFFCURVE",
-"59 657 OFFCURVE",
-"59 566 CURVE SMOOTH",
-"59 495 OFFCURVE",
-"115 441 OFFCURVE",
-"189 441 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"509 -16 OFFCURVE",
-"574 52 OFFCURVE",
-"574 143 CURVE SMOOTH",
-"574 214 OFFCURVE",
-"523 267 OFFCURVE",
-"447 267 CURVE SMOOTH",
-"345 267 OFFCURVE",
-"279 199 OFFCURVE",
-"279 108 CURVE SMOOTH",
-"279 38 OFFCURVE",
-"334 -16 OFFCURVE",
-"408 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"389 66 OFFCURVE",
-"367 88 OFFCURVE",
-"367 117 CURVE SMOOTH",
-"367 159 OFFCURVE",
-"396 184 OFFCURVE",
-"433 184 CURVE SMOOTH",
-"464 184 OFFCURVE",
-"487 165 OFFCURVE",
-"487 133 CURVE SMOOTH",
-"487 94 OFFCURVE",
-"459 66 OFFCURVE",
-"418 66 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 523 OFFCURVE",
-"147 545 OFFCURVE",
-"147 575 CURVE SMOOTH",
-"147 616 OFFCURVE",
-"176 641 OFFCURVE",
-"214 641 CURVE SMOOTH",
-"245 641 OFFCURVE",
-"268 622 OFFCURVE",
-"268 590 CURVE SMOOTH",
-"268 551 OFFCURVE",
-"240 523 OFFCURVE",
-"199 523 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "28A613DE-412F-4E34-8770-ED82FA6F58F3";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"637 674 LINE",
-"569 732 LINE",
-"-2 38 LINE",
-"69 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"289 441 OFFCURVE",
-"355 509 OFFCURVE",
-"355 601 CURVE SMOOTH",
-"355 671 OFFCURVE",
-"303 724 OFFCURVE",
-"228 724 CURVE SMOOTH",
-"125 724 OFFCURVE",
-"59 657 OFFCURVE",
-"59 566 CURVE SMOOTH",
-"59 495 OFFCURVE",
-"115 441 OFFCURVE",
-"189 441 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"509 -16 OFFCURVE",
-"574 52 OFFCURVE",
-"574 143 CURVE SMOOTH",
-"574 214 OFFCURVE",
-"523 267 OFFCURVE",
-"447 267 CURVE SMOOTH",
-"345 267 OFFCURVE",
-"279 199 OFFCURVE",
-"279 108 CURVE SMOOTH",
-"279 38 OFFCURVE",
-"334 -16 OFFCURVE",
-"408 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"389 66 OFFCURVE",
-"367 88 OFFCURVE",
-"367 117 CURVE SMOOTH",
-"367 159 OFFCURVE",
-"396 184 OFFCURVE",
-"433 184 CURVE SMOOTH",
-"464 184 OFFCURVE",
-"487 165 OFFCURVE",
-"487 133 CURVE SMOOTH",
-"487 94 OFFCURVE",
-"459 66 OFFCURVE",
-"418 66 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 523 OFFCURVE",
-"147 545 OFFCURVE",
-"147 575 CURVE SMOOTH",
-"147 616 OFFCURVE",
-"176 641 OFFCURVE",
-"214 641 CURVE SMOOTH",
-"245 641 OFFCURVE",
-"268 622 OFFCURVE",
-"268 590 CURVE SMOOTH",
-"268 551 OFFCURVE",
-"240 523 OFFCURVE",
-"199 523 CURVE SMOOTH"
 );
 }
 );
@@ -267176,7 +262004,7 @@ unicode = 0040;
 },
 {
 glyphname = ampersand;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:06:46 +0000";
 layers = (
 {
 layerId = "8B58F8C3-CBF6-4C04-9FA1-F7EA6C699325";
@@ -267427,128 +262255,6 @@ nodes = (
 width = 688;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"344 -16 OFFCURVE",
-"406 12 OFFCURVE",
-"459 61 CURVE",
-"502 -4 LINE",
-"597 6 LINE",
-"516 125 LINE",
-"652 310 LINE",
-"569 320 LINE",
-"473 189 LINE",
-"305 441 LINE SMOOTH",
-"277 483 OFFCURVE",
-"267 513 OFFCURVE",
-"267 548 CURVE SMOOTH",
-"267 611 OFFCURVE",
-"310 651 OFFCURVE",
-"371 651 CURVE SMOOTH",
-"429 651 OFFCURVE",
-"461 616 OFFCURVE",
-"470 564 CURVE",
-"553 582 LINE",
-"541 671 OFFCURVE",
-"481 732 OFFCURVE",
-"384 732 CURVE SMOOTH",
-"263 732 OFFCURVE",
-"181 653 OFFCURVE",
-"181 542 CURVE SMOOTH",
-"181 508 OFFCURVE",
-"191 471 OFFCURVE",
-"211 434 CURVE",
-"104 384 OFFCURVE",
-"42 299 OFFCURVE",
-"42 187 CURVE SMOOTH",
-"42 70 OFFCURVE",
-"131 -16 OFFCURVE",
-"249 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 61 OFFCURVE",
-"126 124 OFFCURVE",
-"126 198 CURVE SMOOTH",
-"126 281 OFFCURVE",
-"177 337 OFFCURVE",
-"250 372 CURVE",
-"418 122 LINE",
-"376 82 OFFCURVE",
-"329 61 OFFCURVE",
-"267 61 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "526A3F0A-9175-4267-B025-7EA608B604BA";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"344 -16 OFFCURVE",
-"406 12 OFFCURVE",
-"459 61 CURVE",
-"509 -15 LINE",
-"582 29 LINE",
-"516 125 LINE",
-"633 285 LINE",
-"576 329 LINE",
-"473 189 LINE",
-"305 441 LINE SMOOTH",
-"277 483 OFFCURVE",
-"267 513 OFFCURVE",
-"267 548 CURVE SMOOTH",
-"267 611 OFFCURVE",
-"310 651 OFFCURVE",
-"371 651 CURVE SMOOTH",
-"429 651 OFFCURVE",
-"461 616 OFFCURVE",
-"470 564 CURVE",
-"553 582 LINE",
-"541 671 OFFCURVE",
-"481 732 OFFCURVE",
-"384 732 CURVE SMOOTH",
-"263 732 OFFCURVE",
-"181 653 OFFCURVE",
-"181 542 CURVE SMOOTH",
-"181 508 OFFCURVE",
-"191 471 OFFCURVE",
-"211 434 CURVE",
-"104 384 OFFCURVE",
-"42 299 OFFCURVE",
-"42 187 CURVE SMOOTH",
-"42 70 OFFCURVE",
-"131 -16 OFFCURVE",
-"249 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 61 OFFCURVE",
-"126 124 OFFCURVE",
-"126 198 CURVE SMOOTH",
-"126 281 OFFCURVE",
-"177 337 OFFCURVE",
-"250 372 CURVE",
-"418 122 LINE",
-"376 82 OFFCURVE",
-"329 61 OFFCURVE",
-"267 61 CURVE SMOOTH"
-);
-}
-);
-width = 673;
-},
-{
 background = {
 paths = (
 {
@@ -267673,128 +262379,6 @@ nodes = (
 }
 );
 width = 738;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"351 -16 OFFCURVE",
-"412 4 OFFCURVE",
-"462 46 CURVE",
-"495 -4 LINE",
-"638 12 LINE",
-"550 143 LINE",
-"686 317 LINE",
-"566 333 LINE",
-"489 231 LINE",
-"332 466 LINE SMOOTH",
-"312 495 OFFCURVE",
-"301 518 OFFCURVE",
-"301 544 CURVE SMOOTH",
-"301 588 OFFCURVE",
-"331 617 OFFCURVE",
-"377 617 CURVE SMOOTH",
-"419 617 OFFCURVE",
-"446 591 OFFCURVE",
-"451 548 CURVE",
-"575 575 LINE",
-"563 670 OFFCURVE",
-"498 732 OFFCURVE",
-"392 732 CURVE SMOOTH",
-"255 732 OFFCURVE",
-"175 645 OFFCURVE",
-"175 532 CURVE SMOOTH",
-"175 501 OFFCURVE",
-"184 470 OFFCURVE",
-"198 441 CURVE",
-"99 387 OFFCURVE",
-"38 310 OFFCURVE",
-"38 200 CURVE SMOOTH",
-"38 69 OFFCURVE",
-"138 -16 OFFCURVE",
-"267 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"218 102 OFFCURVE",
-"168 148 OFFCURVE",
-"168 214 CURVE SMOOTH",
-"168 277 OFFCURVE",
-"203 322 OFFCURVE",
-"253 352 CURVE",
-"399 138 LINE",
-"367 114 OFFCURVE",
-"330 102 OFFCURVE",
-"286 102 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "435921A9-A3C8-4BAD-AD0D-AD6DE031480B";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"351 -16 OFFCURVE",
-"412 4 OFFCURVE",
-"462 46 CURVE",
-"503 -16 LINE",
-"615 46 LINE",
-"550 143 LINE",
-"670 296 LINE",
-"587 360 LINE",
-"489 231 LINE",
-"332 466 LINE SMOOTH",
-"312 495 OFFCURVE",
-"301 518 OFFCURVE",
-"301 544 CURVE SMOOTH",
-"301 588 OFFCURVE",
-"331 617 OFFCURVE",
-"377 617 CURVE SMOOTH",
-"419 617 OFFCURVE",
-"446 591 OFFCURVE",
-"451 548 CURVE",
-"575 575 LINE",
-"563 670 OFFCURVE",
-"498 732 OFFCURVE",
-"392 732 CURVE SMOOTH",
-"255 732 OFFCURVE",
-"175 645 OFFCURVE",
-"175 532 CURVE SMOOTH",
-"175 501 OFFCURVE",
-"184 470 OFFCURVE",
-"198 441 CURVE",
-"99 387 OFFCURVE",
-"38 310 OFFCURVE",
-"38 200 CURVE SMOOTH",
-"38 69 OFFCURVE",
-"138 -16 OFFCURVE",
-"267 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"218 102 OFFCURVE",
-"168 148 OFFCURVE",
-"168 214 CURVE SMOOTH",
-"168 277 OFFCURVE",
-"203 322 OFFCURVE",
-"253 352 CURVE",
-"399 138 LINE",
-"367 114 OFFCURVE",
-"330 102 OFFCURVE",
-"286 102 CURVE SMOOTH"
-);
-}
-);
-width = 719;
 }
 );
 unicode = 0026;
@@ -278586,7 +273170,7 @@ unicode = 0309;
 },
 {
 glyphname = commaturnedabovecomb;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:07:07 +0000";
 layers = (
 {
 anchors = (
@@ -278690,7 +273274,7 @@ transform = "{-1, 0, 0, -1, 407, 560}";
 }
 );
 layerId = "8B8F5D87-663B-45A6-B19A-2C49D1C82541";
-name = "[16]";
+name = "[17.5]";
 width = 402;
 },
 {
@@ -278713,7 +273297,7 @@ transform = "{-1, 0, 0, -1, 432, 560}";
 }
 );
 layerId = "7370BF60-4257-4924-9183-7FCE8DBA8D48";
-name = "[16]";
+name = "[17.5]";
 width = 427;
 },
 {
@@ -278735,7 +273319,7 @@ transform = "{-1, 0, 0, -1, 415, 544}";
 }
 );
 layerId = "9C1D1125-DD0E-4E11-8A9B-782453B79895";
-name = "[16]";
+name = "[17.5]";
 width = 412;
 },
 {
@@ -278757,7 +273341,7 @@ transform = "{-1, 0, 0, -1, 432, 544}";
 }
 );
 layerId = "02E9F280-C55B-445E-BDDD-4523FB04BA9E";
-name = "[16]";
+name = "[17.5]";
 width = 437;
 }
 );
@@ -279256,7 +273840,7 @@ unicode = 0324;
 },
 {
 glyphname = commaaccentcomb;
-lastChange = "2020-01-22 16:45:12 +0000";
+lastChange = "2020-06-17 17:07:19 +0000";
 layers = (
 {
 anchors = (
@@ -279394,7 +273978,7 @@ nodes = (
 );
 };
 layerId = "4CF76804-A900-449B-892C-C04450268283";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -279481,7 +274065,7 @@ nodes = (
 );
 };
 layerId = "8C985AE6-7CE9-4C39-8E1C-1E00A8C8C822";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -279543,7 +274127,7 @@ nodes = (
 );
 };
 layerId = "22870BBE-4DFD-4B67-928A-51261FF147C9";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -279605,7 +274189,7 @@ nodes = (
 );
 };
 layerId = "2A3706AC-9B8B-4BE9-BA88-DBE84FB396B4";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -295936,7 +290520,7 @@ value = "3 3 1 1033; Google;GoogleSansText-Italic";
 }
 );
 interpolationCustom = 300;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 380;
 instanceInterpolations = {
 "15F39A2A-7598-44C5-A4AA-18A6AD645EAA" = 1;
@@ -295980,7 +290564,7 @@ value = "3 3 1 1033; Google;GoogleSansText-MediumItalic";
 }
 );
 interpolationCustom = 400;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 555;
 instanceInterpolations = {
 "15F39A2A-7598-44C5-A4AA-18A6AD645EAA" = 0.50565;
@@ -296026,7 +290610,7 @@ value = "3 3 1 1033; Google;GoogleSansText-BoldItalic";
 }
 );
 interpolationCustom = 300;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 734;
 instanceInterpolations = {
 "3E1A77A5-2AAF-4B97-842E-5802590C9619" = 1;

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1286";
+.appVersion = "1237";
 classes = (
 {
 code = "zero one two three four five six seven eight nine";
@@ -3220,7 +3220,7 @@ position = "{342, 413}";
 }
 );
 id = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-weightValue = 14;
+weightValue = 17;
 widthValue = 380;
 xHeight = 526;
 },
@@ -3319,7 +3319,7 @@ verticalStems = (
 95
 );
 weight = Bold;
-weightValue = 14;
+weightValue = 17;
 widthValue = 734;
 xHeight = 526;
 },
@@ -9107,7 +9107,7 @@ unicode = 0046;
 },
 {
 glyphname = G;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:28:54 +0000";
 layers = (
 {
 anchors = (
@@ -9228,7 +9228,7 @@ position = "{416, 716}";
 );
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "2FD1A428-4CF8-4BC0-8AB8-1101D6E28FA3";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9288,7 +9288,7 @@ position = "{424, 716}";
 );
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "A9F187CB-F4D3-4981-893C-55162F2917D2";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9454,7 +9454,7 @@ position = "{396, 716}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "74FE3073-A826-4535-BD9A-C3E6EA98D527";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9514,7 +9514,7 @@ position = "{413, 716}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "35E1988C-C116-455C-B420-C2867828E629";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -9577,7 +9577,7 @@ com.typemytype.robofont.mark = (
 },
 {
 glyphname = Gbreve;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:29:12 +0000";
 layers = (
 {
 components = (
@@ -9643,7 +9643,7 @@ transform = "{1, 0, 0, 1, 194, 0}";
 }
 );
 layerId = "A4FFAF04-34E5-4E14-9EAE-F27D94E9EDB3";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -9658,7 +9658,7 @@ transform = "{1, 0, 0, 1, 203, 0}";
 }
 );
 layerId = "DF67A93E-DC99-4953-9DBC-700C3BEE03AE";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -9673,7 +9673,7 @@ transform = "{1, 0, 0, 1, 216, 0}";
 }
 );
 layerId = "A9B31174-663B-4D93-B77D-771C64F67AA9";
-name = "[16]";
+name = "[17.5]";
 width = 789;
 },
 {
@@ -9688,7 +9688,7 @@ transform = "{1, 0, 0, 1, 216, 0}";
 }
 );
 layerId = "070EDEEE-BAB8-4823-A56E-76E6D23CDACB";
-name = "[16]";
+name = "[17.5]";
 width = 806;
 }
 );
@@ -9698,7 +9698,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:29:17 +0000";
 layers = (
 {
 components = (
@@ -9764,7 +9764,7 @@ transform = "{1, 0, 0, 1, 199, 0}";
 }
 );
 layerId = "46660EB8-5FB8-40CC-8835-7A4B1B6E7CF9";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -9779,7 +9779,7 @@ transform = "{1, 0, 0, 1, 185, 0}";
 }
 );
 layerId = "594D41E0-366E-4B01-919C-684805400D2A";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -9794,7 +9794,7 @@ transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
 layerId = "7827C6D5-BBFB-4495-B942-32C414053045";
-name = "[16]";
+name = "[17.5]";
 width = 789;
 },
 {
@@ -9809,7 +9809,7 @@ transform = "{1, 0, 0, 1, 196, 0}";
 }
 );
 layerId = "D9249777-D317-475C-9E46-C2581F835203";
-name = "[16]";
+name = "[17.5]";
 width = 806;
 }
 );
@@ -9819,7 +9819,7 @@ unicode = 011C;
 },
 {
 glyphname = Gcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:29:24 +0000";
 layers = (
 {
 components = (
@@ -9885,7 +9885,7 @@ transform = "{1, 0, 0, 1, 196, 0}";
 }
 );
 layerId = "5D484CAA-CF64-4B12-B8F0-F88AA36013D2";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -9900,7 +9900,7 @@ transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
 layerId = "E05E5600-A375-4AE9-9ABB-725BCF9886CA";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -9915,7 +9915,7 @@ transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
 layerId = "FAB5E53B-877B-4F58-BC31-961F90CCE062";
-name = "[16]";
+name = "[17.5]";
 width = 789;
 },
 {
@@ -9930,7 +9930,7 @@ transform = "{1, 0, 0, 1, 202, 0}";
 }
 );
 layerId = "921A38FF-6906-4114-B8AC-E10CE5D6965F";
-name = "[16]";
+name = "[17.5]";
 width = 806;
 }
 );
@@ -9940,7 +9940,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:29:29 +0000";
 layers = (
 {
 components = (
@@ -10006,7 +10006,7 @@ transform = "{1, 0, 0, 1, 282, 0}";
 }
 );
 layerId = "1EBB1471-2473-40C0-84E4-711C13691362";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -10021,7 +10021,7 @@ transform = "{1, 0, 0, 1, 273, 0}";
 }
 );
 layerId = "A26F1CB6-6F2B-4A4B-95B5-F55AF41BED26";
-name = "[16]";
+name = "[17.5]";
 width = 794;
 },
 {
@@ -10036,7 +10036,7 @@ transform = "{1, 0, 0, 1, 302, 0}";
 }
 );
 layerId = "BE6464F2-CBBA-4252-A982-89B16C5AB039";
-name = "[16]";
+name = "[17.5]";
 width = 789;
 },
 {
@@ -10051,7 +10051,7 @@ transform = "{1, 0, 0, 1, 289, 0}";
 }
 );
 layerId = "4A552C36-CA41-4B67-A76C-0CDFBF030E0A";
-name = "[16]";
+name = "[17.5]";
 width = 806;
 }
 );
@@ -12134,7 +12134,7 @@ unicode = 004B;
 },
 {
 glyphname = Kcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:31:07 +0000";
 layers = (
 {
 components = (
@@ -12200,7 +12200,7 @@ transform = "{1, 0, 0, 1, 115, 0}";
 }
 );
 layerId = "0F2C49E7-7A11-4A5E-B0DE-327A283772CA";
-name = "[16]";
+name = "[17.5]";
 width = 614;
 },
 {
@@ -12215,7 +12215,7 @@ transform = "{1, 0, 0, 1, 139, 0}";
 }
 );
 layerId = "F703593C-B55C-4D85-AF78-6794AC0C76CC";
-name = "[16]";
+name = "[17.5]";
 width = 675;
 },
 {
@@ -12230,7 +12230,7 @@ transform = "{1, 0, 0, 1, 115, 0}";
 }
 );
 layerId = "78337D6E-D1A5-4422-AEC8-9F96FFBDA288";
-name = "[16]";
+name = "[17.5]";
 width = 626;
 },
 {
@@ -12245,7 +12245,7 @@ transform = "{1, 0, 0, 1, 136, 0}";
 }
 );
 layerId = "DADD9698-0553-4DE7-8984-EDF7F40DCDCA";
-name = "[16]";
+name = "[17.5]";
 width = 690;
 }
 );
@@ -12522,7 +12522,7 @@ unicode = 013D;
 },
 {
 glyphname = Lcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:31:22 +0000";
 layers = (
 {
 components = (
@@ -12588,7 +12588,7 @@ transform = "{1, 0, 0, 1, 98, 0}";
 }
 );
 layerId = "ECFE9D91-FAFC-4865-8A62-AA0D46D5B910";
-name = "[16]";
+name = "[17.5]";
 width = 556;
 },
 {
@@ -12603,7 +12603,7 @@ transform = "{1, 0, 0, 1, 107, 0}";
 }
 );
 layerId = "EDE5DAEF-0F5D-4790-A19D-5FA5F3CCFAD0";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -12618,7 +12618,7 @@ transform = "{1, 0, 0, 1, 81, 0}";
 }
 );
 layerId = "96CBC922-F939-40A4-8EC4-63788AD26606";
-name = "[16]";
+name = "[17.5]";
 width = 509;
 },
 {
@@ -12633,7 +12633,7 @@ transform = "{1, 0, 0, 1, 90, 0}";
 }
 );
 layerId = "045325C2-0E4C-4EC8-8AD7-F6DB7ECBA89B";
-name = "[16]";
+name = "[17.5]";
 width = 551;
 }
 );
@@ -13372,7 +13372,7 @@ unicode = 0147;
 },
 {
 glyphname = Ncommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:31:45 +0000";
 layers = (
 {
 components = (
@@ -13438,7 +13438,7 @@ transform = "{1, 0, 0, 1, 154, 0}";
 }
 );
 layerId = "763509E2-8E41-4B2E-9398-D51F4341717E";
-name = "[16]";
+name = "[17.5]";
 width = 703;
 },
 {
@@ -13453,7 +13453,7 @@ transform = "{1, 0, 0, 1, 162, 0}";
 }
 );
 layerId = "E595EE46-66C5-4928-90FA-F655AB5865D9";
-name = "[16]";
+name = "[17.5]";
 width = 748;
 },
 {
@@ -13468,7 +13468,7 @@ transform = "{1, 0, 0, 1, 156, 0}";
 }
 );
 layerId = "1654EF42-BBCF-4886-95DA-8C33CD1818E5";
-name = "[16]";
+name = "[17.5]";
 width = 708;
 },
 {
@@ -13483,7 +13483,7 @@ transform = "{1, 0, 0, 1, 160, 0}";
 }
 );
 layerId = "20D8D086-1193-4A3D-809E-E3EF33B323C0";
-name = "[16]";
+name = "[17.5]";
 width = 743;
 }
 );
@@ -17328,7 +17328,7 @@ unicode = 0158;
 },
 {
 glyphname = Rcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:31:57 +0000";
 layers = (
 {
 components = (
@@ -17394,7 +17394,7 @@ transform = "{1, 0, 0, 1, 115, 0}";
 }
 );
 layerId = "D27B3E86-88A9-4098-8B92-4FA0E212708B";
-name = "[16]";
+name = "[17.5]";
 width = 599;
 },
 {
@@ -17409,7 +17409,7 @@ transform = "{1, 0, 0, 1, 136, 0}";
 }
 );
 layerId = "33D27369-24EE-438B-8B31-60092B787169";
-name = "[16]";
+name = "[17.5]";
 width = 665;
 },
 {
@@ -17424,7 +17424,7 @@ transform = "{1, 0, 0, 1, 95, 0}";
 }
 );
 layerId = "58ECC9BC-885B-41BA-A2D8-AEB59CBFE658";
-name = "[16]";
+name = "[17.5]";
 width = 586;
 },
 {
@@ -17439,7 +17439,7 @@ transform = "{1, 0, 0, 1, 106, 0}";
 }
 );
 layerId = "8E9AEFB5-1832-4058-8374-70A00EF13372";
-name = "[16]";
+name = "[17.5]";
 width = 634;
 }
 );
@@ -18002,7 +18002,7 @@ unicode = 015C;
 },
 {
 glyphname = Scommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:32:17 +0000";
 layers = (
 {
 components = (
@@ -18068,7 +18068,7 @@ transform = "{1, 0, 0, 1, 103, 0}";
 }
 );
 layerId = "65F1C23A-6CB0-45F1-9CD2-8B0AE62E2295";
-name = "[16]";
+name = "[17.5]";
 width = 601;
 },
 {
@@ -18083,7 +18083,7 @@ transform = "{1, 0, 0, 1, 109, 0}";
 }
 );
 layerId = "41CE6561-F735-4A93-B886-D196FC787125";
-name = "[16]";
+name = "[17.5]";
 width = 631;
 },
 {
@@ -18098,7 +18098,7 @@ transform = "{1, 0, 0, 1, 84, 0}";
 }
 );
 layerId = "3BF6AFA0-88D7-4F4E-86C5-D934C608A43B";
-name = "[16]";
+name = "[17.5]";
 width = 562;
 },
 {
@@ -18113,7 +18113,7 @@ transform = "{1, 0, 0, 1, 84, 0}";
 }
 );
 layerId = "F3F62DCA-87A8-4190-BC90-3DF36D79AA61";
-name = "[16]";
+name = "[17.5]";
 width = 589;
 }
 );
@@ -18745,34 +18745,8 @@ unicode = 0162;
 },
 {
 glyphname = Tcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:32:27 +0000";
 layers = (
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 62, 0}";
-}
-);
-layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
-width = 538;
-},
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 60, 0}";
-}
-);
-layerId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
-width = 587;
-},
 {
 components = (
 {
@@ -18784,6 +18758,21 @@ transform = "{1, 0, 0, 1, 79, 0}";
 }
 );
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
+width = 572;
+},
+{
+associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 88, 0}";
+}
+);
+layerId = "5331986A-CB79-41B7-8C31-AE710B36BCB8";
+name = "[17.5]";
 width = 572;
 },
 {
@@ -18800,19 +18789,17 @@ layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 width = 630;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 components = (
 {
 name = T;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 88, 0}";
+transform = "{1, 0, 0, 1, 62, 0}";
 }
 );
-layerId = "5331986A-CB79-41B7-8C31-AE710B36BCB8";
-name = "[16]";
-width = 572;
+layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
+width = 538;
 },
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
@@ -18826,7 +18813,7 @@ transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
 layerId = "F5C57C13-4142-4601-8F2A-BC89C186AC21";
-name = "[16]";
+name = "[17.5]";
 width = 630;
 },
 {
@@ -18841,8 +18828,21 @@ transform = "{1, 0, 0, 1, 71, 0}";
 }
 );
 layerId = "633AF194-AB18-4B5E-93CE-F2007B6F5DE4";
-name = "[16]";
+name = "[17.5]";
 width = 538;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 60, 0}";
+}
+);
+layerId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
+width = 587;
 },
 {
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
@@ -18856,7 +18856,7 @@ transform = "{1, 0, 0, 1, 82, 0}";
 }
 );
 layerId = "E6C499FA-9F40-4F32-9BA1-2D0F935D3905";
-name = "[16]";
+name = "[17.5]";
 width = 587;
 }
 );
@@ -22710,7 +22710,7 @@ rightKerningGroup = G.alt;
 },
 {
 glyphname = Gcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:32:41 +0000";
 layers = (
 {
 components = (
@@ -22776,7 +22776,7 @@ transform = "{1, 0, 0, 1, 172, 0}";
 }
 );
 layerId = "F0B70F9A-A7F4-4598-A444-7F3F375F596D";
-name = "[16]";
+name = "[17.5]";
 width = 736;
 },
 {
@@ -22791,7 +22791,7 @@ transform = "{1, 0, 0, 1, 179, 0}";
 }
 );
 layerId = "02017384-4945-4D92-8C10-F0927A2A5C82";
-name = "[16]";
+name = "[17.5]";
 width = 782;
 },
 {
@@ -22806,7 +22806,7 @@ transform = "{1, 0, 0, 1, 208, 0}";
 }
 );
 layerId = "038AAE88-BFED-4323-96A5-5C065F52F22B";
-name = "[16]";
+name = "[17.5]";
 width = 812;
 },
 {
@@ -22821,7 +22821,7 @@ transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
 layerId = "F6841AB9-EF50-45E7-AF65-D6C666D2A54E";
-name = "[16]";
+name = "[17.5]";
 width = 830;
 }
 );
@@ -24084,7 +24084,7 @@ rightKerningGroup = K;
 },
 {
 glyphname = Kcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:32:52 +0000";
 layers = (
 {
 components = (
@@ -24150,7 +24150,7 @@ transform = "{1, 0, 0, 1, 113, 0}";
 }
 );
 layerId = "7288B434-DFD6-49A2-A8AA-FE4EB49FA570";
-name = "[16]";
+name = "[17.5]";
 width = 606;
 },
 {
@@ -24165,7 +24165,7 @@ transform = "{1, 0, 0, 1, 131, 0}";
 }
 );
 layerId = "EF9E80A9-8C19-4504-B383-60A8324BC1FC";
-name = "[16]";
+name = "[17.5]";
 width = 668;
 },
 {
@@ -24180,7 +24180,7 @@ transform = "{1, 0, 0, 1, 109, 0}";
 }
 );
 layerId = "17D002F8-1432-4AD6-8BE4-AB7DD1C66DA9";
-name = "[16]";
+name = "[17.5]";
 width = 614;
 },
 {
@@ -24195,7 +24195,7 @@ transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
 layerId = "A440E94B-99FC-49B4-9FAD-1D5649FD5AC3";
-name = "[16]";
+name = "[17.5]";
 width = 672;
 }
 );
@@ -25221,7 +25221,7 @@ rightKerningGroup = R.alt;
 },
 {
 glyphname = Rcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:33:02 +0000";
 layers = (
 {
 background = {
@@ -25305,11 +25305,11 @@ name = R.alt;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 91, 0}";
+transform = "{1, 0, 0, 1, 82, 0}";
 }
 );
 layerId = "AF1FFAE4-5B40-4BF7-A1B6-75D374F9EAD1";
-name = "[16]";
+name = "[17.5]";
 width = 584;
 },
 {
@@ -25320,11 +25320,11 @@ name = R.alt;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 116, 0}";
+transform = "{1, 0, 0, 1, 92, 0}";
 }
 );
 layerId = "9A5B8E9C-A41A-412E-ABA2-CC66E4FCA0CB";
-name = "[16]";
+name = "[17.5]";
 width = 658;
 },
 {
@@ -25346,11 +25346,11 @@ name = R.alt;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 87, 0}";
+transform = "{1, 0, 0, 1, 78, 0}";
 }
 );
 layerId = "4B1B8EF9-FCD5-4BC0-B7E8-700DA2C3253B";
-name = "[16]";
+name = "[17.5]";
 width = 572;
 },
 {
@@ -25372,11 +25372,11 @@ name = R.alt;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 110, 0}";
+transform = "{1, 0, 0, 1, 88, 0}";
 }
 );
 layerId = "EC39A053-3396-4504-A87C-AD7E27885986";
-name = "[16]";
+name = "[17.5]";
 width = 641;
 }
 );
@@ -33819,7 +33819,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:33:52 +0000";
 layers = (
 {
 components = (
@@ -33885,7 +33885,7 @@ transform = "{1, 0, 0, 1, 90, 0}";
 }
 );
 layerId = "8B5FC6A6-69CA-41B8-B0C6-9D53EEAD6B4E";
-name = "[16]";
+name = "[17.5]";
 width = 591;
 },
 {
@@ -33900,7 +33900,7 @@ transform = "{1, 0, 0, 1, 110, 0}";
 }
 );
 layerId = "03837B7D-FB80-4303-8306-2E4B19107044";
-name = "[16]";
+name = "[17.5]";
 width = 612;
 },
 {
@@ -33915,7 +33915,7 @@ transform = "{1, 0, 0, 1, 95, 0}";
 }
 );
 layerId = "270D9695-A45E-4367-832D-81C72A913EEA";
-name = "[16]";
+name = "[17.5]";
 width = 597;
 },
 {
@@ -33930,7 +33930,7 @@ transform = "{1, 0, 0, 1, 116, 0}";
 }
 );
 layerId = "3CFA4D85-AB02-4A76-AB77-A4B866BB4E79";
-name = "[16]";
+name = "[17.5]";
 width = 624;
 }
 );
@@ -36456,7 +36456,7 @@ unicode = 006B;
 },
 {
 glyphname = kcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:34:21 +0000";
 layers = (
 {
 components = (
@@ -36522,7 +36522,7 @@ transform = "{1, 0, 0, 1, 69, 0}";
 }
 );
 layerId = "F7F5EFCF-FE59-4A0F-A4F9-2BB5EADC254B";
-name = "[16]";
+name = "[17.5]";
 width = 499;
 },
 {
@@ -36537,7 +36537,7 @@ transform = "{1, 0, 0, 1, 82, 0}";
 }
 );
 layerId = "8B52531E-0CAD-4AA5-B0E8-8FB068188B20";
-name = "[16]";
+name = "[17.5]";
 width = 571;
 },
 {
@@ -36552,7 +36552,7 @@ transform = "{1, 0, 0, 1, 64, 0}";
 }
 );
 layerId = "FC65C166-B00A-456D-A7BF-0344A7716885";
-name = "[16]";
+name = "[17.5]";
 width = 505;
 },
 {
@@ -36567,7 +36567,7 @@ transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
 layerId = "CD9ED046-9890-42AE-B64D-46D89AAAE791";
-name = "[16]";
+name = "[17.5]";
 width = 559;
 }
 );
@@ -36933,7 +36933,7 @@ unicode = 013E;
 },
 {
 glyphname = lcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:35:48 +0000";
 layers = (
 {
 components = (
@@ -36999,7 +36999,7 @@ transform = "{1, 0, 0, 1, -83, 0}";
 }
 );
 layerId = "F2FCFBB1-A90F-4B4C-911C-C5BD6809CB17";
-name = "[16]";
+name = "[17.5]";
 width = 230;
 },
 {
@@ -37014,7 +37014,7 @@ transform = "{1, 0, 0, 1, -70, 0}";
 }
 );
 layerId = "F3FBDC00-55FF-41DE-B1DC-49E09F917A57";
-name = "[16]";
+name = "[17.5]";
 width = 279;
 },
 {
@@ -37029,7 +37029,7 @@ transform = "{1, 0, 0, 1, -93, 0}";
 }
 );
 layerId = "F510F168-65A3-4290-B29A-3AF160ED82DD";
-name = "[16]";
+name = "[17.5]";
 width = 211;
 },
 {
@@ -37044,7 +37044,7 @@ transform = "{1, 0, 0, 1, -80, 0}";
 }
 );
 layerId = "721976EE-3BD2-4C26-B94B-9869E7DDE996";
-name = "[16]";
+name = "[17.5]";
 width = 261;
 }
 );
@@ -37747,7 +37747,7 @@ unicode = 0148;
 },
 {
 glyphname = ncommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:36:10 +0000";
 layers = (
 {
 components = (
@@ -37813,7 +37813,7 @@ transform = "{1, 0, 0, 1, 86, 0}";
 }
 );
 layerId = "71D5C466-8CF8-49D5-9521-5999039F821F";
-name = "[16]";
+name = "[17.5]";
 width = 566;
 },
 {
@@ -37828,7 +37828,7 @@ transform = "{1, 0, 0, 1, 97, 0}";
 }
 );
 layerId = "820338A1-DFF3-4C01-9BEC-49014FA9C498";
-name = "[16]";
+name = "[17.5]";
 width = 613;
 },
 {
@@ -37843,7 +37843,7 @@ transform = "{1, 0, 0, 1, 85, 0}";
 }
 );
 layerId = "4CBBD98E-18F6-4F76-8E70-904B6ABBAE50";
-name = "[16]";
+name = "[17.5]";
 width = 561;
 },
 {
@@ -37858,7 +37858,7 @@ transform = "{1, 0, 0, 1, 93, 0}";
 }
 );
 layerId = "5BB0D7F5-CF54-4AFA-B151-364678FDA97D";
-name = "[16]";
+name = "[17.5]";
 width = 599;
 }
 );
@@ -41783,7 +41783,7 @@ unicode = 0159;
 },
 {
 glyphname = rcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:36:29 +0000";
 layers = (
 {
 components = (
@@ -41849,7 +41849,7 @@ transform = "{1, 0, 0, 1, -83, 0}";
 }
 );
 layerId = "A408FF3C-711D-491F-89B5-7B07CDFB9425";
-name = "[16]";
+name = "[17.5]";
 width = 379;
 },
 {
@@ -41864,7 +41864,7 @@ transform = "{1, 0, 0, 1, -73, 0}";
 }
 );
 layerId = "1B08BBC4-05F8-420B-8DCC-4091FE3243DF";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -41879,7 +41879,7 @@ transform = "{1, 0, 0, 1, -93, 0}";
 }
 );
 layerId = "0A1C5281-3120-4122-9A4E-7C65D6BFE5EF";
-name = "[16]";
+name = "[17.5]";
 width = 375;
 },
 {
@@ -41894,7 +41894,7 @@ transform = "{1, 0, 0, 1, -81, 0}";
 }
 );
 layerId = "D4926DDD-9452-4DFE-8085-DCDC48A6E9BA";
-name = "[16]";
+name = "[17.5]";
 width = 427;
 }
 );
@@ -42409,7 +42409,7 @@ unicode = 015D;
 },
 {
 glyphname = scommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:36:44 +0000";
 layers = (
 {
 components = (
@@ -42475,7 +42475,7 @@ transform = "{1, 0, 0, 1, 50, 0}";
 }
 );
 layerId = "684AB673-DE6B-490D-A542-CA8DDD31BAAE";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 },
 {
@@ -42490,7 +42490,7 @@ transform = "{1, 0, 0, 1, 51, 0}";
 }
 );
 layerId = "B694D12A-AA25-4BFA-B8DA-B46537E9DD6D";
-name = "[16]";
+name = "[17.5]";
 width = 525;
 },
 {
@@ -42505,7 +42505,7 @@ transform = "{1, 0, 0, 1, 44, 0}";
 }
 );
 layerId = "4D2C0989-4CDD-4CBA-B687-9CAEF8FC83E6";
-name = "[16]";
+name = "[17.5]";
 width = 473;
 },
 {
@@ -42520,7 +42520,7 @@ transform = "{1, 0, 0, 1, 46, 0}";
 }
 );
 layerId = "AB0AA28A-60AC-46D0-84A7-B0B5A163BE09";
-name = "[16]";
+name = "[17.5]";
 width = 505;
 }
 );
@@ -43661,7 +43661,7 @@ unicode = 0163;
 },
 {
 glyphname = tcommaaccent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:37:00 +0000";
 layers = (
 {
 components = (
@@ -43727,7 +43727,7 @@ transform = "{1, 0, 0, 1, 25, 0}";
 }
 );
 layerId = "23C5911F-376F-4A7C-95BF-EFE19427FD14";
-name = "[16]";
+name = "[17.5]";
 width = 360;
 },
 {
@@ -43742,7 +43742,7 @@ transform = "{1, 0, 0, 1, 49, 0}";
 }
 );
 layerId = "15785696-0B55-4F63-ABF3-AFAD2FE2AA90";
-name = "[16]";
+name = "[17.5]";
 width = 415;
 },
 {
@@ -43757,7 +43757,7 @@ transform = "{1, 0, 0, 1, 36, 0}";
 }
 );
 layerId = "FCC88FB1-3111-4471-9299-B69CB8CB58C0";
-name = "[16]";
+name = "[17.5]";
 width = 366;
 },
 {
@@ -43772,7 +43772,7 @@ transform = "{1, 0, 0, 1, 50, 0}";
 }
 );
 layerId = "BACEB1B9-44CD-48A0-9C55-FF76D4BB7B88";
-name = "[16]";
+name = "[17.5]";
 width = 418;
 }
 );
@@ -46162,7 +46162,7 @@ unicode = 0078;
 },
 {
 glyphname = y;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:37:17 +0000";
 layers = (
 {
 anchors = (
@@ -46333,7 +46333,7 @@ nodes = (
 );
 };
 layerId = "0A7A2E36-2239-4915-9816-10A57EE2D095";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -46371,7 +46371,7 @@ position = "{290, 510}";
 );
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "E56FF807-18C8-4BDB-BE34-AA1CFA9165AA";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -46505,7 +46505,7 @@ position = "{254, 526}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "52E854A3-3C13-492D-9D8A-046D9932EB60";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -46543,7 +46543,7 @@ position = "{303, 526}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "4F62000A-1DBC-4818-A0C5-94959B44F76D";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -46575,7 +46575,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:37:32 +0000";
 layers = (
 {
 components = (
@@ -46641,7 +46641,7 @@ transform = "{1, 0, 0, 1, 62, 0}";
 }
 );
 layerId = "DE4E6522-30EF-42EC-8F8C-7680538900B5";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -46656,7 +46656,7 @@ transform = "{1, 0, 0, 1, 98, 0}";
 }
 );
 layerId = "BC37AEF6-7D01-43AD-8609-3F02A4BA6A00";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -46671,7 +46671,7 @@ transform = "{1, 0, 0, 1, 66, 0}";
 }
 );
 layerId = "35E699EA-4DFC-4C85-B915-E1C7C021CA77";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -46686,7 +46686,7 @@ transform = "{1, 0, 0, 1, 85, 0}";
 }
 );
 layerId = "EC9922C0-DCE3-47A9-A26D-2B2D06711F7D";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -46696,7 +46696,7 @@ unicode = 00FD;
 },
 {
 glyphname = ycircumflex;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:37:43 +0000";
 layers = (
 {
 components = (
@@ -46762,7 +46762,7 @@ transform = "{1, 0, 0, 1, 57, 0}";
 }
 );
 layerId = "A93C4C3D-A019-4B71-B5FA-0C471C608D4D";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -46777,7 +46777,7 @@ transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
 layerId = "22F7AEE5-903C-475B-B079-E8F73274E925";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -46792,7 +46792,7 @@ transform = "{1, 0, 0, 1, 61, 0}";
 }
 );
 layerId = "4F19CE8A-9955-4DA1-9CF3-DE3665CEA99A";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -46807,7 +46807,7 @@ transform = "{1, 0, 0, 1, 62, 0}";
 }
 );
 layerId = "25B9ED80-4737-409F-ADB2-5C2D1FE25528";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -46817,7 +46817,7 @@ unicode = 0177;
 },
 {
 glyphname = ydieresis;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:37:54 +0000";
 layers = (
 {
 components = (
@@ -46883,7 +46883,7 @@ transform = "{1, 0, 0, 1, 58, 0}";
 }
 );
 layerId = "1FC497E1-C98F-49AF-A039-E64439E37019";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -46898,7 +46898,7 @@ transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
 layerId = "334A143C-7D04-4CF9-BBB7-706A92A65B66";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -46913,7 +46913,7 @@ transform = "{1, 0, 0, 1, 62, 0}";
 }
 );
 layerId = "87E5696D-F244-4B94-84D2-BD707AA6AE7D";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -46928,7 +46928,7 @@ transform = "{1, 0, 0, 1, 64, 0}";
 }
 );
 layerId = "4F5D889D-79E3-4DD4-8550-AAF4D95B145D";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -46938,7 +46938,7 @@ unicode = 00FF;
 },
 {
 glyphname = ydotbelow;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:38:06 +0000";
 layers = (
 {
 components = (
@@ -47004,7 +47004,7 @@ transform = "{1, 0, 0, 1, 269, 0}";
 }
 );
 layerId = "15194F49-F140-43EC-B3E9-844FADE913D5";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47019,7 +47019,7 @@ transform = "{1, 0, 0, 1, 319, 0}";
 }
 );
 layerId = "9051DF1D-7F3D-42D7-9606-00B653145F22";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47034,7 +47034,7 @@ transform = "{1, 0, 0, 1, 250, 0}";
 }
 );
 layerId = "0EB71DFD-EE66-40B6-994B-23144BD082A8";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47049,7 +47049,7 @@ transform = "{1, 0, 0, 1, 289, 0}";
 }
 );
 layerId = "FD76CDEE-7FF0-4D95-8154-EF63C20C2CD3";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -47059,7 +47059,7 @@ unicode = 1EF5;
 },
 {
 glyphname = ygrave;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:38:19 +0000";
 layers = (
 {
 components = (
@@ -47125,7 +47125,7 @@ transform = "{1, 0, 0, 1, 49, 0}";
 }
 );
 layerId = "BB361B7A-AC05-46D0-BD2E-D486C9F5FEEF";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47140,7 +47140,7 @@ transform = "{1, 0, 0, 1, 65, 0}";
 }
 );
 layerId = "FFC0E598-F64E-43C8-86CF-8A2969B67B25";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47155,7 +47155,7 @@ transform = "{1, 0, 0, 1, 53, 0}";
 }
 );
 layerId = "ABC85E7A-C6A5-4B3E-A01F-8DBE21653450";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47170,7 +47170,7 @@ transform = "{1, 0, 0, 1, 46, 0}";
 }
 );
 layerId = "E461B0DD-EF73-4F21-84D6-C614E90B34AC";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -47180,7 +47180,7 @@ unicode = 1EF3;
 },
 {
 glyphname = yhookabove;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:38:41 +0000";
 layers = (
 {
 components = (
@@ -47246,7 +47246,7 @@ transform = "{1, 0, 0, 1, 154, 0}";
 }
 );
 layerId = "8B631BB4-7ECE-4CE3-8809-EF1559D28499";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47261,7 +47261,7 @@ transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
 layerId = "1F0AA97E-0DA8-4733-BDB7-3956E7928B10";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47276,7 +47276,7 @@ transform = "{1, 0, 0, 1, 158, 0}";
 }
 );
 layerId = "AB35EF8A-782B-4181-BC3C-A51D3FF663EA";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47291,7 +47291,7 @@ transform = "{1, 0, 0, 1, 180, 0}";
 }
 );
 layerId = "B379FB95-7DB5-4FA9-AE14-291E79555C68";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -47301,7 +47301,7 @@ unicode = 1EF7;
 },
 {
 glyphname = ytilde;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:38:55 +0000";
 layers = (
 {
 components = (
@@ -47367,7 +47367,7 @@ transform = "{1, 0, 0, 1, 55, 0}";
 }
 );
 layerId = "ABE60132-5EE5-4D8D-935A-34F0FF3574B6";
-name = "[16]";
+name = "[17.5]";
 width = 514;
 },
 {
@@ -47382,7 +47382,7 @@ transform = "{1, 0, 0, 1, 94, 0}";
 }
 );
 layerId = "1BA81BBB-ADAB-47E3-B54F-ED33C974AE3D";
-name = "[16]";
+name = "[17.5]";
 width = 595;
 },
 {
@@ -47397,7 +47397,7 @@ transform = "{1, 0, 0, 1, 59, 0}";
 }
 );
 layerId = "CB45F7B3-23A9-4199-A633-217686FF2EE0";
-name = "[16]";
+name = "[17.5]";
 width = 516;
 },
 {
@@ -47412,7 +47412,7 @@ transform = "{1, 0, 0, 1, 81, 0}";
 }
 );
 layerId = "94A04427-114C-4983-903F-0C7BDE51D66C";
-name = "[16]";
+name = "[17.5]";
 width = 578;
 }
 );
@@ -50749,7 +50749,7 @@ rightKerningGroup = k;
 },
 {
 glyphname = kcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:39:22 +0000";
 layers = (
 {
 components = (
@@ -50815,7 +50815,7 @@ transform = "{1, 0, 0, 1, 55, 0}";
 }
 );
 layerId = "579FC0A5-1AFD-4539-A374-67F2F6B4FC3A";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -50830,7 +50830,7 @@ transform = "{1, 0, 0, 1, 73, 0}";
 }
 );
 layerId = "34141C76-2B6E-4469-B29C-0B9231DC3FD7";
-name = "[16]";
+name = "[17.5]";
 width = 551;
 },
 {
@@ -50845,7 +50845,7 @@ transform = "{1, 0, 0, 1, 46, 0}";
 }
 );
 layerId = "63DC74F9-1B8C-4261-8C5B-84ABF32F3B6F";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 },
 {
@@ -50860,7 +50860,7 @@ transform = "{1, 0, 0, 1, 60, 0}";
 }
 );
 layerId = "910B0BBF-F5B6-4A9A-ADAC-059FAE13668B";
-name = "[16]";
+name = "[17.5]";
 width = 541;
 }
 );
@@ -51453,7 +51453,7 @@ rightKerningGroup = r;
 },
 {
 glyphname = rcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:39:43 +0000";
 layers = (
 {
 components = (
@@ -51519,7 +51519,7 @@ transform = "{1, 0, 0, 1, -83, 0}";
 }
 );
 layerId = "435D4195-17CA-472E-9D77-D4B85727AA1C";
-name = "[16]";
+name = "[17.5]";
 width = 379;
 },
 {
@@ -51534,7 +51534,7 @@ transform = "{1, 0, 0, 1, -73, 0}";
 }
 );
 layerId = "15583255-17B7-4BDC-8198-42EC5A57A713";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -51549,7 +51549,7 @@ transform = "{1, 0, 0, 1, -93, 0}";
 }
 );
 layerId = "94FB224B-C815-4997-95AF-6C1B6CA8EB04";
-name = "[16]";
+name = "[17.5]";
 width = 369;
 },
 {
@@ -51564,7 +51564,7 @@ transform = "{1, 0, 0, 1, -81, 0}";
 }
 );
 layerId = "055E7840-D4B3-4AEE-989C-4F21634E9D1E";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 }
 );
@@ -52398,7 +52398,7 @@ rightKerningGroup = t.alt;
 },
 {
 glyphname = tcommaaccent.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:39:56 +0000";
 layers = (
 {
 anchors = (
@@ -52654,7 +52654,7 @@ transform = "{1, 0, 0, 1, -20, 0}";
 }
 );
 layerId = "83251873-E740-4485-AB64-AD14ACD913F7";
-name = "[16]";
+name = "[17.5]";
 width = 364;
 },
 {
@@ -52687,7 +52687,7 @@ transform = "{1, 0, 0, 1, -16, 0}";
 }
 );
 layerId = "DAB77A15-76BD-417D-9168-91BBBB38092A";
-name = "[16]";
+name = "[17.5]";
 width = 405;
 },
 {
@@ -52770,7 +52770,7 @@ transform = "{1, 0, 0, 1, -22, 0}";
 }
 );
 layerId = "27A3D203-671D-473D-8204-182D95E227FC";
-name = "[16]";
+name = "[17.5]";
 width = 354;
 },
 {
@@ -52853,7 +52853,7 @@ transform = "{1, 0, 0, 1, -16, 0}";
 }
 );
 layerId = "D7E02CE4-3C5D-49F0-9CC8-BBF75EF8EBE1";
-name = "[16]";
+name = "[17.5]";
 width = 401;
 }
 );
@@ -68636,7 +68636,7 @@ rightKerningGroup = f.sc;
 },
 {
 glyphname = g.sc;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:40:45 +0000";
 layers = (
 {
 anchors = (
@@ -68863,7 +68863,7 @@ position = "{328, 580}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "2A572E80-D3A4-4572-BE8D-678E3C3AF9A2";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -68923,7 +68923,7 @@ position = "{346, 580}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "DF7BF0CA-C768-461F-BE3C-6EECD94E5324";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -68983,7 +68983,7 @@ position = "{344, 580}";
 );
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "AC08742A-7D06-4E7A-BBB8-C80B99325691";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -69043,7 +69043,7 @@ position = "{351, 580}";
 );
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "93126EC6-7C10-4E1E-B329-C402AE9AB839";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -83293,7 +83293,7 @@ width = 342;
 },
 {
 glyphname = y.sc.lc.ss04;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:41:28 +0000";
 layers = (
 {
 background = {
@@ -83504,7 +83504,7 @@ nodes = (
 );
 };
 layerId = "C4AAB2BA-8F69-4C5F-AD49-F7009ED4093D";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -83556,7 +83556,7 @@ nodes = (
 );
 };
 layerId = "3550ED2B-3E82-4AFF-818E-D3867210CD44";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -83583,7 +83583,7 @@ width = 340;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "F72F3163-2218-4E39-A87D-BE5CA1CA7695";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -83610,7 +83610,7 @@ width = 373;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "C5E23407-F57C-4B1D-AF1B-3BE7346A6FE5";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -84612,7 +84612,7 @@ width = 371;
 },
 {
 glyphname = g.sc.ss04;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:41:46 +0000";
 layers = (
 {
 background = {
@@ -84955,7 +84955,7 @@ nodes = (
 );
 };
 layerId = "4B127761-F702-406D-A6A6-146F76D56E58";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -85059,7 +85059,7 @@ nodes = (
 );
 };
 layerId = "F23173E5-FE30-47E7-BAA5-FC09165AC855";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -85117,7 +85117,7 @@ width = 509;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "1A57382A-C3B8-46B8-AE01-8A7F8C131D93";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -85175,7 +85175,7 @@ width = 486;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "774FD360-95D2-4B65-8839-F5836F9EED1B";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -200292,7 +200292,7 @@ unicode = 0030;
 },
 {
 glyphname = one;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:43:54 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -200365,46 +200365,6 @@ nodes = (
 }
 );
 width = 426;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "3A38A1F7-7B79-44BD-A2E9-5AAE2CD00635";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"289 0 LINE",
-"289 708 LINE",
-"236 708 LINE",
-"49 573 LINE",
-"95 509 LINE",
-"205 591 LINE",
-"205 0 LINE"
-);
-}
-);
-width = 373;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "4C68EC27-7432-4F2B-BEFF-3DDA8C6CE40F";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"342 0 LINE",
-"342 708 LINE",
-"243 708 LINE",
-"49 567 LINE",
-"49 421 LINE",
-"211 541 LINE",
-"211 0 LINE"
-);
-}
-);
-width = 428;
 }
 );
 unicode = 0031;
@@ -202011,7 +201971,7 @@ unicode = 0039;
 },
 {
 glyphname = one.sansSerifCircled;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:01 +0000";
 layers = (
 {
 components = (
@@ -202161,55 +202121,6 @@ transform = "{1, 0, 0, 1, 275, -169}";
 }
 );
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"268 69 OFFCURVE",
-"138 200 OFFCURVE",
-"138 358 CURVE SMOOTH",
-"138 517 OFFCURVE",
-"268 647 OFFCURVE",
-"426 647 CURVE SMOOTH",
-"586 647 OFFCURVE",
-"715 517 OFFCURVE",
-"715 358 CURVE SMOOTH",
-"715 200 OFFCURVE",
-"586 69 OFFCURVE",
-"426 69 CURVE SMOOTH"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-components = (
-{
-alignment = -1;
-name = one.numerator;
-transform = "{1, 0, 0, 1, 275, -169}";
-}
-);
-layerId = "39975EA4-E589-47DD-A96F-66CA7AF0FD1F";
-name = "{15}";
 paths = (
 {
 closed = 1;
@@ -203813,7 +203724,7 @@ unicode = 2788;
 },
 {
 glyphname = one.sansSerifBlackCircled;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:06 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -203950,80 +203861,6 @@ nodes = (
 "483 549 LINE",
 "483 171 LINE",
 "394 171 LINE"
-);
-}
-);
-width = 853;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "A7BCBE99-B687-4F6C-96F7-8F04EF153A32";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"631 -16 OFFCURVE",
-"799 152 OFFCURVE",
-"799 358 CURVE SMOOTH",
-"799 564 OFFCURVE",
-"631 732 OFFCURVE",
-"425 732 CURVE SMOOTH",
-"219 732 OFFCURVE",
-"51 564 OFFCURVE",
-"51 358 CURVE SMOOTH",
-"51 152 OFFCURVE",
-"219 -16 OFFCURVE",
-"425 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"406 462 LINE",
-"343 416 LINE",
-"304 465 LINE",
-"415 548 LINE",
-"471 548 LINE",
-"471 173 LINE",
-"406 173 LINE"
-);
-}
-);
-width = 851;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "BFD29655-37BD-4636-96F2-2A50F7AF6AA5";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"632 -16 OFFCURVE",
-"800 152 OFFCURVE",
-"800 358 CURVE SMOOTH",
-"800 564 OFFCURVE",
-"632 732 OFFCURVE",
-"426 732 CURVE SMOOTH",
-"220 732 OFFCURVE",
-"52 564 OFFCURVE",
-"52 358 CURVE SMOOTH",
-"52 152 OFFCURVE",
-"220 -16 OFFCURVE",
-"426 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"394 431 LINE",
-"341 388 LINE",
-"288 457 LINE",
-"402 548 LINE",
-"483 548 LINE",
-"483 173 LINE",
-"394 173 LINE"
 );
 }
 );
@@ -206362,7 +206199,7 @@ rightMetricsKey = zero;
 },
 {
 glyphname = one.alt;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:14 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -206451,54 +206288,6 @@ nodes = (
 }
 );
 width = 571;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "EC3AB6D4-AEF9-48D1-8729-86A725891E57";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"466 0 LINE",
-"466 81 LINE",
-"305 81 LINE",
-"305 708 LINE",
-"252 708 LINE",
-"55 565 LINE",
-"98 501 LINE",
-"221 591 LINE",
-"221 81 LINE",
-"59 81 LINE",
-"59 0 LINE"
-);
-}
-);
-width = 515;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "8208BD2E-0438-4370-8D18-C60D1C61DD78";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"511 0 LINE",
-"511 120 LINE",
-"350 120 LINE",
-"350 708 LINE",
-"251 708 LINE",
-"35 550 LINE",
-"98 452 LINE",
-"219 541 LINE",
-"219 120 LINE",
-"58 120 LINE",
-"58 0 LINE"
-);
-}
-);
-width = 565;
 }
 );
 },
@@ -207312,7 +207101,7 @@ rightKerningGroup = zero.cap;
 },
 {
 glyphname = one.alt.cap;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:19 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -207433,94 +207222,6 @@ nodes = (
 "261 716 LINE",
 "83 588 LINE",
 "83 439 LINE",
-"229 545 LINE",
-"229 120 LINE",
-"66 120 LINE",
-"66 0 LINE"
-);
-}
-);
-width = 568;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"459 0 LINE",
-"459 81 LINE",
-"299 81 LINE",
-"299 716 LINE",
-"245 716 LINE",
-"50 576 LINE",
-"94 511 LINE",
-"214 597 LINE",
-"214 81 LINE",
-"53 81 LINE",
-"53 0 LINE"
-);
-}
-);
-};
-layerId = "38B6B2DA-8788-4353-8D55-6CDF084C4877";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"459 0 LINE",
-"459 81 LINE",
-"299 81 LINE",
-"299 716 LINE",
-"245 716 LINE",
-"39 569 LINE",
-"84 504 LINE",
-"214 597 LINE",
-"214 81 LINE",
-"53 81 LINE",
-"53 0 LINE"
-);
-}
-);
-width = 505;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"521 0 LINE",
-"521 120 LINE",
-"360 120 LINE",
-"360 716 LINE",
-"261 716 LINE",
-"60 571 LINE",
-"126 470 LINE",
-"229 545 LINE",
-"229 120 LINE",
-"66 120 LINE",
-"66 0 LINE"
-);
-}
-);
-};
-layerId = "EDC946BA-A53F-4E55-807C-560C672D4700";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"521 0 LINE",
-"521 120 LINE",
-"360 120 LINE",
-"360 716 LINE",
-"261 716 LINE",
-"50 564 LINE",
-"117 464 LINE",
 "229 545 LINE",
 "229 120 LINE",
 "66 120 LINE",
@@ -208319,7 +208020,7 @@ rightKerningGroup = zero.cap;
 },
 {
 glyphname = one.cap;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:53 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -208392,46 +208093,6 @@ nodes = (
 }
 );
 width = 426;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "D5EA23CE-3FC6-4E65-96A8-E95E3E30830A";
-name = "[14]";
-paths = (
-{
-closed = 1;
-nodes = (
-"294 0 LINE",
-"294 716 LINE",
-"240 716 LINE",
-"45 576 LINE",
-"89 511 LINE",
-"209 597 LINE",
-"209 0 LINE"
-);
-}
-);
-width = 380;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "8ECFD5DE-2373-4B3D-8D56-1EE2407AD3C5";
-name = "[14]";
-paths = (
-{
-closed = 1;
-nodes = (
-"346 0 LINE",
-"346 716 LINE",
-"247 716 LINE",
-"46 571 LINE",
-"112 470 LINE",
-"215 545 LINE",
-"215 0 LINE"
-);
-}
-);
-width = 434;
 }
 );
 },
@@ -210724,7 +210385,7 @@ width = 397;
 },
 {
 glyphname = one.numerator;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:44:41 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -210797,46 +210458,6 @@ nodes = (
 }
 );
 width = 275;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "418D9BEB-C116-44B7-AA9B-264EBFA0FF09";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"182 341 LINE",
-"182 716 LINE",
-"126 716 LINE",
-"15 633 LINE",
-"54 584 LINE",
-"117 630 LINE",
-"117 341 LINE"
-);
-}
-);
-width = 244;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "548EE276-0555-4E21-B4FA-17784847DAFC";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"211 341 LINE",
-"211 716 LINE",
-"130 716 LINE",
-"16 625 LINE",
-"69 556 LINE",
-"122 599 LINE",
-"122 341 LINE"
-);
-}
-);
-width = 274;
 }
 );
 leftKerningGroup = one.superior;
@@ -212564,7 +212185,7 @@ rightKerningGroup = zero;
 },
 {
 glyphname = one.ss03;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:04 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -212649,62 +212270,6 @@ nodes = (
 "59 528 LINE",
 "195 626 LINE",
 "195 0 LINE"
-);
-}
-);
-width = 355;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"259 0 LINE",
-"259 716 LINE",
-"218 716 LINE",
-"40 586 LINE",
-"74 537 LINE",
-"195 626 LINE",
-"195 0 LINE"
-);
-}
-);
-};
-layerId = "367DBC04-83DF-44FE-BFAD-F2E0DB29CB3E";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"261 0 LINE",
-"261 708 LINE",
-"220 708 LINE",
-"56 589 LINE",
-"92 541 LINE",
-"197 618 LINE",
-"197 0 LINE"
-);
-}
-);
-width = 355;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "B1092111-6B38-4E84-8E7D-7D3947D41A7C";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"261 0 LINE",
-"261 708 LINE",
-"220 708 LINE",
-"56 589 LINE",
-"92 541 LINE",
-"197 618 LINE",
-"197 0 LINE"
 );
 }
 );
@@ -213441,7 +213006,7 @@ width = 559;
 },
 {
 glyphname = six.ss03;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:14 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -213638,117 +213203,12 @@ nodes = (
 }
 );
 width = 563;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-components = (
-{
-name = six;
-}
-);
-};
-layerId = "03A6F488-F3D2-46DB-8D63-08018D852B85";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"411 -16 OFFCURVE",
-"511 93 OFFCURVE",
-"511 220 CURVE SMOOTH",
-"511 357 OFFCURVE",
-"409 449 OFFCURVE",
-"295 449 CURVE SMOOTH",
-"253 449 OFFCURVE",
-"217 437 OFFCURVE",
-"191 418 CURVE",
-"189 420 LINE",
-"363 677 LINE",
-"311 712 LINE",
-"136 445 LINE SMOOTH",
-"89 372 OFFCURVE",
-"51 308 OFFCURVE",
-"51 221 CURVE SMOOTH",
-"51 99 OFFCURVE",
-"140 -16 OFFCURVE",
-"281 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 45 OFFCURVE",
-"116 117 OFFCURVE",
-"116 219 CURVE SMOOTH",
-"116 320 OFFCURVE",
-"184 391 OFFCURVE",
-"281 391 CURVE SMOOTH",
-"378 391 OFFCURVE",
-"447 320 OFFCURVE",
-"447 219 CURVE SMOOTH",
-"447 117 OFFCURVE",
-"378 45 OFFCURVE",
-"281 45 CURVE SMOOTH"
-);
-}
-);
-width = 561;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "2AE991D4-0CEE-4CFC-913E-02D056DFBB14";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"411 -16 OFFCURVE",
-"511 93 OFFCURVE",
-"511 220 CURVE SMOOTH",
-"511 357 OFFCURVE",
-"409 449 OFFCURVE",
-"295 449 CURVE SMOOTH",
-"253 449 OFFCURVE",
-"217 437 OFFCURVE",
-"191 418 CURVE",
-"189 420 LINE",
-"363 677 LINE",
-"311 712 LINE",
-"136 445 LINE SMOOTH",
-"89 372 OFFCURVE",
-"51 308 OFFCURVE",
-"51 221 CURVE SMOOTH",
-"51 99 OFFCURVE",
-"140 -16 OFFCURVE",
-"281 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 45 OFFCURVE",
-"116 117 OFFCURVE",
-"116 219 CURVE SMOOTH",
-"116 320 OFFCURVE",
-"184 391 OFFCURVE",
-"281 391 CURVE SMOOTH",
-"378 391 OFFCURVE",
-"447 320 OFFCURVE",
-"447 219 CURVE SMOOTH",
-"447 117 OFFCURVE",
-"378 45 OFFCURVE",
-"281 45 CURVE SMOOTH"
-);
-}
-);
-width = 561;
 }
 );
 },
 {
 glyphname = seven.ss03;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:19 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -213825,48 +213285,6 @@ nodes = (
 }
 );
 width = 536;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "95E28833-3DCE-46F5-A75B-37C5CCE75F03";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"482 642 LINE",
-"482 708 LINE",
-"51 708 LINE",
-"51 647 LINE",
-"416 647 LINE",
-"416 647 LINE",
-"130 23 LINE",
-"187 -3 LINE"
-);
-}
-);
-width = 533;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "93F05490-2E9A-444C-A800-1440682004E7";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"482 642 LINE",
-"482 708 LINE",
-"51 708 LINE",
-"51 647 LINE",
-"416 647 LINE",
-"416 647 LINE",
-"130 23 LINE",
-"187 -3 LINE"
-);
-}
-);
-width = 533;
 }
 );
 leftKerningGroup = seven;
@@ -214172,7 +213590,7 @@ width = 560;
 },
 {
 glyphname = nine.ss03;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:25 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -214361,104 +213779,6 @@ nodes = (
 }
 );
 width = 564;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "3B243D13-2F86-49CC-8647-543EE9F01156";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"426 263 LINE SMOOTH",
-"474 336 OFFCURVE",
-"511 400 OFFCURVE",
-"511 487 CURVE SMOOTH",
-"511 609 OFFCURVE",
-"422 724 OFFCURVE",
-"281 724 CURVE SMOOTH",
-"151 724 OFFCURVE",
-"51 615 OFFCURVE",
-"51 488 CURVE SMOOTH",
-"51 351 OFFCURVE",
-"153 259 OFFCURVE",
-"267 259 CURVE SMOOTH",
-"309 259 OFFCURVE",
-"345 271 OFFCURVE",
-"371 290 CURVE",
-"373 288 LINE",
-"199 31 LINE",
-"251 -4 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 317 OFFCURVE",
-"115 388 OFFCURVE",
-"115 489 CURVE SMOOTH",
-"115 591 OFFCURVE",
-"184 663 OFFCURVE",
-"281 663 CURVE SMOOTH",
-"378 663 OFFCURVE",
-"446 591 OFFCURVE",
-"446 489 CURVE SMOOTH",
-"446 388 OFFCURVE",
-"378 317 OFFCURVE",
-"281 317 CURVE SMOOTH"
-);
-}
-);
-width = 562;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "B6B3B246-8588-42DA-8B63-33EEC6D07F55";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"426 263 LINE SMOOTH",
-"474 336 OFFCURVE",
-"511 400 OFFCURVE",
-"511 487 CURVE SMOOTH",
-"511 609 OFFCURVE",
-"422 724 OFFCURVE",
-"281 724 CURVE SMOOTH",
-"151 724 OFFCURVE",
-"51 615 OFFCURVE",
-"51 488 CURVE SMOOTH",
-"51 351 OFFCURVE",
-"153 259 OFFCURVE",
-"267 259 CURVE SMOOTH",
-"309 259 OFFCURVE",
-"345 271 OFFCURVE",
-"371 290 CURVE",
-"373 288 LINE",
-"199 31 LINE",
-"251 -4 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 317 OFFCURVE",
-"115 388 OFFCURVE",
-"115 489 CURVE SMOOTH",
-"115 591 OFFCURVE",
-"184 663 OFFCURVE",
-"281 663 CURVE SMOOTH",
-"378 663 OFFCURVE",
-"446 591 OFFCURVE",
-"446 489 CURVE SMOOTH",
-"446 388 OFFCURVE",
-"378 317 OFFCURVE",
-"281 317 CURVE SMOOTH"
-);
-}
-);
-width = 562;
 }
 );
 },
@@ -214631,7 +213951,7 @@ widthMetricsKey = "=600";
 },
 {
 glyphname = one.tf;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:30 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -214699,46 +214019,6 @@ nodes = (
 "88 574 LINE",
 "88 430 LINE",
 "298 551 LINE",
-"298 0 LINE"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "1D5A1886-3FAB-46AD-A21B-08B7C8990EFE";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"409 0 LINE",
-"409 716 LINE",
-"356 716 LINE",
-"94 555 LINE",
-"135 487 LINE",
-"325 604 LINE",
-"325 0 LINE"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "1103A2E6-C30C-4A2C-85BE-935CACFE8783";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"429 0 LINE",
-"429 716 LINE",
-"330 716 LINE",
-"67 552 LINE",
-"135 447 LINE",
-"298 550 LINE",
 "298 0 LINE"
 );
 }
@@ -220031,26 +219311,8 @@ source = zero.cap;
 },
 {
 glyphname = one.sc.ss04;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:45:45 +0000";
 layers = (
-{
-layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
-paths = (
-{
-closed = 1;
-nodes = (
-"192 0 LINE",
-"192 447 LINE",
-"142 447 LINE",
-"27 364 LINE",
-"57 317 LINE",
-"126 367 LINE",
-"126 0 LINE"
-);
-}
-);
-width = 244;
-},
 {
 layerId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 paths = (
@@ -220068,24 +219330,6 @@ nodes = (
 }
 );
 width = 262;
-},
-{
-layerId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
-paths = (
-{
-closed = 1;
-nodes = (
-"233 0 LINE",
-"233 447 LINE",
-"152 447 LINE",
-"28 357 LINE",
-"74 285 LINE",
-"140 333 LINE",
-"140 0 LINE"
-);
-}
-);
-width = 285;
 },
 {
 layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
@@ -220106,44 +219350,40 @@ nodes = (
 width = 297;
 },
 {
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "CAF8B4F7-EAE5-4418-B5D2-E0D1FA34CAF5";
-name = "{15}";
+layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 paths = (
 {
 closed = 1;
 nodes = (
-"202 0 LINE",
-"202 447 LINE",
-"152 447 LINE",
-"27 358 LINE",
-"59 310 LINE",
-"136 366 LINE",
-"136 0 LINE"
+"192 0 LINE",
+"192 447 LINE",
+"142 447 LINE",
+"27 364 LINE",
+"57 317 LINE",
+"126 367 LINE",
+"126 0 LINE"
 );
 }
 );
-width = 258;
+width = 244;
 },
 {
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "5A262C4B-0D0C-4D25-A0D2-69FB66A87BAE";
-name = "{15}";
+layerId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 paths = (
 {
 closed = 1;
 nodes = (
-"242 0 LINE",
-"242 447 LINE",
-"161 447 LINE",
-"15 342 LINE",
-"61 268 LINE",
-"149 333 LINE",
-"149 0 LINE"
+"233 0 LINE",
+"233 447 LINE",
+"152 447 LINE",
+"28 357 LINE",
+"74 285 LINE",
+"140 333 LINE",
+"140 0 LINE"
 );
 }
 );
-width = 294;
+width = 285;
 }
 );
 userData = {
@@ -225642,7 +224882,7 @@ unicode = 002E;
 },
 {
 glyphname = comma;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:46:06 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -225677,7 +224917,7 @@ width = 288;
 {
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "6852A681-2644-4857-B7FB-6E53CD1A6E4B";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -225705,7 +224945,7 @@ width = 238;
 {
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "96944E9F-AB09-4D77-A559-83F4114B8680";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -225763,7 +225003,7 @@ width = 294;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "FDE4FFC5-621E-4FD5-92D8-BDD391D9B014";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -225791,7 +225031,7 @@ width = 258;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "AC26E747-C6F4-4E21-AAB7-322FAFEF7D7E";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -226000,7 +225240,7 @@ unicode = 003A;
 },
 {
 glyphname = semicolon;
-lastChange = "2020-03-11 14:17:30 +0000";
+lastChange = "2020-06-17 16:46:23 +0000";
 layers = (
 {
 components = (
@@ -226085,7 +225325,7 @@ position = "{189, 298}";
 }
 );
 layerId = "F3AAC054-E876-4729-A5A5-45D3AAE934AE";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -226121,7 +225361,7 @@ position = "{232, 298}";
 }
 );
 layerId = "E726AC87-A780-4EEB-845B-A0DACA966162";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -226211,7 +225451,7 @@ transform = "{1, 0, 0, 1, 16, 0}";
 }
 );
 layerId = "402383DF-A370-4BE0-A309-CAA4199BC401";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -226242,7 +225482,7 @@ name = comma;
 }
 );
 layerId = "146D5B79-2E14-4993-9645-1298462030B7";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -232302,7 +231542,7 @@ rightMetricsKey = hyphen;
 },
 {
 glyphname = quotesinglbase;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:46:49 +0000";
 layers = (
 {
 components = (
@@ -232356,7 +231596,7 @@ transform = "{1, 0, 0, 1, 0, -611}";
 }
 );
 layerId = "078D59F4-FE65-4E36-B912-AD53AAE1AA8F";
-name = "[16]";
+name = "[17.5]";
 width = 292;
 },
 {
@@ -232369,7 +231609,7 @@ transform = "{1, 0, 0, 1, 0, -567}";
 }
 );
 layerId = "A0394C69-C158-4001-9530-347ACE531D01";
-name = "[16]";
+name = "[17.5]";
 width = 342;
 },
 {
@@ -232381,7 +231621,7 @@ transform = "{1, 0, 0, 1, 0, -611}";
 }
 );
 layerId = "66895B9D-B01B-401B-946F-52F129F38DCC";
-name = "[16]";
+name = "[17.5]";
 width = 224;
 },
 {
@@ -232393,7 +231633,7 @@ transform = "{1, 0, 0, 1, 0, -567}";
 }
 );
 layerId = "A857E3CE-D386-493A-B81F-A7B3507C5828";
-name = "[16]";
+name = "[17.5]";
 width = 269;
 }
 );
@@ -232403,7 +231643,7 @@ unicode = 201A;
 },
 {
 glyphname = quotedblbase;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:46:58 +0000";
 layers = (
 {
 components = (
@@ -232480,7 +231720,7 @@ transform = "{1, 0, 0, 1, 157, -611}";
 }
 );
 layerId = "CBB2531C-C504-48BB-9856-405A29685214";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -232498,7 +231738,7 @@ transform = "{1, 0, 0, 1, 196, -567}";
 }
 );
 layerId = "61C6AF3E-99DC-426E-BB7B-3DFE527F8DF7";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -232514,7 +231754,7 @@ transform = "{1, 0, 0, 1, 169, -611}";
 }
 );
 layerId = "AF7967B9-DD0E-42D0-8FF8-73E61B23315E";
-name = "[16]";
+name = "[17.5]";
 width = 393;
 },
 {
@@ -232530,7 +231770,7 @@ transform = "{1, 0, 0, 1, 201, -567}";
 }
 );
 layerId = "3298FF07-1F52-4E0E-B035-4AA67E3493A4";
-name = "[16]";
+name = "[17.5]";
 width = 417;
 }
 );
@@ -232540,7 +231780,7 @@ unicode = 201E;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:47:09 +0000";
 layers = (
 {
 components = (
@@ -232613,7 +231853,7 @@ transform = "{1, 0, 0, 1, 163, 0}";
 }
 );
 layerId = "4471FD8F-3964-4E5C-9065-C124454A4AB3";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -232631,7 +231871,7 @@ transform = "{1, 0, 0, 1, 202, 0}";
 }
 );
 layerId = "EB0EDBD6-43BC-4C48-8A17-EF30CB4EF5F6";
-name = "[16]";
+name = "[17.5]";
 width = 504;
 },
 {
@@ -232647,7 +231887,7 @@ transform = "{1, 0, 0, 1, 189, 0}";
 }
 );
 layerId = "A477458D-21E7-4F7B-AFC8-F0D6821F9C8E";
-name = "[16]";
+name = "[17.5]";
 width = 413;
 },
 {
@@ -232662,7 +231902,7 @@ transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
 layerId = "AD570B5D-E07E-4DCD-AEF9-5B5033EE9CF6";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 }
 );
@@ -232672,7 +231912,7 @@ unicode = 201C;
 },
 {
 glyphname = quotedblright;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:47:20 +0000";
 layers = (
 {
 components = (
@@ -232745,7 +231985,7 @@ transform = "{1, 0, 0, 1, 157, 0}";
 }
 );
 layerId = "F7262B6F-F510-490E-AAB0-D4D2283329E4";
-name = "[16]";
+name = "[17.5]";
 width = 422;
 },
 {
@@ -232763,7 +232003,7 @@ transform = "{1, 0, 0, 1, 186, 0}";
 }
 );
 layerId = "53F81095-EC24-4C80-9836-126E6E4B6B5B";
-name = "[16]";
+name = "[17.5]";
 width = 494;
 },
 {
@@ -232779,7 +232019,7 @@ transform = "{1, 0, 0, 1, 170, 0}";
 }
 );
 layerId = "136D7377-0205-4909-BBBD-65205A77EC67";
-name = "[16]";
+name = "[17.5]";
 width = 395;
 },
 {
@@ -232794,7 +232034,7 @@ transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
 layerId = "C15BE273-8C1E-44F8-9CED-91F4DC179984";
-name = "[16]";
+name = "[17.5]";
 width = 488;
 }
 );
@@ -232804,7 +232044,7 @@ unicode = 201D;
 },
 {
 glyphname = quoteleft;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:47:28 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -232839,7 +232079,7 @@ width = 269;
 {
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "7DEB9DA0-E401-4A89-BA0C-C0E8393CF043";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -232867,7 +232107,7 @@ width = 224;
 {
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "3D26B56D-8201-4974-AFB9-F8192DA0E0F8";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -232925,7 +232165,7 @@ width = 342;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "E3E23C49-A4D7-46A3-A3FF-ACBF27458A7F";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -232953,7 +232193,7 @@ width = 292;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "B8349351-1620-452C-B9C5-CB35FBAC694A";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -232993,7 +232233,7 @@ com.typemytype.robofont.mark = (
 },
 {
 glyphname = quoteright;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:47:36 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -233028,7 +232268,7 @@ width = 269;
 {
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "33755A95-0710-4A3C-BFFD-70343530C50C";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233056,7 +232296,7 @@ width = 224;
 {
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "FA25951B-1D18-470E-9AE5-2374015DD7FC";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233114,7 +232354,7 @@ width = 342;
 {
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "B0CDA944-6D57-46A8-BBF3-B713B9D45F53";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -233142,7 +232382,7 @@ width = 292;
 {
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "2D2BD335-084D-4213-8F62-CA6F28F80738";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -234305,7 +233545,7 @@ unicode = 0387;
 },
 {
 glyphname = questiongreek;
-lastChange = "2020-03-11 14:18:22 +0000";
+lastChange = "2020-06-17 16:47:53 +0000";
 layers = (
 {
 components = (
@@ -234353,7 +233593,7 @@ name = comma;
 }
 );
 layerId = "50A81AC5-BA09-41A1-9E44-50A61AF5E3F0";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -234384,7 +233624,7 @@ name = comma;
 }
 );
 layerId = "E8503801-CB5A-491B-8FB0-4669A1E291D7";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -234416,7 +233656,7 @@ transform = "{1, 0, 0, 1, 0, 16}";
 );
 layerId = "8C8E90C1-8977-4B47-9B6D-72E9DFDA8FD4";
 rightMetricsKey = "=semicolon";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -234446,7 +233686,7 @@ name = comma;
 }
 );
 layerId = "61E189F8-B753-46F2-BD9D-ABA21855F7A8";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -248239,7 +247479,7 @@ unicode = 00B5;
 },
 {
 glyphname = percent;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:15 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -248653,339 +247893,6 @@ nodes = (
 }
 );
 width = 923;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"698 701 LINE",
-"627 710 LINE",
-"154 7 LINE",
-"226 -2 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 373 OFFCURVE",
-"388 446 OFFCURVE",
-"388 549 CURVE SMOOTH",
-"388 651 OFFCURVE",
-"313 724 OFFCURVE",
-"215 724 CURVE SMOOTH",
-"116 724 OFFCURVE",
-"42 651 OFFCURVE",
-"42 549 CURVE SMOOTH",
-"42 446 OFFCURVE",
-"116 373 OFFCURVE",
-"215 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"154 435 OFFCURVE",
-"110 478 OFFCURVE",
-"110 549 CURVE SMOOTH",
-"110 620 OFFCURVE",
-"154 662 OFFCURVE",
-"215 662 CURVE SMOOTH",
-"275 662 OFFCURVE",
-"319 620 OFFCURVE",
-"319 549 CURVE SMOOTH",
-"319 478 OFFCURVE",
-"275 435 OFFCURVE",
-"215 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"736 -16 OFFCURVE",
-"811 57 OFFCURVE",
-"811 160 CURVE SMOOTH",
-"811 262 OFFCURVE",
-"736 335 OFFCURVE",
-"638 335 CURVE SMOOTH",
-"539 335 OFFCURVE",
-"465 262 OFFCURVE",
-"465 160 CURVE SMOOTH",
-"465 57 OFFCURVE",
-"539 -16 OFFCURVE",
-"638 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 46 OFFCURVE",
-"533 89 OFFCURVE",
-"533 160 CURVE SMOOTH",
-"533 231 OFFCURVE",
-"577 273 OFFCURVE",
-"638 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"638 46 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "B6FFEDDC-023D-4F97-B614-FC530BA85C7B";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"686 683 LINE",
-"633 719 LINE",
-"167 26 LINE",
-"221 -10 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 373 OFFCURVE",
-"388 446 OFFCURVE",
-"388 549 CURVE SMOOTH",
-"388 651 OFFCURVE",
-"313 724 OFFCURVE",
-"215 724 CURVE SMOOTH",
-"116 724 OFFCURVE",
-"42 651 OFFCURVE",
-"42 549 CURVE SMOOTH",
-"42 446 OFFCURVE",
-"116 373 OFFCURVE",
-"215 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"154 435 OFFCURVE",
-"110 478 OFFCURVE",
-"110 549 CURVE SMOOTH",
-"110 620 OFFCURVE",
-"154 662 OFFCURVE",
-"215 662 CURVE SMOOTH",
-"275 662 OFFCURVE",
-"320 620 OFFCURVE",
-"320 549 CURVE SMOOTH",
-"320 478 OFFCURVE",
-"275 435 OFFCURVE",
-"215 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"736 -16 OFFCURVE",
-"811 57 OFFCURVE",
-"811 160 CURVE SMOOTH",
-"811 262 OFFCURVE",
-"736 335 OFFCURVE",
-"638 335 CURVE SMOOTH",
-"539 335 OFFCURVE",
-"465 262 OFFCURVE",
-"465 160 CURVE SMOOTH",
-"465 57 OFFCURVE",
-"539 -16 OFFCURVE",
-"638 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 46 OFFCURVE",
-"533 89 OFFCURVE",
-"533 160 CURVE SMOOTH",
-"533 231 OFFCURVE",
-"577 273 OFFCURVE",
-"638 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"743 231 OFFCURVE",
-"743 160 CURVE SMOOTH",
-"743 89 OFFCURVE",
-"698 46 OFFCURVE",
-"638 46 CURVE SMOOTH"
-);
-}
-);
-visible = 1;
-width = 853;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"716 660 LINE",
-"636 712 LINE",
-"193 50 LINE",
-"271 -4 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"333 373 OFFCURVE",
-"402 452 OFFCURVE",
-"402 549 CURVE SMOOTH",
-"402 645 OFFCURVE",
-"333 724 OFFCURVE",
-"223 724 CURVE SMOOTH",
-"113 724 OFFCURVE",
-"43 645 OFFCURVE",
-"43 549 CURVE SMOOTH",
-"43 452 OFFCURVE",
-"113 373 OFFCURVE",
-"223 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 471 OFFCURVE",
-"151 499 OFFCURVE",
-"151 549 CURVE SMOOTH",
-"151 598 OFFCURVE",
-"184 626 OFFCURVE",
-"223 626 CURVE SMOOTH",
-"264 626 OFFCURVE",
-"294 598 OFFCURVE",
-"294 549 CURVE SMOOTH",
-"294 499 OFFCURVE",
-"264 471 OFFCURVE",
-"223 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"795 -16 OFFCURVE",
-"864 63 OFFCURVE",
-"864 160 CURVE SMOOTH",
-"864 256 OFFCURVE",
-"795 335 OFFCURVE",
-"685 335 CURVE SMOOTH",
-"574 335 OFFCURVE",
-"505 256 OFFCURVE",
-"505 160 CURVE SMOOTH",
-"505 63 OFFCURVE",
-"574 -16 OFFCURVE",
-"685 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"645 82 OFFCURVE",
-"613 110 OFFCURVE",
-"613 160 CURVE SMOOTH",
-"613 209 OFFCURVE",
-"645 237 OFFCURVE",
-"685 237 CURVE SMOOTH",
-"725 237 OFFCURVE",
-"756 209 OFFCURVE",
-"756 160 CURVE SMOOTH",
-"756 110 OFFCURVE",
-"725 82 OFFCURVE",
-"685 82 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "0E3EF83C-80C4-4CEE-9CC5-7563B6E57BE0";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"724 672 LINE",
-"644 724 LINE",
-"187 42 LINE",
-"265 -12 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"333 373 OFFCURVE",
-"402 452 OFFCURVE",
-"402 549 CURVE SMOOTH",
-"402 645 OFFCURVE",
-"333 724 OFFCURVE",
-"223 724 CURVE SMOOTH",
-"113 724 OFFCURVE",
-"43 645 OFFCURVE",
-"43 549 CURVE SMOOTH",
-"43 452 OFFCURVE",
-"113 373 OFFCURVE",
-"223 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 471 OFFCURVE",
-"151 499 OFFCURVE",
-"151 549 CURVE SMOOTH",
-"151 598 OFFCURVE",
-"184 626 OFFCURVE",
-"223 626 CURVE SMOOTH",
-"264 626 OFFCURVE",
-"294 598 OFFCURVE",
-"294 549 CURVE SMOOTH",
-"294 499 OFFCURVE",
-"264 471 OFFCURVE",
-"223 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"795 -16 OFFCURVE",
-"864 63 OFFCURVE",
-"864 160 CURVE SMOOTH",
-"864 256 OFFCURVE",
-"795 335 OFFCURVE",
-"685 335 CURVE SMOOTH",
-"574 335 OFFCURVE",
-"505 256 OFFCURVE",
-"505 160 CURVE SMOOTH",
-"505 63 OFFCURVE",
-"574 -16 OFFCURVE",
-"685 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"645 82 OFFCURVE",
-"613 110 OFFCURVE",
-"613 160 CURVE SMOOTH",
-"613 209 OFFCURVE",
-"645 237 OFFCURVE",
-"685 237 CURVE SMOOTH",
-"725 237 OFFCURVE",
-"756 209 OFFCURVE",
-"756 160 CURVE SMOOTH",
-"756 110 OFFCURVE",
-"725 82 OFFCURVE",
-"685 82 CURVE SMOOTH"
-);
-}
-);
-width = 907;
 }
 );
 leftKerningGroup = percent;
@@ -248993,7 +247900,7 @@ unicode = 0025;
 },
 {
 glyphname = pertenthousand;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:20 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -249565,300 +248472,6 @@ nodes = (
 }
 );
 width = 1429;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "9F7FA7CE-6FA8-4FD7-84C9-A053983F4A02";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"686 683 LINE",
-"633 719 LINE",
-"167 26 LINE",
-"221 -10 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"314 373 OFFCURVE",
-"388 446 OFFCURVE",
-"388 549 CURVE SMOOTH",
-"388 651 OFFCURVE",
-"314 724 OFFCURVE",
-"215 724 CURVE SMOOTH",
-"116 724 OFFCURVE",
-"42 651 OFFCURVE",
-"42 549 CURVE SMOOTH",
-"42 446 OFFCURVE",
-"116 373 OFFCURVE",
-"215 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"154 435 OFFCURVE",
-"110 478 OFFCURVE",
-"110 549 CURVE SMOOTH",
-"110 620 OFFCURVE",
-"154 662 OFFCURVE",
-"215 662 CURVE SMOOTH",
-"276 662 OFFCURVE",
-"320 620 OFFCURVE",
-"320 549 CURVE SMOOTH",
-"320 478 OFFCURVE",
-"276 435 OFFCURVE",
-"215 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 46 OFFCURVE",
-"533 89 OFFCURVE",
-"533 160 CURVE SMOOTH",
-"533 231 OFFCURVE",
-"577 273 OFFCURVE",
-"638 273 CURVE SMOOTH",
-"699 273 OFFCURVE",
-"743 231 OFFCURVE",
-"743 160 CURVE SMOOTH",
-"743 89 OFFCURVE",
-"699 46 OFFCURVE",
-"638 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"697 -16 OFFCURVE",
-"749 11 OFFCURVE",
-"778 61 CURVE",
-"807 11 OFFCURVE",
-"859 -16 OFFCURVE",
-"918 -16 CURVE SMOOTH",
-"977 -16 OFFCURVE",
-"1029 11 OFFCURVE",
-"1058 61 CURVE",
-"1087 11 OFFCURVE",
-"1139 -16 OFFCURVE",
-"1198 -16 CURVE SMOOTH",
-"1297 -16 OFFCURVE",
-"1371 57 OFFCURVE",
-"1371 160 CURVE SMOOTH",
-"1371 262 OFFCURVE",
-"1297 335 OFFCURVE",
-"1198 335 CURVE SMOOTH",
-"1139 335 OFFCURVE",
-"1087 308 OFFCURVE",
-"1058 258 CURVE",
-"1029 308 OFFCURVE",
-"977 335 OFFCURVE",
-"918 335 CURVE SMOOTH",
-"859 335 OFFCURVE",
-"807 308 OFFCURVE",
-"778 258 CURVE",
-"749 308 OFFCURVE",
-"697 335 OFFCURVE",
-"638 335 CURVE SMOOTH",
-"539 335 OFFCURVE",
-"465 262 OFFCURVE",
-"465 160 CURVE SMOOTH",
-"465 57 OFFCURVE",
-"539 -16 OFFCURVE",
-"638 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"857 46 OFFCURVE",
-"813 89 OFFCURVE",
-"813 160 CURVE SMOOTH",
-"813 231 OFFCURVE",
-"857 273 OFFCURVE",
-"918 273 CURVE SMOOTH",
-"979 273 OFFCURVE",
-"1023 231 OFFCURVE",
-"1023 160 CURVE SMOOTH",
-"1023 89 OFFCURVE",
-"979 46 OFFCURVE",
-"918 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1137 46 OFFCURVE",
-"1093 89 OFFCURVE",
-"1093 160 CURVE SMOOTH",
-"1093 231 OFFCURVE",
-"1137 273 OFFCURVE",
-"1198 273 CURVE SMOOTH",
-"1259 273 OFFCURVE",
-"1303 231 OFFCURVE",
-"1303 160 CURVE SMOOTH",
-"1303 89 OFFCURVE",
-"1259 46 OFFCURVE",
-"1198 46 CURVE SMOOTH"
-);
-}
-);
-width = 1413;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-components = (
-{
-name = perthousand;
-transform = "{1, 0, 0, 1, 2, 0}";
-}
-);
-};
-layerId = "E60F6630-477B-4A62-940D-6DC7B06C1F09";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"724 672 LINE",
-"644 724 LINE",
-"187 42 LINE",
-"265 -12 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"333 373 OFFCURVE",
-"402 452 OFFCURVE",
-"402 549 CURVE SMOOTH",
-"402 645 OFFCURVE",
-"333 724 OFFCURVE",
-"223 724 CURVE SMOOTH",
-"113 724 OFFCURVE",
-"43 645 OFFCURVE",
-"43 549 CURVE SMOOTH",
-"43 452 OFFCURVE",
-"113 373 OFFCURVE",
-"223 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"183 471 OFFCURVE",
-"151 499 OFFCURVE",
-"151 549 CURVE SMOOTH",
-"151 598 OFFCURVE",
-"183 626 OFFCURVE",
-"223 626 CURVE SMOOTH",
-"263 626 OFFCURVE",
-"294 598 OFFCURVE",
-"294 549 CURVE SMOOTH",
-"294 499 OFFCURVE",
-"263 471 OFFCURVE",
-"223 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"645 82 OFFCURVE",
-"612 110 OFFCURVE",
-"612 160 CURVE SMOOTH",
-"612 209 OFFCURVE",
-"645 237 OFFCURVE",
-"684 237 CURVE SMOOTH",
-"725 237 OFFCURVE",
-"756 209 OFFCURVE",
-"756 160 CURVE SMOOTH",
-"756 110 OFFCURVE",
-"725 82 OFFCURVE",
-"684 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"737 -16 OFFCURVE",
-"783 6 OFFCURVE",
-"811 41 CURVE",
-"839 6 OFFCURVE",
-"885 -16 OFFCURVE",
-"937 -16 CURVE SMOOTH",
-"989 -16 OFFCURVE",
-"1036 6 OFFCURVE",
-"1063 41 CURVE",
-"1092 6 OFFCURVE",
-"1138 -16 OFFCURVE",
-"1190 -16 CURVE SMOOTH",
-"1300 -16 OFFCURVE",
-"1369 63 OFFCURVE",
-"1369 160 CURVE SMOOTH",
-"1369 256 OFFCURVE",
-"1300 335 OFFCURVE",
-"1190 335 CURVE SMOOTH",
-"1138 335 OFFCURVE",
-"1092 313 OFFCURVE",
-"1063 278 CURVE",
-"1036 313 OFFCURVE",
-"989 335 OFFCURVE",
-"937 335 CURVE SMOOTH",
-"885 335 OFFCURVE",
-"839 313 OFFCURVE",
-"811 278 CURVE",
-"783 313 OFFCURVE",
-"737 335 OFFCURVE",
-"684 335 CURVE SMOOTH",
-"574 335 OFFCURVE",
-"505 256 OFFCURVE",
-"505 160 CURVE SMOOTH",
-"505 63 OFFCURVE",
-"574 -16 OFFCURVE",
-"684 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"898 82 OFFCURVE",
-"865 110 OFFCURVE",
-"865 160 CURVE SMOOTH",
-"865 209 OFFCURVE",
-"898 237 OFFCURVE",
-"937 237 CURVE SMOOTH",
-"978 237 OFFCURVE",
-"1009 209 OFFCURVE",
-"1009 160 CURVE SMOOTH",
-"1009 110 OFFCURVE",
-"978 82 OFFCURVE",
-"937 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1151 82 OFFCURVE",
-"1118 110 OFFCURVE",
-"1118 160 CURVE SMOOTH",
-"1118 209 OFFCURVE",
-"1151 237 OFFCURVE",
-"1190 237 CURVE SMOOTH",
-"1231 237 OFFCURVE",
-"1262 209 OFFCURVE",
-"1262 160 CURVE SMOOTH",
-"1262 110 OFFCURVE",
-"1231 82 OFFCURVE",
-"1190 82 CURVE SMOOTH"
-);
-}
-);
-width = 1412;
 }
 );
 leftKerningGroup = percent;
@@ -249868,7 +248481,7 @@ unicode = 2031;
 },
 {
 glyphname = perthousand;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:23 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -250432,349 +249045,6 @@ nodes = (
 }
 );
 width = 1176;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"711 716 LINE",
-"634 716 LINE",
-"151 0 LINE",
-"229 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"317 378 OFFCURVE",
-"391 449 OFFCURVE",
-"391 555 CURVE SMOOTH",
-"391 661 OFFCURVE",
-"317 732 OFFCURVE",
-"217 732 CURVE SMOOTH",
-"117 732 OFFCURVE",
-"43 661 OFFCURVE",
-"43 555 CURVE SMOOTH",
-"43 449 OFFCURVE",
-"117 378 OFFCURVE",
-"217 378 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"155 440 OFFCURVE",
-"111 481 OFFCURVE",
-"111 555 CURVE SMOOTH",
-"111 629 OFFCURVE",
-"155 670 OFFCURVE",
-"217 670 CURVE SMOOTH",
-"279 670 OFFCURVE",
-"323 629 OFFCURVE",
-"323 555 CURVE SMOOTH",
-"323 481 OFFCURVE",
-"279 440 OFFCURVE",
-"217 440 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"745 -16 OFFCURVE",
-"819 55 OFFCURVE",
-"819 161 CURVE SMOOTH",
-"819 267 OFFCURVE",
-"745 338 OFFCURVE",
-"645 338 CURVE SMOOTH",
-"545 338 OFFCURVE",
-"471 267 OFFCURVE",
-"471 161 CURVE SMOOTH",
-"471 55 OFFCURVE",
-"545 -16 OFFCURVE",
-"645 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"583 46 OFFCURVE",
-"539 87 OFFCURVE",
-"539 161 CURVE SMOOTH",
-"539 235 OFFCURVE",
-"583 276 OFFCURVE",
-"645 276 CURVE SMOOTH",
-"707 276 OFFCURVE",
-"751 235 OFFCURVE",
-"751 161 CURVE SMOOTH",
-"751 87 OFFCURVE",
-"707 46 OFFCURVE",
-"645 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1025 -16 OFFCURVE",
-"1099 55 OFFCURVE",
-"1099 161 CURVE SMOOTH",
-"1099 267 OFFCURVE",
-"1025 338 OFFCURVE",
-"925 338 CURVE SMOOTH",
-"825 338 OFFCURVE",
-"751 267 OFFCURVE",
-"751 161 CURVE SMOOTH",
-"751 55 OFFCURVE",
-"825 -16 OFFCURVE",
-"925 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"863 46 OFFCURVE",
-"819 87 OFFCURVE",
-"819 161 CURVE SMOOTH",
-"819 235 OFFCURVE",
-"863 276 OFFCURVE",
-"925 276 CURVE SMOOTH",
-"987 276 OFFCURVE",
-"1031 235 OFFCURVE",
-"1031 161 CURVE SMOOTH",
-"1031 87 OFFCURVE",
-"987 46 OFFCURVE",
-"925 46 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "A457451A-36F6-4FA9-96D8-4BCD6E3071A9";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"686 683 LINE",
-"633 719 LINE",
-"167 26 LINE",
-"221 -10 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"314 373 OFFCURVE",
-"388 446 OFFCURVE",
-"388 549 CURVE SMOOTH",
-"388 651 OFFCURVE",
-"314 724 OFFCURVE",
-"215 724 CURVE SMOOTH",
-"116 724 OFFCURVE",
-"42 651 OFFCURVE",
-"42 549 CURVE SMOOTH",
-"42 446 OFFCURVE",
-"116 373 OFFCURVE",
-"215 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"154 435 OFFCURVE",
-"110 478 OFFCURVE",
-"110 549 CURVE SMOOTH",
-"110 620 OFFCURVE",
-"154 662 OFFCURVE",
-"215 662 CURVE SMOOTH",
-"276 662 OFFCURVE",
-"320 620 OFFCURVE",
-"320 549 CURVE SMOOTH",
-"320 478 OFFCURVE",
-"276 435 OFFCURVE",
-"215 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 46 OFFCURVE",
-"533 89 OFFCURVE",
-"533 160 CURVE SMOOTH",
-"533 231 OFFCURVE",
-"577 273 OFFCURVE",
-"638 273 CURVE SMOOTH",
-"699 273 OFFCURVE",
-"743 231 OFFCURVE",
-"743 160 CURVE SMOOTH",
-"743 89 OFFCURVE",
-"699 46 OFFCURVE",
-"638 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"697 -16 OFFCURVE",
-"749 11 OFFCURVE",
-"778 61 CURVE",
-"807 11 OFFCURVE",
-"859 -16 OFFCURVE",
-"918 -16 CURVE SMOOTH",
-"1017 -16 OFFCURVE",
-"1091 57 OFFCURVE",
-"1091 160 CURVE SMOOTH",
-"1091 262 OFFCURVE",
-"1017 335 OFFCURVE",
-"918 335 CURVE SMOOTH",
-"859 335 OFFCURVE",
-"807 308 OFFCURVE",
-"778 258 CURVE",
-"749 308 OFFCURVE",
-"697 335 OFFCURVE",
-"638 335 CURVE SMOOTH",
-"539 335 OFFCURVE",
-"465 262 OFFCURVE",
-"465 160 CURVE SMOOTH",
-"465 57 OFFCURVE",
-"539 -16 OFFCURVE",
-"638 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"857 46 OFFCURVE",
-"813 89 OFFCURVE",
-"813 160 CURVE SMOOTH",
-"813 231 OFFCURVE",
-"857 273 OFFCURVE",
-"918 273 CURVE SMOOTH",
-"979 273 OFFCURVE",
-"1023 231 OFFCURVE",
-"1023 160 CURVE SMOOTH",
-"1023 89 OFFCURVE",
-"979 46 OFFCURVE",
-"918 46 CURVE SMOOTH"
-);
-}
-);
-width = 1133;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "FF18C846-6E69-4AE9-A9D0-9C7D27CB32DD";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"724 672 LINE",
-"644 724 LINE",
-"187 42 LINE",
-"265 -12 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"333 373 OFFCURVE",
-"402 452 OFFCURVE",
-"402 549 CURVE SMOOTH",
-"402 645 OFFCURVE",
-"333 724 OFFCURVE",
-"223 724 CURVE SMOOTH",
-"113 724 OFFCURVE",
-"43 645 OFFCURVE",
-"43 549 CURVE SMOOTH",
-"43 452 OFFCURVE",
-"113 373 OFFCURVE",
-"223 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"184 471 OFFCURVE",
-"151 499 OFFCURVE",
-"151 549 CURVE SMOOTH",
-"151 598 OFFCURVE",
-"184 626 OFFCURVE",
-"223 626 CURVE SMOOTH",
-"264 626 OFFCURVE",
-"294 598 OFFCURVE",
-"294 549 CURVE SMOOTH",
-"294 499 OFFCURVE",
-"264 471 OFFCURVE",
-"223 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"645 82 OFFCURVE",
-"613 110 OFFCURVE",
-"613 160 CURVE SMOOTH",
-"613 209 OFFCURVE",
-"645 237 OFFCURVE",
-"685 237 CURVE SMOOTH",
-"725 237 OFFCURVE",
-"756 209 OFFCURVE",
-"756 160 CURVE SMOOTH",
-"756 110 OFFCURVE",
-"725 82 OFFCURVE",
-"685 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"737 -16 OFFCURVE",
-"783 6 OFFCURVE",
-"811 41 CURVE",
-"839 6 OFFCURVE",
-"885 -16 OFFCURVE",
-"937 -16 CURVE SMOOTH",
-"1048 -16 OFFCURVE",
-"1117 63 OFFCURVE",
-"1117 160 CURVE SMOOTH",
-"1117 256 OFFCURVE",
-"1048 335 OFFCURVE",
-"937 335 CURVE SMOOTH",
-"885 335 OFFCURVE",
-"839 313 OFFCURVE",
-"811 278 CURVE",
-"783 313 OFFCURVE",
-"737 335 OFFCURVE",
-"685 335 CURVE SMOOTH",
-"574 335 OFFCURVE",
-"505 256 OFFCURVE",
-"505 160 CURVE SMOOTH",
-"505 63 OFFCURVE",
-"574 -16 OFFCURVE",
-"685 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"898 82 OFFCURVE",
-"865 110 OFFCURVE",
-"865 160 CURVE SMOOTH",
-"865 209 OFFCURVE",
-"898 237 OFFCURVE",
-"937 237 CURVE SMOOTH",
-"978 237 OFFCURVE",
-"1008 209 OFFCURVE",
-"1008 160 CURVE SMOOTH",
-"1008 110 OFFCURVE",
-"978 82 OFFCURVE",
-"937 82 CURVE SMOOTH"
-);
-}
-);
-width = 1160;
 }
 );
 leftKerningGroup = percent;
@@ -250784,7 +249054,7 @@ unicode = 2030;
 },
 {
 glyphname = percent.cap;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:27 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -251117,346 +249387,13 @@ nodes = (
 }
 );
 width = 923;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"682 682 LINE",
-"629 718 LINE",
-"169 34 LINE",
-"222 -2 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 381 OFFCURVE",
-"387 454 OFFCURVE",
-"387 557 CURVE SMOOTH",
-"387 659 OFFCURVE",
-"313 732 OFFCURVE",
-"214 732 CURVE SMOOTH",
-"115 732 OFFCURVE",
-"41 659 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 454 OFFCURVE",
-"115 381 OFFCURVE",
-"214 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"153 443 OFFCURVE",
-"109 486 OFFCURVE",
-"109 557 CURVE SMOOTH",
-"109 628 OFFCURVE",
-"153 670 OFFCURVE",
-"214 670 CURVE SMOOTH",
-"275 670 OFFCURVE",
-"319 628 OFFCURVE",
-"319 557 CURVE SMOOTH",
-"319 486 OFFCURVE",
-"275 443 OFFCURVE",
-"214 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"736 -16 OFFCURVE",
-"810 57 OFFCURVE",
-"810 160 CURVE SMOOTH",
-"810 262 OFFCURVE",
-"736 335 OFFCURVE",
-"637 335 CURVE SMOOTH",
-"538 335 OFFCURVE",
-"464 262 OFFCURVE",
-"464 160 CURVE SMOOTH",
-"464 57 OFFCURVE",
-"538 -16 OFFCURVE",
-"637 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 46 OFFCURVE",
-"532 89 OFFCURVE",
-"532 160 CURVE SMOOTH",
-"532 231 OFFCURVE",
-"576 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"637 46 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "9883A2B4-57D9-416F-99DF-63F2DB979C5D";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"686 688 LINE",
-"633 724 LINE",
-"165 28 LINE",
-"218 -8 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 381 OFFCURVE",
-"387 454 OFFCURVE",
-"387 557 CURVE SMOOTH",
-"387 659 OFFCURVE",
-"313 732 OFFCURVE",
-"214 732 CURVE SMOOTH",
-"115 732 OFFCURVE",
-"41 659 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 454 OFFCURVE",
-"115 381 OFFCURVE",
-"214 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"153 443 OFFCURVE",
-"109 486 OFFCURVE",
-"109 557 CURVE SMOOTH",
-"109 628 OFFCURVE",
-"153 670 OFFCURVE",
-"214 670 CURVE SMOOTH",
-"275 670 OFFCURVE",
-"319 628 OFFCURVE",
-"319 557 CURVE SMOOTH",
-"319 486 OFFCURVE",
-"275 443 OFFCURVE",
-"214 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"736 -16 OFFCURVE",
-"810 57 OFFCURVE",
-"810 160 CURVE SMOOTH",
-"810 262 OFFCURVE",
-"736 335 OFFCURVE",
-"637 335 CURVE SMOOTH",
-"538 335 OFFCURVE",
-"464 262 OFFCURVE",
-"464 160 CURVE SMOOTH",
-"464 57 OFFCURVE",
-"538 -16 OFFCURVE",
-"637 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 46 OFFCURVE",
-"532 89 OFFCURVE",
-"532 160 CURVE SMOOTH",
-"532 231 OFFCURVE",
-"576 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"637 46 CURVE SMOOTH"
-);
-}
-);
-visible = 1;
-width = 851;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"714 667 LINE",
-"635 720 LINE",
-"186 49 LINE",
-"264 -4 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 381 OFFCURVE",
-"400 460 OFFCURVE",
-"400 557 CURVE SMOOTH",
-"400 653 OFFCURVE",
-"331 732 OFFCURVE",
-"221 732 CURVE SMOOTH",
-"111 732 OFFCURVE",
-"41 653 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 460 OFFCURVE",
-"111 381 OFFCURVE",
-"221 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 479 OFFCURVE",
-"149 507 OFFCURVE",
-"149 557 CURVE SMOOTH",
-"149 606 OFFCURVE",
-"181 634 OFFCURVE",
-"221 634 CURVE SMOOTH",
-"261 634 OFFCURVE",
-"292 606 OFFCURVE",
-"292 557 CURVE SMOOTH",
-"292 507 OFFCURVE",
-"261 479 OFFCURVE",
-"221 479 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"789 -16 OFFCURVE",
-"858 63 OFFCURVE",
-"858 160 CURVE SMOOTH",
-"858 256 OFFCURVE",
-"789 335 OFFCURVE",
-"679 335 CURVE SMOOTH",
-"569 335 OFFCURVE",
-"499 256 OFFCURVE",
-"499 160 CURVE SMOOTH",
-"499 63 OFFCURVE",
-"569 -16 OFFCURVE",
-"679 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"639 82 OFFCURVE",
-"607 110 OFFCURVE",
-"607 160 CURVE SMOOTH",
-"607 209 OFFCURVE",
-"639 237 OFFCURVE",
-"679 237 CURVE SMOOTH",
-"719 237 OFFCURVE",
-"750 209 OFFCURVE",
-"750 160 CURVE SMOOTH",
-"750 110 OFFCURVE",
-"719 82 OFFCURVE",
-"679 82 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "C4A37500-5690-44EE-97DA-CEA3FDBDA09D";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"718 673 LINE",
-"639 726 LINE",
-"181 42 LINE",
-"259 -11 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 381 OFFCURVE",
-"400 460 OFFCURVE",
-"400 557 CURVE SMOOTH",
-"400 653 OFFCURVE",
-"331 732 OFFCURVE",
-"221 732 CURVE SMOOTH",
-"111 732 OFFCURVE",
-"41 653 OFFCURVE",
-"41 557 CURVE SMOOTH",
-"41 460 OFFCURVE",
-"111 381 OFFCURVE",
-"221 381 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 479 OFFCURVE",
-"149 507 OFFCURVE",
-"149 557 CURVE SMOOTH",
-"149 606 OFFCURVE",
-"181 634 OFFCURVE",
-"221 634 CURVE SMOOTH",
-"261 634 OFFCURVE",
-"292 606 OFFCURVE",
-"292 557 CURVE SMOOTH",
-"292 507 OFFCURVE",
-"261 479 OFFCURVE",
-"221 479 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"789 -16 OFFCURVE",
-"858 63 OFFCURVE",
-"858 160 CURVE SMOOTH",
-"858 256 OFFCURVE",
-"789 335 OFFCURVE",
-"679 335 CURVE SMOOTH",
-"569 335 OFFCURVE",
-"499 256 OFFCURVE",
-"499 160 CURVE SMOOTH",
-"499 63 OFFCURVE",
-"569 -16 OFFCURVE",
-"679 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"639 82 OFFCURVE",
-"607 110 OFFCURVE",
-"607 160 CURVE SMOOTH",
-"607 209 OFFCURVE",
-"639 237 OFFCURVE",
-"679 237 CURVE SMOOTH",
-"719 237 OFFCURVE",
-"750 209 OFFCURVE",
-"750 160 CURVE SMOOTH",
-"750 110 OFFCURVE",
-"719 82 OFFCURVE",
-"679 82 CURVE SMOOTH"
-);
-}
-);
-width = 899;
 }
 );
 leftKerningGroup = percent.cap;
 },
 {
 glyphname = pertenthousand.cap;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:31 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -252021,299 +249958,13 @@ nodes = (
 }
 );
 width = 1429;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "0D0F65E5-2840-487E-9756-611439096161";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"688 688 LINE",
-"635 724 LINE",
-"167 28 LINE",
-"220 -8 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 373 OFFCURVE",
-"387 446 OFFCURVE",
-"387 549 CURVE SMOOTH",
-"387 651 OFFCURVE",
-"313 724 OFFCURVE",
-"214 724 CURVE SMOOTH",
-"115 724 OFFCURVE",
-"41 651 OFFCURVE",
-"41 549 CURVE SMOOTH",
-"41 446 OFFCURVE",
-"115 373 OFFCURVE",
-"214 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"153 435 OFFCURVE",
-"109 478 OFFCURVE",
-"109 549 CURVE SMOOTH",
-"109 620 OFFCURVE",
-"153 662 OFFCURVE",
-"214 662 CURVE SMOOTH",
-"275 662 OFFCURVE",
-"319 620 OFFCURVE",
-"319 549 CURVE SMOOTH",
-"319 478 OFFCURVE",
-"275 435 OFFCURVE",
-"214 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 46 OFFCURVE",
-"532 89 OFFCURVE",
-"532 160 CURVE SMOOTH",
-"532 231 OFFCURVE",
-"576 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"637 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"696 -16 OFFCURVE",
-"748 11 OFFCURVE",
-"777 61 CURVE",
-"806 11 OFFCURVE",
-"858 -16 OFFCURVE",
-"917 -16 CURVE SMOOTH",
-"976 -16 OFFCURVE",
-"1028 11 OFFCURVE",
-"1057 61 CURVE",
-"1086 11 OFFCURVE",
-"1138 -16 OFFCURVE",
-"1197 -16 CURVE SMOOTH",
-"1296 -16 OFFCURVE",
-"1370 57 OFFCURVE",
-"1370 160 CURVE SMOOTH",
-"1370 262 OFFCURVE",
-"1296 335 OFFCURVE",
-"1197 335 CURVE SMOOTH",
-"1138 335 OFFCURVE",
-"1086 308 OFFCURVE",
-"1057 258 CURVE",
-"1028 308 OFFCURVE",
-"976 335 OFFCURVE",
-"917 335 CURVE SMOOTH",
-"858 335 OFFCURVE",
-"806 308 OFFCURVE",
-"777 258 CURVE",
-"748 308 OFFCURVE",
-"696 335 OFFCURVE",
-"637 335 CURVE SMOOTH",
-"538 335 OFFCURVE",
-"464 262 OFFCURVE",
-"464 160 CURVE SMOOTH",
-"464 57 OFFCURVE",
-"538 -16 OFFCURVE",
-"637 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"856 46 OFFCURVE",
-"812 89 OFFCURVE",
-"812 160 CURVE SMOOTH",
-"812 231 OFFCURVE",
-"856 273 OFFCURVE",
-"917 273 CURVE SMOOTH",
-"978 273 OFFCURVE",
-"1022 231 OFFCURVE",
-"1022 160 CURVE SMOOTH",
-"1022 89 OFFCURVE",
-"978 46 OFFCURVE",
-"917 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1136 46 OFFCURVE",
-"1092 89 OFFCURVE",
-"1092 160 CURVE SMOOTH",
-"1092 231 OFFCURVE",
-"1136 273 OFFCURVE",
-"1197 273 CURVE SMOOTH",
-"1258 273 OFFCURVE",
-"1302 231 OFFCURVE",
-"1302 160 CURVE SMOOTH",
-"1302 89 OFFCURVE",
-"1258 46 OFFCURVE",
-"1197 46 CURVE SMOOTH"
-);
-}
-);
-width = 1411;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "5962BD75-AF13-48DF-B2D7-D1E91F757CA5";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"723 673 LINE",
-"644 726 LINE",
-"186 42 LINE",
-"264 -11 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 373 OFFCURVE",
-"400 452 OFFCURVE",
-"400 549 CURVE SMOOTH",
-"400 645 OFFCURVE",
-"331 724 OFFCURVE",
-"221 724 CURVE SMOOTH",
-"111 724 OFFCURVE",
-"41 645 OFFCURVE",
-"41 549 CURVE SMOOTH",
-"41 452 OFFCURVE",
-"111 373 OFFCURVE",
-"221 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 471 OFFCURVE",
-"149 499 OFFCURVE",
-"149 549 CURVE SMOOTH",
-"149 598 OFFCURVE",
-"181 626 OFFCURVE",
-"221 626 CURVE SMOOTH",
-"261 626 OFFCURVE",
-"292 598 OFFCURVE",
-"292 549 CURVE SMOOTH",
-"292 499 OFFCURVE",
-"261 471 OFFCURVE",
-"221 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"643 82 OFFCURVE",
-"610 110 OFFCURVE",
-"610 160 CURVE SMOOTH",
-"610 209 OFFCURVE",
-"643 237 OFFCURVE",
-"682 237 CURVE SMOOTH",
-"723 237 OFFCURVE",
-"754 209 OFFCURVE",
-"754 160 CURVE SMOOTH",
-"754 110 OFFCURVE",
-"723 82 OFFCURVE",
-"682 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"735 -16 OFFCURVE",
-"781 6 OFFCURVE",
-"809 41 CURVE",
-"837 6 OFFCURVE",
-"883 -16 OFFCURVE",
-"935 -16 CURVE SMOOTH",
-"987 -16 OFFCURVE",
-"1034 6 OFFCURVE",
-"1061 41 CURVE",
-"1090 6 OFFCURVE",
-"1136 -16 OFFCURVE",
-"1188 -16 CURVE SMOOTH",
-"1298 -16 OFFCURVE",
-"1367 63 OFFCURVE",
-"1367 160 CURVE SMOOTH",
-"1367 256 OFFCURVE",
-"1298 335 OFFCURVE",
-"1188 335 CURVE SMOOTH",
-"1136 335 OFFCURVE",
-"1090 313 OFFCURVE",
-"1061 278 CURVE",
-"1034 313 OFFCURVE",
-"987 335 OFFCURVE",
-"935 335 CURVE SMOOTH",
-"883 335 OFFCURVE",
-"837 313 OFFCURVE",
-"809 278 CURVE",
-"781 313 OFFCURVE",
-"735 335 OFFCURVE",
-"682 335 CURVE SMOOTH",
-"572 335 OFFCURVE",
-"503 256 OFFCURVE",
-"503 160 CURVE SMOOTH",
-"503 63 OFFCURVE",
-"572 -16 OFFCURVE",
-"682 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"896 82 OFFCURVE",
-"863 110 OFFCURVE",
-"863 160 CURVE SMOOTH",
-"863 209 OFFCURVE",
-"896 237 OFFCURVE",
-"935 237 CURVE SMOOTH",
-"976 237 OFFCURVE",
-"1007 209 OFFCURVE",
-"1007 160 CURVE SMOOTH",
-"1007 110 OFFCURVE",
-"976 82 OFFCURVE",
-"935 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1149 82 OFFCURVE",
-"1116 110 OFFCURVE",
-"1116 160 CURVE SMOOTH",
-"1116 209 OFFCURVE",
-"1149 237 OFFCURVE",
-"1188 237 CURVE SMOOTH",
-"1229 237 OFFCURVE",
-"1260 209 OFFCURVE",
-"1260 160 CURVE SMOOTH",
-"1260 110 OFFCURVE",
-"1229 82 OFFCURVE",
-"1188 82 CURVE SMOOTH"
-);
-}
-);
-width = 1408;
 }
 );
 leftKerningGroup = percent.cap;
 },
 {
 glyphname = perthousand.cap;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:34 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -252762,234 +250413,6 @@ nodes = (
 }
 );
 width = 1176;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "31534B8C-FF06-4D9F-9322-08E28D5114AA";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"688 688 LINE",
-"635 724 LINE",
-"167 28 LINE",
-"220 -8 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"313 373 OFFCURVE",
-"387 446 OFFCURVE",
-"387 549 CURVE SMOOTH",
-"387 651 OFFCURVE",
-"313 724 OFFCURVE",
-"214 724 CURVE SMOOTH",
-"115 724 OFFCURVE",
-"41 651 OFFCURVE",
-"41 549 CURVE SMOOTH",
-"41 446 OFFCURVE",
-"115 373 OFFCURVE",
-"214 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"153 435 OFFCURVE",
-"109 478 OFFCURVE",
-"109 549 CURVE SMOOTH",
-"109 620 OFFCURVE",
-"153 662 OFFCURVE",
-"214 662 CURVE SMOOTH",
-"275 662 OFFCURVE",
-"319 620 OFFCURVE",
-"319 549 CURVE SMOOTH",
-"319 478 OFFCURVE",
-"275 435 OFFCURVE",
-"214 435 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 46 OFFCURVE",
-"532 89 OFFCURVE",
-"532 160 CURVE SMOOTH",
-"532 231 OFFCURVE",
-"576 273 OFFCURVE",
-"637 273 CURVE SMOOTH",
-"698 273 OFFCURVE",
-"742 231 OFFCURVE",
-"742 160 CURVE SMOOTH",
-"742 89 OFFCURVE",
-"698 46 OFFCURVE",
-"637 46 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"696 -16 OFFCURVE",
-"748 11 OFFCURVE",
-"777 61 CURVE",
-"806 11 OFFCURVE",
-"858 -16 OFFCURVE",
-"917 -16 CURVE SMOOTH",
-"1016 -16 OFFCURVE",
-"1090 57 OFFCURVE",
-"1090 160 CURVE SMOOTH",
-"1090 262 OFFCURVE",
-"1016 335 OFFCURVE",
-"917 335 CURVE SMOOTH",
-"858 335 OFFCURVE",
-"806 308 OFFCURVE",
-"777 258 CURVE",
-"748 308 OFFCURVE",
-"696 335 OFFCURVE",
-"637 335 CURVE SMOOTH",
-"538 335 OFFCURVE",
-"464 262 OFFCURVE",
-"464 160 CURVE SMOOTH",
-"464 57 OFFCURVE",
-"538 -16 OFFCURVE",
-"637 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"856 46 OFFCURVE",
-"812 89 OFFCURVE",
-"812 160 CURVE SMOOTH",
-"812 231 OFFCURVE",
-"856 273 OFFCURVE",
-"917 273 CURVE SMOOTH",
-"978 273 OFFCURVE",
-"1022 231 OFFCURVE",
-"1022 160 CURVE SMOOTH",
-"1022 89 OFFCURVE",
-"978 46 OFFCURVE",
-"917 46 CURVE SMOOTH"
-);
-}
-);
-width = 1131;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "94AC9435-7EC8-4480-907B-DC59DD190AD6";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"723 673 LINE",
-"644 726 LINE",
-"186 42 LINE",
-"264 -11 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 373 OFFCURVE",
-"400 452 OFFCURVE",
-"400 549 CURVE SMOOTH",
-"400 645 OFFCURVE",
-"331 724 OFFCURVE",
-"221 724 CURVE SMOOTH",
-"111 724 OFFCURVE",
-"41 645 OFFCURVE",
-"41 549 CURVE SMOOTH",
-"41 452 OFFCURVE",
-"111 373 OFFCURVE",
-"221 373 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"182 471 OFFCURVE",
-"149 499 OFFCURVE",
-"149 549 CURVE SMOOTH",
-"149 598 OFFCURVE",
-"182 626 OFFCURVE",
-"221 626 CURVE SMOOTH",
-"262 626 OFFCURVE",
-"292 598 OFFCURVE",
-"292 549 CURVE SMOOTH",
-"292 499 OFFCURVE",
-"262 471 OFFCURVE",
-"221 471 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"643 82 OFFCURVE",
-"611 110 OFFCURVE",
-"611 160 CURVE SMOOTH",
-"611 209 OFFCURVE",
-"643 237 OFFCURVE",
-"683 237 CURVE SMOOTH",
-"723 237 OFFCURVE",
-"754 209 OFFCURVE",
-"754 160 CURVE SMOOTH",
-"754 110 OFFCURVE",
-"723 82 OFFCURVE",
-"683 82 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"735 -16 OFFCURVE",
-"781 6 OFFCURVE",
-"809 41 CURVE",
-"837 6 OFFCURVE",
-"883 -16 OFFCURVE",
-"935 -16 CURVE SMOOTH",
-"1046 -16 OFFCURVE",
-"1115 63 OFFCURVE",
-"1115 160 CURVE SMOOTH",
-"1115 256 OFFCURVE",
-"1046 335 OFFCURVE",
-"935 335 CURVE SMOOTH",
-"883 335 OFFCURVE",
-"837 313 OFFCURVE",
-"809 278 CURVE",
-"781 313 OFFCURVE",
-"735 335 OFFCURVE",
-"683 335 CURVE SMOOTH",
-"572 335 OFFCURVE",
-"503 256 OFFCURVE",
-"503 160 CURVE SMOOTH",
-"503 63 OFFCURVE",
-"572 -16 OFFCURVE",
-"683 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"896 82 OFFCURVE",
-"863 110 OFFCURVE",
-"863 160 CURVE SMOOTH",
-"863 209 OFFCURVE",
-"896 237 OFFCURVE",
-"935 237 CURVE SMOOTH",
-"976 237 OFFCURVE",
-"1006 209 OFFCURVE",
-"1006 160 CURVE SMOOTH",
-"1006 110 OFFCURVE",
-"976 82 OFFCURVE",
-"935 82 CURVE SMOOTH"
-);
-}
-);
-width = 1156;
 }
 );
 leftKerningGroup = percent.cap;
@@ -253610,7 +251033,7 @@ width = 600;
 },
 {
 glyphname = percent.tf;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:41 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -253939,177 +251362,6 @@ nodes = (
 "210 553 OFFCURVE",
 "185 529 OFFCURVE",
 "149 529 CURVE SMOOTH"
-);
-}
-);
-width = 600;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "6A5FBBEA-E624-4ED2-BE68-9B2CC5D88181";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"553 684 LINE",
-"500 719 LINE",
-"47 25 LINE",
-"101 -10 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"231 443 OFFCURVE",
-"290 500 OFFCURVE",
-"290 584 CURVE SMOOTH",
-"290 668 OFFCURVE",
-"231 724 OFFCURVE",
-"151 724 CURVE SMOOTH",
-"70 724 OFFCURVE",
-"10 668 OFFCURVE",
-"10 584 CURVE SMOOTH",
-"10 500 OFFCURVE",
-"70 443 OFFCURVE",
-"151 443 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"531 -16 OFFCURVE",
-"590 41 OFFCURVE",
-"590 125 CURVE SMOOTH",
-"590 209 OFFCURVE",
-"531 265 OFFCURVE",
-"451 265 CURVE SMOOTH",
-"370 265 OFFCURVE",
-"310 209 OFFCURVE",
-"310 125 CURVE SMOOTH",
-"310 41 OFFCURVE",
-"370 -16 OFFCURVE",
-"451 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"406 43 OFFCURVE",
-"373 75 OFFCURVE",
-"373 125 CURVE SMOOTH",
-"373 174 OFFCURVE",
-"406 206 OFFCURVE",
-"451 206 CURVE SMOOTH",
-"496 206 OFFCURVE",
-"527 174 OFFCURVE",
-"527 125 CURVE SMOOTH",
-"527 75 OFFCURVE",
-"496 43 OFFCURVE",
-"451 43 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"106 502 OFFCURVE",
-"73 534 OFFCURVE",
-"73 584 CURVE SMOOTH",
-"73 633 OFFCURVE",
-"106 665 OFFCURVE",
-"151 665 CURVE SMOOTH",
-"196 665 OFFCURVE",
-"227 633 OFFCURVE",
-"227 584 CURVE SMOOTH",
-"227 534 OFFCURVE",
-"196 502 OFFCURVE",
-"151 502 CURVE SMOOTH"
-);
-}
-);
-visible = 1;
-width = 600;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "63AB594E-32FB-4B42-A380-2248073340A3";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"567 672 LINE",
-"487 724 LINE",
-"36 39 LINE",
-"116 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"234 441 OFFCURVE",
-"296 501 OFFCURVE",
-"296 582 CURVE SMOOTH",
-"296 664 OFFCURVE",
-"234 724 OFFCURVE",
-"151 724 CURVE SMOOTH",
-"67 724 OFFCURVE",
-"5 664 OFFCURVE",
-"5 582 CURVE SMOOTH",
-"5 501 OFFCURVE",
-"67 441 OFFCURVE",
-"151 441 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"534 -16 OFFCURVE",
-"595 44 OFFCURVE",
-"595 125 CURVE SMOOTH",
-"595 207 OFFCURVE",
-"534 267 OFFCURVE",
-"450 267 CURVE SMOOTH",
-"366 267 OFFCURVE",
-"304 207 OFFCURVE",
-"304 125 CURVE SMOOTH",
-"304 44 OFFCURVE",
-"366 -16 OFFCURVE",
-"450 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"415 66 OFFCURVE",
-"390 91 OFFCURVE",
-"390 125 CURVE SMOOTH",
-"390 160 OFFCURVE",
-"415 184 OFFCURVE",
-"450 184 CURVE SMOOTH",
-"484 184 OFFCURVE",
-"509 160 OFFCURVE",
-"509 125 CURVE SMOOTH",
-"509 91 OFFCURVE",
-"484 66 OFFCURVE",
-"450 66 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"116 523 OFFCURVE",
-"91 547 OFFCURVE",
-"91 582 CURVE SMOOTH",
-"91 617 OFFCURVE",
-"116 641 OFFCURVE",
-"151 641 CURVE SMOOTH",
-"185 641 OFFCURVE",
-"210 617 OFFCURVE",
-"210 582 CURVE SMOOTH",
-"210 547 OFFCURVE",
-"185 523 OFFCURVE",
-"151 523 CURVE SMOOTH"
 );
 }
 );
@@ -257236,7 +254488,7 @@ unicode = 0040;
 },
 {
 glyphname = ampersand;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:48:50 +0000";
 layers = (
 {
 layerId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
@@ -257505,144 +254757,6 @@ nodes = (
 }
 );
 width = 738;
-},
-{
-associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
-layerId = "D869E4BE-EF08-4DB8-9AE2-53CEB1A15455";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"615 35 LINE",
-"252 463 LINE SMOOTH",
-"226 494 OFFCURVE",
-"212 526 OFFCURVE",
-"212 562 CURVE SMOOTH",
-"212 618 OFFCURVE",
-"258 651 OFFCURVE",
-"312 651 CURVE SMOOTH",
-"371 651 OFFCURVE",
-"402 614 OFFCURVE",
-"413 564 CURVE",
-"492 583 LINE",
-"477 671 OFFCURVE",
-"416 732 OFFCURVE",
-"312 732 CURVE SMOOTH",
-"211 732 OFFCURVE",
-"127 659 OFFCURVE",
-"127 562 CURVE SMOOTH",
-"127 508 OFFCURVE",
-"149 461 OFFCURVE",
-"195 407 CURVE SMOOTH",
-"551 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"392 -16 OFFCURVE",
-"467 28 OFFCURVE",
-"517 95 CURVE",
-"467 159 LINE",
-"429 99 OFFCURVE",
-"374 61 OFFCURVE",
-"297 61 CURVE SMOOTH",
-"203 61 OFFCURVE",
-"132 126 OFFCURVE",
-"132 217 CURVE SMOOTH",
-"132 299 OFFCURVE",
-"183 356 OFFCURVE",
-"267 388 CURVE",
-"221 446 LINE",
-"110 402 OFFCURVE",
-"51 313 OFFCURVE",
-"51 214 CURVE SMOOTH",
-"51 74 OFFCURVE",
-"156 -16 OFFCURVE",
-"294 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"641 310 LINE",
-"574 347 LINE",
-"467 161 LINE",
-"530 120 LINE"
-);
-}
-);
-width = 673;
-},
-{
-associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
-layerId = "1B3B3FF5-57FC-41E9-BC20-6B39D5BCBF78";
-name = "{15}";
-paths = (
-{
-closed = 1;
-nodes = (
-"646 61 LINE",
-"289 477 LINE SMOOTH",
-"269 500 OFFCURVE",
-"254 525 OFFCURVE",
-"254 551 CURVE SMOOTH",
-"254 590 OFFCURVE",
-"283 617 OFFCURVE",
-"323 617 CURVE SMOOTH",
-"363 617 OFFCURVE",
-"390 590 OFFCURVE",
-"402 548 CURVE",
-"523 576 LINE",
-"498 684 OFFCURVE",
-"432 732 OFFCURVE",
-"324 732 CURVE SMOOTH",
-"209 732 OFFCURVE",
-"129 653 OFFCURVE",
-"129 547 CURVE SMOOTH",
-"129 490 OFFCURVE",
-"161 438 OFFCURVE",
-"192 402 CURVE SMOOTH",
-"552 -16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 -16 OFFCURVE",
-"490 27 OFFCURVE",
-"540 94 CURVE",
-"463 177 LINE",
-"431 125 OFFCURVE",
-"376 102 OFFCURVE",
-"316 102 CURVE SMOOTH",
-"243 102 OFFCURVE",
-"177 150 OFFCURVE",
-"177 234 CURVE SMOOTH",
-"177 299 OFFCURVE",
-"224 358 OFFCURVE",
-"302 381 CURVE",
-"236 474 LINE",
-"129 427 OFFCURVE",
-"51 345 OFFCURVE",
-"51 230 CURVE SMOOTH",
-"51 78 OFFCURVE",
-"153 -16 OFFCURVE",
-"310 -16 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"666 295 LINE",
-"573 354 LINE",
-"466 179 LINE",
-"556 119 LINE"
-);
-}
-);
-width = 719;
 }
 );
 unicode = 0026;
@@ -268701,7 +265815,7 @@ unicode = 0309;
 },
 {
 glyphname = commaturnedabovecomb;
-lastChange = "2020-01-22 16:44:47 +0000";
+lastChange = "2020-06-17 16:49:13 +0000";
 layers = (
 {
 anchors = (
@@ -268805,7 +265919,7 @@ transform = "{-1, 0, 0, -1, 398, 560}";
 }
 );
 layerId = "81ED6017-19D4-43A2-9D6D-25738B20DBDC";
-name = "[16]";
+name = "[17.5]";
 width = 402;
 },
 {
@@ -268828,7 +265942,7 @@ transform = "{-1, 0, 0, -1, 422, 560}";
 }
 );
 layerId = "D555DA6C-5B36-45C8-B2B8-C2D9A0E70AE6";
-name = "[16]";
+name = "[17.5]";
 width = 427;
 },
 {
@@ -268850,7 +265964,7 @@ transform = "{-1, 0, 0, -1, 398, 544}";
 }
 );
 layerId = "27284F09-D4E3-4BB8-A235-2A4CDF2F5F3F";
-name = "[16]";
+name = "[17.5]";
 width = 402;
 },
 {
@@ -268872,7 +265986,7 @@ transform = "{-1, 0, 0, -1, 422, 544}";
 }
 );
 layerId = "40B7A160-11D9-440B-9C83-D5485B2D412C";
-name = "[16]";
+name = "[17.5]";
 width = 427;
 }
 );
@@ -269371,7 +266485,7 @@ unicode = 0324;
 },
 {
 glyphname = commaaccentcomb;
-lastChange = "2020-02-04 13:57:14 +0000";
+lastChange = "2020-06-17 16:49:25 +0000";
 layers = (
 {
 anchors = (
@@ -269486,7 +266600,7 @@ position = "{198, -238}";
 );
 associatedMasterId = "15F39A2A-7598-44C5-A4AA-18A6AD645EAA";
 layerId = "47A88C17-6888-437B-A7E6-187739074A1E";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -269525,7 +266639,7 @@ position = "{211, -285}";
 );
 associatedMasterId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 layerId = "7A524CCB-ED00-4E43-8627-A4CA90CEBD34";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -269563,7 +266677,7 @@ position = "{198, -238}";
 );
 associatedMasterId = "BE1166E3-1CAA-4651-A534-350E8BF10E0B";
 layerId = "838FA659-7224-441C-82FD-8C6A204F7FDA";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -269601,7 +266715,7 @@ position = "{211, -285}";
 );
 associatedMasterId = "090CB6A0-BE7C-4D17-A551-206C7456A8A3";
 layerId = "B94844CD-0EB4-40A0-A6C4-E403AE8380A3";
-name = "[16]";
+name = "[17.5]";
 paths = (
 {
 closed = 1;
@@ -286268,7 +283382,7 @@ value = "3 3 1 1033; Google;GoogleSansText-Regiular";
 }
 );
 interpolationCustom = 300;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 380;
 instanceInterpolations = {
 "15F39A2A-7598-44C5-A4AA-18A6AD645EAA" = 1;
@@ -286310,7 +283424,7 @@ value = "3 3 1 1033; Google;GoogleSansText-Medium";
 }
 );
 interpolationCustom = 400;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 555;
 instanceInterpolations = {
 "15F39A2A-7598-44C5-A4AA-18A6AD645EAA" = 0.50565;
@@ -286354,7 +283468,7 @@ value = "3 3 1 1033; Google;GoogleSansText-Bold";
 }
 );
 interpolationCustom = 300;
-interpolationWeight = 14;
+interpolationWeight = 17;
 interpolationWidth = 734;
 instanceInterpolations = {
 "3E1A77A5-2AAF-4B97-842E-5802590C9619" = 1;


### PR DESCRIPTION
- Remove Brace layers `{15}`
- Update Bracket layers to `17.5` from `16` (Majority)
- Shift Master position to `17` from `14`

The shift to 17.5 is needed to initiate the glyph swap in forms (G y etc).

@chrissimpkins The build will still fail I believe because of the shift in naming for the brace/bracket layers.

Below is a quick snippet for spotting all brace/bracket layers (Just change the if statement from `[` to `{`)

``` python
import GlyphsApp

Font = Glyphs.font
editString = ""
for thisGlyph in Font.glyphs:
	if "[" in "".join([ l.name for l in thisGlyph.layers ]):
		editString += "/" + thisGlyph.name
		print thisGlyph.name
		print l.name
```