### PR TITLE
Adds smart colon height adjustment

### DIFF
--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -2767,7 +2767,11 @@ sub g underscore l o g o by g.logo;
 sub l underscore l o g o by l.logo;
 sub o underscore l o g o by o.logo;
 
-sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;";
+sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;
+
+sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
+sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
+sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;";
 name = calt;
 },
 {

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -2757,7 +2757,11 @@ sub l underscore l o g o by l.logo;
 sub o underscore l o g o by o.logo;
 
 sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;
-";
+
+sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
+sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
+sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;
+sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.time;";
 name = calt;
 },
 {


### PR DESCRIPTION
Closes #63

This PR includes changes from Edd Harrington to support contextual figure centered colon positioning when the colon is displayed between numerals (e.g., in time displays `12:32pm`.  This will be supported in the `calt` feature and merged as part of the v3.001 release.
