### PR TITLE
Static build name fixes following 2-axis VF name updates

### DIFF
--- a/scripts/gs-partial-instancer.py
+++ b/scripts/gs-partial-instancer.py
@@ -19,7 +19,7 @@ import os
 from fontTools.ttLib import TTFont
 from fontTools.varLib import instancer
 
-MIN_OPSZ_SIZE = 14
+MIN_OPSZ_SIZE = 17
 MAX_OPSZ_SIZE = 18
 
 VARIABLE_DIR = "../build/GoogleSans/variable/expert"
@@ -56,13 +56,23 @@ def main():
         assert "opsz" in pre_axis_tags
         assert "wght" in pre_axis_tags
 
-        # partial instance of min optical size design
-        print(f"[PARTIAL INSTANCE] {fontpath} to min optical size instance builds...")
+        # =================================================
+        # BUILD partial instance of min optical size design
+        # =================================================
+        print(
+            f"[PARTIAL INSTANCE] {fontpath} to min optical size instance "
+            f"builds defined at opsz {MIN_OPSZ_SIZE}..."
+        )
         vf_partial_min_opsz = instancer.instantiateVariableFont(
             vf_full, {"opsz": MIN_OPSZ_SIZE}
         )
-        # partial instance of amx optical size design
-        print(f"[PARTIAL INSTANCE] {fontpath} to max optical size instance builds...")
+        # =================================================
+        # BUILD partial instance of max optical size design
+        # =================================================
+        print(
+            f"[PARTIAL INSTANCE] {fontpath} to max optical size instance "
+            f"builds defined at opsz {MAX_OPSZ_SIZE}..."
+        )
         vf_partial_max_opsz = instancer.instantiateVariableFont(
             vf_full, {"opsz": MAX_OPSZ_SIZE}
         )
@@ -75,12 +85,14 @@ def main():
             assert "wght" in post_axis_tags
 
         # ========================================
-        # Fix name tables after partial instancing
+        # FIX name tables after partial instancing
         # ========================================
         namerecord_list_min_opsz = vf_partial_min_opsz["name"].names
         namerecord_list_max_opsz = vf_partial_max_opsz["name"].names
 
+        # -------------------------
         # *** min opsz name fix ***
+        # -------------------------
         new_min_opsz_namerecords = []
         for record in namerecord_list_min_opsz:
             skip_record = False
@@ -117,6 +129,19 @@ def main():
             elif record.nameID == 17:
                 # eliminate nameID 17
                 skip_record = True
+            elif (
+                record.nameID == 268
+                or record.nameID == 269
+                or record.nameID == 270
+                or record.nameID == 271
+            ):
+                # eliminate "Text" from the style names in the name table records
+                # 268, 269, 270, 271
+                # note that the space after Text must remain in the pre-string
+                # platformID = 1 replacements
+                record.string = record.string.replace(b"Text ", b"")
+                # platformID = 3 replacements
+                record.string = record.string.replace(b"\x00T\x00e\x00x\x00t\x00 ", b"")
 
             if not skip_record:
                 new_min_opsz_namerecords.append(record)
@@ -124,7 +149,9 @@ def main():
         # define new min opsz name records following above edits
         vf_partial_min_opsz["name"].names = new_min_opsz_namerecords
 
+        # -------------------------
         # *** max opsz name fix ***
+        # -------------------------
         new_max_opsz_namerecords = []
         for record in namerecord_list_max_opsz:
             skip_record = False

--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1286";
+.appVersion = "1342";
 classes = (
 {
 code = "zero one two three four five six seven eight nine";
@@ -290525,6 +290525,14 @@ value = "Google Sans Text";
 {
 name = WWSSubfamilyName;
 value = Italic;
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
+value = Italic;
 }
 );
 interpolationCustom = 300;
@@ -290576,6 +290584,14 @@ value = "Google Sans Text";
 },
 {
 name = WWSSubfamilyName;
+value = "Medium Italic";
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
 value = "Medium Italic";
 }
 );
@@ -290630,6 +290646,14 @@ value = "Google Sans Text";
 },
 {
 name = WWSSubfamilyName;
+value = "Bold Italic";
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
 value = "Bold Italic";
 }
 );

--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -290560,7 +290560,7 @@ value = 0;
 },
 {
 name = styleMapFamilyName;
-value = "Google Sans Text";
+value = "Google Sans Text Medium";
 },
 {
 name = "Name Table Entry";

--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -290519,14 +290519,6 @@ name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-Italic";
 },
 {
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = Italic;
-},
-{
 name = preferredFamilyName;
 value = "Google Sans Text";
 },
