### PR TITLE
calt fea update: fix colon position between tabular figures

### DIFF
--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -2971,7 +2971,7 @@ sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphe
 
 sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
 sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
-sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;";
+sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;";
 name = calt;
 },
 {

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -2963,7 +2963,7 @@ sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphe
 
 sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
 sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
-sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;
+sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;
 sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.time;";
 name = calt;
 },


### PR DESCRIPTION
The `calt` feature code required an update to center the colon between tabular figures.  When `tnum` is on, the `colon.tf` is defined rather than `colon`.  This change updates the feature code to the substitution target `colon.tf'` from `colon'` when positioned between *.tf figures in the `calt` feature source.

This change will be merged to #76 and released in v3.002.

cc @Colophon-Foundry (just a FYI)

Related: https://github.com/googlefonts/googlesans/issues/79