### PR TITLE
Pin fontbakery, opentype-sanitizer, and flake8 GH Actions to major release 1.x versions

### DIFF
--- a/.github/workflows/lang-coverage.yml
+++ b/.github/workflows/lang-coverage.yml
@@ -35,7 +35,7 @@ jobs:
           # Check for requirements file cache hit
           key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
       - name: Install Python build dependencies
-        uses: py-actions/py-dependency-install@v1
+        uses: py-actions/py-dependency-install@v2
         with:
           update-wheel: "true"
           update-setuptools: "true"

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: flake8 lint of Python sources
-        uses: py-actions/flake8@master # uses flake8 configuration in repository setup.cfg file
+        uses: py-actions/flake8@v1 # uses flake8 configuration in repository setup.cfg file
         with:
           flake8-version: "latest"

--- a/.github/workflows/static-artifact-ci.yml
+++ b/.github/workflows/static-artifact-ci.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Build fonts
         run: ${{ steps.config.outputs.buildcommand }}
       - name: Font Bakery GS profile tests (Expert artifacts)
-        uses: f-actions/font-bakery@master
+        uses: f-actions/font-bakery@v1
         with:
           version: "latest"
           subcmd: "check-profile"
           args: "-C --loglevel WARN qa/check-googlesans.py"
           path: "${{ steps.config.outputs.buildpath }}"
       - name: Font Bakery character set profile tests (Expert artifacts)
-        uses: f-actions/font-bakery@master
+        uses: f-actions/font-bakery@v1
         with:
           version: "latest"
           subcmd: "check-profile"
@@ -63,10 +63,10 @@ jobs:
       #     args: "-C --loglevel WARN qa/check-googlesans.py"
       #     path: "build/GoogleSans/static/default/*.ttf"
       - name: OpenType Sanitizer checks (Expert artifacts)
-        uses: f-actions/opentype-sanitizer@master
+        uses: f-actions/opentype-sanitizer@v1
         with:
           path: "${{ steps.config.outputs.buildpath }}"
       - name: OpenType Sanitizer checks (Default artifacts)
-        uses: f-actions/opentype-sanitizer@master
+        uses: f-actions/opentype-sanitizer@v1
         with:
           path: "build/GoogleSans/static/default/*.ttf"

--- a/.github/workflows/static-artifact-ci.yml
+++ b/.github/workflows/static-artifact-ci.yml
@@ -35,7 +35,7 @@ jobs:
           # Check for requirements file cache hit
           key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
       - name: Install Python build dependencies
-        uses: py-actions/py-dependency-install@v1
+        uses: py-actions/py-dependency-install@v2
         with:
           update-wheel: "true"
           update-setuptools: "true"

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
           # Check for requirements file cache hit
           key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
       - name: Install Python build dependencies
-        uses: py-actions/py-dependency-install@v1
+        uses: py-actions/py-dependency-install@v2
         with:
           update-wheel: "true"
           update-setuptools: "true"
@@ -80,7 +80,7 @@ jobs:
           # Check for requirements file cache hit
           key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
       - name: Install Python build dependencies
-        uses: py-actions/py-dependency-install@v1
+        uses: py-actions/py-dependency-install@v2
         with:
           update-wheel: "true"
           update-setuptools: "true"

--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -42,31 +42,31 @@ jobs:
       - name: Build fonts
         run: ${{ steps.config.outputs.buildcommand }}
       - name: Font Bakery GS profile tests (2-axis Expert)
-        uses: f-actions/font-bakery@master
+        uses: f-actions/font-bakery@v1
         with:
           version: "latest"
           subcmd: "check-profile"
           args: "-C --loglevel WARN qa/check-googlesans.py"
           path: "${{ steps.config.outputs.buildpath }}"
       - name: Font Bakery character set profile tests (2-axis Expert)
-        uses: f-actions/font-bakery@master
+        uses: f-actions/font-bakery@v1
         with:
           version: "latest"
           subcmd: "check-profile"
           args: "-C --loglevel WARN qa/check-charset.py"
           path: "${{ steps.config.outputs.buildpath }}"
       - name: Font Bakery GS profile tests (1-axis Expert artifacts)
-        uses: f-actions/font-bakery@master
+        uses: f-actions/font-bakery@v1
         with:
           version: "latest"
           subcmd: "check-profile"
           args: "-C --loglevel WARN qa/check-googlesans.py"
           path: "build/GoogleSans/variable/expert/partial/*.ttf"
       - name: OpenType Sanitizer checks (2-axis Expert artifacts)
-        uses: f-actions/opentype-sanitizer@master
+        uses: f-actions/opentype-sanitizer@v1
         with:
           path: "${{ steps.config.outputs.buildpath }}"
       - name: OpenType Sanitizer checks (1-axis Expert artifacts)
-        uses: f-actions/opentype-sanitizer@master
+        uses: f-actions/opentype-sanitizer@v1
         with:
           path: "build/GoogleSans/variable/expert/partial/*.ttf"

--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -35,7 +35,7 @@ jobs:
           # Check for requirements file cache hit
           key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
       - name: Install Python build dependencies
-        uses: py-actions/py-dependency-install@v1
+        uses: py-actions/py-dependency-install@v2
         with:
           update-wheel: "true"
           update-setuptools: "true"


### PR DESCRIPTION
Now that releases are available, the following actions will track v1.x minor action source releases and will not automatically use a new backward incompatible major release:

- f-actions/font-bakery (used for font QA)
- py-actions/flake8 (used for Py script linting)
- f-actions/opentype-sanitizer (used for font QA)

The following action will now use v2.x (from v1.x):

- py-actions/py-dependency-install (used for requirements.txt dependency management in CI)