@@ -290577,14 +290569,6 @@ value = "3 1 0 0; Google;GoogleSansText-MediumItalic";
 {
 name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-MediumItalic";
-},
-{
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = "Medium Italic";
 },
 {
 name = preferredFamilyName;
@@ -290639,14 +290623,6 @@ value = "3 1 0 0; Google;GoogleSansText-BoldItalic";
 {
 name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-BoldItalic";
-},
-{
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = "Bold Italic";
 },
 {
 name = preferredFamilyName;

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -283214,14 +283214,6 @@ name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-Regiular";
 },
 {
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = Regular;
-},
-{
 name = preferredFamilyName;
 value = "Google Sans Text";
 },
@@ -283270,14 +283262,6 @@ value = "3 1 0 0; Google;GoogleSansText-Medium";
 {
 name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-Medium";
-},
-{
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = Medium;
 },
 {
 name = preferredFamilyName;
@@ -283330,14 +283314,6 @@ value = "3 1 0 0; Google;GoogleSansText-Bold";
 {
 name = "Name Table Entry";
 value = "3 3 1 1033; Google;GoogleSansText-Bold";
-},
-{
-name = WWSFamilyName;
-value = "Google Sans Text";
-},
-{
-name = WWSSubfamilyName;
-value = Bold;
 },
 {
 name = preferredFamilyName;

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1286";
+.appVersion = "1342";
 classes = (
 {
 code = "zero one two three four five six seven eight nine";
@@ -283220,6 +283220,14 @@ value = "Google Sans Text";
 {
 name = WWSSubfamilyName;
 value = Regular;
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
+value = Regular;
 }
 );
 interpolationCustom = 300;
@@ -283269,6 +283277,14 @@ value = "Google Sans Text";
 },
 {
 name = WWSSubfamilyName;
+value = Medium;
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
 value = Medium;
 }
 );
@@ -283321,6 +283337,14 @@ value = "Google Sans Text";
 },
 {
 name = WWSSubfamilyName;
+value = Bold;
+},
+{
+name = preferredFamilyName;
+value = "Google Sans Text";
+},
+{
+name = preferredSubfamilyName;
 value = Bold;
 }
 );

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -283253,7 +283253,7 @@ value = 0;
 },
 {
 name = styleMapFamilyName;
-value = "Google Sans Text";
+value = "Google Sans Text Medium";
 },
 {
 name = "Name Table Entry";

--- a/source/Makefile
+++ b/source/Makefile
@@ -45,6 +45,16 @@ DEFAULT_VARIABLE_BUILD_DIR=$(FONT_BUILD_DIR)/variable/default
 
 PARTIAL_INSTANCE_VARIABLE_BUILD_DIR=$(EXPERT_VARIABLE_BUILD_DIR)/partial
 
+# Static font expert Text opsz build artifacts
+#  - these paths are necessary for post compile path
+#    edits vs. what comes out of the compiler
+STATIC_TEXT_BUILD_PATH_REGULAR=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-Regular.ttf
+STATIC_TEXT_BUILD_PATH_ITALIC=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-Italic.ttf
+STATIC_TEXT_BUILD_PATH_BOLD=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-Bold.ttf
+STATIC_TEXT_BUILD_PATH_BOLDITALIC=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-BoldItalic.ttf
+STATIC_TEXT_BUILD_PATH_MEDIUM=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-Medium.ttf
+STATIC_TEXT_BUILD_PATH_MEDIUMITALIC=$(EXPERT_STATIC_BUILD_DIR)/GoogleSansText-MediumItalic.ttf
+
 # Variable font build artifacts
 
 # upright
@@ -108,6 +118,13 @@ gs-static: $(FONT_BUILD_DIR)
 	@echo "================================"
 	@echo " Beginning post-compile edits..."
 	@echo "================================"
+	# edit Text opsz file paths
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextRegular.ttf $(STATIC_TEXT_BUILD_PATH_REGULAR)
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextItalic.ttf $(STATIC_TEXT_BUILD_PATH_ITALIC)
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextBold.ttf $(STATIC_TEXT_BUILD_PATH_BOLD)
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextBoldItalic.ttf $(STATIC_TEXT_BUILD_PATH_BOLDITALIC)
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextMedium.ttf $(STATIC_TEXT_BUILD_PATH_MEDIUM)
+	mv $(EXPERT_STATIC_BUILD_DIR)/GoogleSans-TextMediumItalic.ttf $(STATIC_TEXT_BUILD_PATH_MEDIUMITALIC)
 	@echo "================================"
 	@echo " Beginning font subsetting..."
 	@echo "================================"


### PR DESCRIPTION
This PR fixes the static font family name regression that occurred with the new naming approach that was required to support appropriate fvar table definitions in the 2-axis variable fonts. Prior to these changes, both optical sizes show under the same family name (Google Sans) rather than the separate opsz families: Google Sans and Google Sans Text.

Changes include:

- remove WWS family and subfamily name custom parameters in the sources
- add preferredFamily and preferredSubfamily custom parameters in the sources
- add stylemapFamilyName custom parameter = "Google Sans Text Medium" to Text Medium and Text Medium Italic instances 
- update the source/Makefile with text opsz static font file path edits as the file paths regressed relative to our v3.000 release with the name table changes that occurred here

These changes are based on the `Latin-opsz` branch and work in #62 