### PR TITLE
Normalize glyphs source files with glyphsLib, remove unnecessary Robofont/RMXScaler glyph level user metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,16 @@ test-fb-vf-expert:
 black:
 	black --line-length 90 scripts/*.py qa/*.py
 
+# --------------------------------------
+# Glyphs source formatting/normalization
+# --------------------------------------
+glyphs-norm:
+	python3 scripts/gs-glyphs-norm.py source/GoogleSans/*.glyphs
+
 .PHONY: all \
 black \
 clean \
+glyphs-norm \
 gs-static gs-vf \
 gs-regular gs-italic gs-medium gs-medium-italic gs-bold gs-bold-italic \
 gst-regular gst-italic gst-medium gst-medium-italic gst-bold gst-bold-italic \

--- a/scripts/gs-glyphs-norm.py
+++ b/scripts/gs-glyphs-norm.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from glyphsLib import GSFont
+
+
+def main(argv):
+    for fontpath in argv:
+        removed_rmxscaler = False
+        removed_robofont_guides = False
+        removed_robofont_mark = False
+
+        try:
+            font = GSFont(fontpath)
+            print(f"Beginning normalization of {fontpath}")
+            for glyph in font.glyphs:
+                # remove extraneous user data definitions
+                if len(glyph.userData) > 0:
+                    # RMXScaler user data
+                    if "RMXScaler" in glyph.userData.keys():
+                        del glyph.userData["RMXScaler"]
+                        removed_rmxscaler = True
+                    # Robofont user data
+                    if "com.typemytype.robofont.guides" in glyph.userData.keys():
+                        del glyph.userData["com.typemytype.robofont.guides"]
+                        removed_robofont_guides = True
+                    if "com.typemytype.robofont.mark" in glyph.userData.keys():
+                        del glyph.userData["com.typemytype.robofont.mark"]
+                        removed_robofont_mark = True
+
+            font.save(fontpath)
+
+            # report changes
+            if removed_rmxscaler:
+                print(f"Removed 'RMXScaler' user data from {fontpath}")
+            if removed_robofont_guides:
+                print(
+                    f"Removed 'com.typemytype.robofont.guides' user data from {fontpath}"
+                )
+            if removed_robofont_mark:
+                print(
+                    f"Removed 'com.typemytype.robofont.mark' user data from {fontpath}"
+                )
+            print(f"Glyphs source file normalization successful for {fontpath}")
+            print(f"Updated file saved in place on path {fontpath}")
+        except Exception as e:
+            sys.stderr.write(f"[ERROR] gs-glyphs-norm.py: {e}{os.linesep}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/source/GoogleSans/GoogleSans-Italic.glyphs
+++ b/source/GoogleSans/GoogleSans-Italic.glyphs
@@ -43,689 +43,15 @@ code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove A
 name = Uppercase;
 },
 {
-code = "Alpha
-Beta
-Gamma
-Delta
-Epsilon
-Zeta
-Eta
-Theta
-Iota
-Kappa
-Lambda
-Mu
-Nu
-Xi
-Omicron
-Pi
-Rho
-Sigma
-Tau
-Upsilon
-Phi
-Chi
-Psi
-Omega
-Alphatonos
-Epsilontonos
-Etatonos
-Iotatonos
-Omicrontonos
-Upsilontonos
-Omegatonos
-Iotadieresis
-Upsilondieresis
-KaiSymbol
-Alphapsili
-Alphadasia
-Alphapsilivaria
-Alphadasiavaria
-Alphapsilioxia
-Alphadasiaoxia
-Alphapsiliperispomeni
-Alphadasiaperispomeni
-Alphavaria
-Alphaoxia
-Alphavrachy
-Alphamacron
-Alphaprosgegrammeni
-Alphapsiliprosgegrammeni
-Alphadasiaprosgegrammeni
-Alphapsilivariaprosgegrammeni
-Alphadasiavariaprosgegrammeni
-Alphapsilioxiaprosgegrammeni
-Alphadasiaoxiaprosgegrammeni
-Alphapsiliperispomeniprosgegrammeni
-Alphadasiaperispomeniprosgegrammeni
-Epsilonpsili
-Epsilondasia
-Epsilonpsilivaria
-Epsilondasiavaria
-Epsilonpsilioxia
-Epsilondasiaoxia
-Epsilonvaria
-Epsilonoxia
-Etapsili
-Etadasia
-Etapsilivaria
-Etadasiavaria
-Etapsilioxia
-Etadasiaoxia
-Etapsiliperispomeni
-Etadasiaperispomeni
-Etavaria
-Etaoxia
-Etaprosgegrammeni
-Etapsiliprosgegrammeni
-Etadasiaprosgegrammeni
-Etapsilivariaprosgegrammeni
-Etadasiavariaprosgegrammeni
-Etapsilioxiaprosgegrammeni
-Etadasiaoxiaprosgegrammeni
-Etapsiliperispomeniprosgegrammeni
-Etadasiaperispomeniprosgegrammeni
-Iotapsili
-Iotadasia
-Iotapsilivaria
-Iotadasiavaria
-Iotapsilioxia
-Iotadasiaoxia
-Iotapsiliperispomeni
-Iotadasiaperispomeni
-Iotavaria
-Iotaoxia
-Iotavrachy
-Iotamacron
-Omicronpsili
-Omicrondasia
-Omicronpsilivaria
-Omicrondasiavaria
-Omicronpsilioxia
-Omicrondasiaoxia
-Omicronvaria
-Omicronoxia
-Rhodasia
-Upsilondasia
-Upsilondasiavaria
-Upsilondasiaoxia
-Upsilondasiaperispomeni
-Upsilonvaria
-Upsilonoxia
-Upsilonvrachy
-Upsilonmacron
-Omegapsili
-Omegadasia
-Omegapsilivaria
-Omegadasiavaria
-Omegapsilioxia
-Omegadasiaoxia
-Omegapsiliperispomeni
-Omegadasiaperispomeni
-Omegavaria
-Omegaoxia
-Omegaprosgegrammeni
-Omegapsiliprosgegrammeni
-Omegadasiaprosgegrammeni
-Omegapsilivariaprosgegrammeni
-Omegadasiavariaprosgegrammeni
-Omegapsilioxiaprosgegrammeni
-Omegadasiaoxiaprosgegrammeni
-Omegapsiliperispomeniprosgegrammeni
-Omegadasiaperispomeniprosgegrammeni
-Alphaprosgegrammeni.ad
-Alphapsiliprosgegrammeni.ad
-Alphadasiaprosgegrammeni.ad
-Alphapsilivariaprosgegrammeni.ad
-Alphadasiavariaprosgegrammeni.ad
-Alphapsilioxiaprosgegrammeni.ad
-Alphadasiaoxiaprosgegrammeni.ad
-Alphapsiliperispomeniprosgegrammeni.ad
-Alphadasiaperispomeniprosgegrammeni.ad
-Etaprosgegrammeni.ad
-Etapsiliprosgegrammeni.ad
-Etadasiaprosgegrammeni.ad
-Etapsilivariaprosgegrammeni.ad
-Etadasiavariaprosgegrammeni.ad
-Etapsilioxiaprosgegrammeni.ad
-Etadasiaoxiaprosgegrammeni.ad
-Etapsiliperispomeniprosgegrammeni.ad
-Etadasiaperispomeniprosgegrammeni.ad
-Omegaprosgegrammeni.ad
-Omegapsiliprosgegrammeni.ad
-Omegadasiaprosgegrammeni.ad
-Omegapsilivariaprosgegrammeni.ad
-Omegadasiavariaprosgegrammeni.ad
-Omegapsilioxiaprosgegrammeni.ad
-Omegadasiaoxiaprosgegrammeni.ad
-Omegapsiliperispomeniprosgegrammeni.ad
-Omegadasiaperispomeniprosgegrammeni.ad";
+code = "Alpha\012Beta\012Gamma\012Delta\012Epsilon\012Zeta\012Eta\012Theta\012Iota\012Kappa\012Lambda\012Mu\012Nu\012Xi\012Omicron\012Pi\012Rho\012Sigma\012Tau\012Upsilon\012Phi\012Chi\012Psi\012Omega\012Alphatonos\012Epsilontonos\012Etatonos\012Iotatonos\012Omicrontonos\012Upsilontonos\012Omegatonos\012Iotadieresis\012Upsilondieresis\012KaiSymbol\012Alphapsili\012Alphadasia\012Alphapsilivaria\012Alphadasiavaria\012Alphapsilioxia\012Alphadasiaoxia\012Alphapsiliperispomeni\012Alphadasiaperispomeni\012Alphavaria\012Alphaoxia\012Alphavrachy\012Alphamacron\012Alphaprosgegrammeni\012Alphapsiliprosgegrammeni\012Alphadasiaprosgegrammeni\012Alphapsilivariaprosgegrammeni\012Alphadasiavariaprosgegrammeni\012Alphapsilioxiaprosgegrammeni\012Alphadasiaoxiaprosgegrammeni\012Alphapsiliperispomeniprosgegrammeni\012Alphadasiaperispomeniprosgegrammeni\012Epsilonpsili\012Epsilondasia\012Epsilonpsilivaria\012Epsilondasiavaria\012Epsilonpsilioxia\012Epsilondasiaoxia\012Epsilonvaria\012Epsilonoxia\012Etapsili\012Etadasia\012Etapsilivaria\012Etadasiavaria\012Etapsilioxia\012Etadasiaoxia\012Etapsiliperispomeni\012Etadasiaperispomeni\012Etavaria\012Etaoxia\012Etaprosgegrammeni\012Etapsiliprosgegrammeni\012Etadasiaprosgegrammeni\012Etapsilivariaprosgegrammeni\012Etadasiavariaprosgegrammeni\012Etapsilioxiaprosgegrammeni\012Etadasiaoxiaprosgegrammeni\012Etapsiliperispomeniprosgegrammeni\012Etadasiaperispomeniprosgegrammeni\012Iotapsili\012Iotadasia\012Iotapsilivaria\012Iotadasiavaria\012Iotapsilioxia\012Iotadasiaoxia\012Iotapsiliperispomeni\012Iotadasiaperispomeni\012Iotavaria\012Iotaoxia\012Iotavrachy\012Iotamacron\012Omicronpsili\012Omicrondasia\012Omicronpsilivaria\012Omicrondasiavaria\012Omicronpsilioxia\012Omicrondasiaoxia\012Omicronvaria\012Omicronoxia\012Rhodasia\012Upsilondasia\012Upsilondasiavaria\012Upsilondasiaoxia\012Upsilondasiaperispomeni\012Upsilonvaria\012Upsilonoxia\012Upsilonvrachy\012Upsilonmacron\012Omegapsili\012Omegadasia\012Omegapsilivaria\012Omegadasiavaria\012Omegapsilioxia\012Omegadasiaoxia\012Omegapsiliperispomeni\012Omegadasiaperispomeni\012Omegavaria\012Omegaoxia\012Omegaprosgegrammeni\012Omegapsiliprosgegrammeni\012Omegadasiaprosgegrammeni\012Omegapsilivariaprosgegrammeni\012Omegadasiavariaprosgegrammeni\012Omegapsilioxiaprosgegrammeni\012Omegadasiaoxiaprosgegrammeni\012Omegapsiliperispomeniprosgegrammeni\012Omegadasiaperispomeniprosgegrammeni\012Alphaprosgegrammeni.ad\012Alphapsiliprosgegrammeni.ad\012Alphadasiaprosgegrammeni.ad\012Alphapsilivariaprosgegrammeni.ad\012Alphadasiavariaprosgegrammeni.ad\012Alphapsilioxiaprosgegrammeni.ad\012Alphadasiaoxiaprosgegrammeni.ad\012Alphapsiliperispomeniprosgegrammeni.ad\012Alphadasiaperispomeniprosgegrammeni.ad\012Etaprosgegrammeni.ad\012Etapsiliprosgegrammeni.ad\012Etadasiaprosgegrammeni.ad\012Etapsilivariaprosgegrammeni.ad\012Etadasiavariaprosgegrammeni.ad\012Etapsilioxiaprosgegrammeni.ad\012Etadasiaoxiaprosgegrammeni.ad\012Etapsiliperispomeniprosgegrammeni.ad\012Etadasiaperispomeniprosgegrammeni.ad\012Omegaprosgegrammeni.ad\012Omegapsiliprosgegrammeni.ad\012Omegadasiaprosgegrammeni.ad\012Omegapsilivariaprosgegrammeni.ad\012Omegadasiavariaprosgegrammeni.ad\012Omegapsilioxiaprosgegrammeni.ad\012Omegadasiaoxiaprosgegrammeni.ad\012Omegapsiliperispomeniprosgegrammeni.ad\012Omegadasiaperispomeniprosgegrammeni.ad";
 name = grk_UPPERCASE;
 },
 {
-code = "alpha
-beta
-gamma
-delta
-epsilon
-zeta
-eta
-theta
-iota
-kappa
-lambda
-mu
-nu
-xi
-omicron
-pi
-rho
-sigmafinal
-sigma
-tau
-upsilon
-phi
-chi
-psi
-omega
-iotatonos
-iotadieresis
-iotadieresistonos
-upsilontonos
-upsilondieresis
-upsilondieresistonos
-omicrontonos
-omegatonos
-alphatonos
-epsilontonos
-etatonos
-kaiSymbol
-alphapsili
-alphadasia
-alphapsilivaria
-alphadasiavaria
-alphapsilioxia
-alphadasiaoxia
-alphapsiliperispomeni
-alphadasiaperispomeni
-alphavaria
-alphaoxia
-alphaperispomeni
-alphavrachy
-alphamacron
-alphaypogegrammeni
-alphavariaypogegrammeni
-alphaoxiaypogegrammeni
-alphapsiliypogegrammeni
-alphadasiaypogegrammeni
-alphapsilivariaypogegrammeni
-alphadasiavariaypogegrammeni
-alphapsilioxiaypogegrammeni
-alphadasiaoxiaypogegrammeni
-alphapsiliperispomeniypogegrammeni
-alphadasiaperispomeniypogegrammeni
-alphaperispomeniypogegrammeni
-epsilonpsili
-epsilondasia
-epsilonpsilivaria
-epsilondasiavaria
-epsilonpsilioxia
-epsilondasiaoxia
-epsilonvaria
-epsilonoxia
-etapsili
-etadasia
-etapsilivaria
-etadasiavaria
-etapsilioxia
-etadasiaoxia
-etapsiliperispomeni
-etadasiaperispomeni
-etavaria
-etaoxia
-etaperispomeni
-etaypogegrammeni
-etavariaypogegrammeni
-etaoxiaypogegrammeni
-etapsiliypogegrammeni
-etadasiaypogegrammeni
-etapsilivariaypogegrammeni
-etadasiavariaypogegrammeni
-etapsilioxiaypogegrammeni
-etadasiaoxiaypogegrammeni
-etapsiliperispomeniypogegrammeni
-etadasiaperispomeniypogegrammeni
-etaperispomeniypogegrammeni
-iotapsili
-iotadasia
-iotapsilivaria
-iotadasiavaria
-iotapsilioxia
-iotadasiaoxia
-iotapsiliperispomeni
-iotadasiaperispomeni
-iotavaria
-iotaoxia
-iotaperispomeni
-iotavrachy
-iotamacron
-iotadialytikavaria
-iotadialytikaoxia
-iotadialytikaperispomeni
-omicronpsili
-omicrondasia
-omicronpsilivaria
-omicrondasiavaria
-omicronpsilioxia
-omicrondasiaoxia
-omicronvaria
-omicronoxia
-rhopsili
-rhodasia
-upsilonpsili
-upsilondasia
-upsilonpsilivaria
-upsilondasiavaria
-upsilonpsilioxia
-upsilondasiaoxia
-upsilonpsiliperispomeni
-upsilondasiaperispomeni
-upsilonvaria
-upsilonoxia
-upsilonperispomeni
-upsilonvrachy
-upsilonmacron
-upsilondialytikavaria
-upsilondialytikaoxia
-upsilondialytikaperispomeni
-omegapsili
-omegadasia
-omegapsilivaria
-omegadasiavaria
-omegapsilioxia
-omegadasiaoxia
-omegapsiliperispomeni
-omegadasiaperispomeni
-omegavaria
-omegaoxia
-omegaperispomeni
-omegaypogegrammeni
-omegavariaypogegrammeni
-omegaoxiaypogegrammeni
-omegapsiliypogegrammeni
-omegadasiaypogegrammeni
-omegapsilivariaypogegrammeni
-omegadasiavariaypogegrammeni
-omegapsilioxiaypogegrammeni
-omegadasiaoxiaypogegrammeni
-omegapsiliperispomeniypogegrammeni
-omegadasiaperispomeniypogegrammeni
-omegaperispomeniypogegrammeni";
+code = "alpha\012beta\012gamma\012delta\012epsilon\012zeta\012eta\012theta\012iota\012kappa\012lambda\012mu\012nu\012xi\012omicron\012pi\012rho\012sigmafinal\012sigma\012tau\012upsilon\012phi\012chi\012psi\012omega\012iotatonos\012iotadieresis\012iotadieresistonos\012upsilontonos\012upsilondieresis\012upsilondieresistonos\012omicrontonos\012omegatonos\012alphatonos\012epsilontonos\012etatonos\012kaiSymbol\012alphapsili\012alphadasia\012alphapsilivaria\012alphadasiavaria\012alphapsilioxia\012alphadasiaoxia\012alphapsiliperispomeni\012alphadasiaperispomeni\012alphavaria\012alphaoxia\012alphaperispomeni\012alphavrachy\012alphamacron\012alphaypogegrammeni\012alphavariaypogegrammeni\012alphaoxiaypogegrammeni\012alphapsiliypogegrammeni\012alphadasiaypogegrammeni\012alphapsilivariaypogegrammeni\012alphadasiavariaypogegrammeni\012alphapsilioxiaypogegrammeni\012alphadasiaoxiaypogegrammeni\012alphapsiliperispomeniypogegrammeni\012alphadasiaperispomeniypogegrammeni\012alphaperispomeniypogegrammeni\012epsilonpsili\012epsilondasia\012epsilonpsilivaria\012epsilondasiavaria\012epsilonpsilioxia\012epsilondasiaoxia\012epsilonvaria\012epsilonoxia\012etapsili\012etadasia\012etapsilivaria\012etadasiavaria\012etapsilioxia\012etadasiaoxia\012etapsiliperispomeni\012etadasiaperispomeni\012etavaria\012etaoxia\012etaperispomeni\012etaypogegrammeni\012etavariaypogegrammeni\012etaoxiaypogegrammeni\012etapsiliypogegrammeni\012etadasiaypogegrammeni\012etapsilivariaypogegrammeni\012etadasiavariaypogegrammeni\012etapsilioxiaypogegrammeni\012etadasiaoxiaypogegrammeni\012etapsiliperispomeniypogegrammeni\012etadasiaperispomeniypogegrammeni\012etaperispomeniypogegrammeni\012iotapsili\012iotadasia\012iotapsilivaria\012iotadasiavaria\012iotapsilioxia\012iotadasiaoxia\012iotapsiliperispomeni\012iotadasiaperispomeni\012iotavaria\012iotaoxia\012iotaperispomeni\012iotavrachy\012iotamacron\012iotadialytikavaria\012iotadialytikaoxia\012iotadialytikaperispomeni\012omicronpsili\012omicrondasia\012omicronpsilivaria\012omicrondasiavaria\012omicronpsilioxia\012omicrondasiaoxia\012omicronvaria\012omicronoxia\012rhopsili\012rhodasia\012upsilonpsili\012upsilondasia\012upsilonpsilivaria\012upsilondasiavaria\012upsilonpsilioxia\012upsilondasiaoxia\012upsilonpsiliperispomeni\012upsilondasiaperispomeni\012upsilonvaria\012upsilonoxia\012upsilonperispomeni\012upsilonvrachy\012upsilonmacron\012upsilondialytikavaria\012upsilondialytikaoxia\012upsilondialytikaperispomeni\012omegapsili\012omegadasia\012omegapsilivaria\012omegadasiavaria\012omegapsilioxia\012omegadasiaoxia\012omegapsiliperispomeni\012omegadasiaperispomeni\012omegavaria\012omegaoxia\012omegaperispomeni\012omegaypogegrammeni\012omegavariaypogegrammeni\012omegaoxiaypogegrammeni\012omegapsiliypogegrammeni\012omegadasiaypogegrammeni\012omegapsilivariaypogegrammeni\012omegadasiavariaypogegrammeni\012omegapsilioxiaypogegrammeni\012omegadasiaoxiaypogegrammeni\012omegapsiliperispomeniypogegrammeni\012omegadasiaperispomeniypogegrammeni\012omegaperispomeniypogegrammeni";
 name = grk_lowercase;
 },
 {
-code = "alphaypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-etaypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-omegaypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-alpha.sc
-beta.sc
-gamma.sc
-delta.sc
-epsilon.sc
-zeta.sc
-eta.sc
-theta.sc
-iota.sc
-kappa.sc
-lambda.sc
-mu.sc
-nu.sc
-xi.sc
-omicron.sc
-pi.sc
-rho.sc
-sigmafinal.sc
-sigma.sc
-tau.sc
-upsilon.sc
-phi.sc
-chi.sc
-psi.sc
-omega.sc
-iotatonos.sc
-iotadieresis.sc
-iotadieresistonos.sc
-upsilontonos.sc
-upsilondieresis.sc
-upsilondieresistonos.sc
-omicrontonos.sc
-omegatonos.sc
-alphatonos.sc
-epsilontonos.sc
-etatonos.sc
-kaiSymbol.sc
-alphapsili.sc
-alphadasia.sc
-alphapsilivaria.sc
-alphadasiavaria.sc
-alphapsilioxia.sc
-alphadasiaoxia.sc
-alphapsiliperispomeni.sc
-alphadasiaperispomeni.sc
-alphavaria.sc
-alphaoxia.sc
-alphaperispomeni.sc
-alphavrachy.sc
-alphamacron.sc
-alphaypogegrammeni.sc
-alphavariaypogegrammeni.sc
-alphaoxiaypogegrammeni.sc
-alphapsiliypogegrammeni.sc
-alphadasiaypogegrammeni.sc
-alphapsilivariaypogegrammeni.sc
-alphadasiavariaypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotadialytikaperispomeni.sc
-iotadialytikaperispomeni.sc
-iotadialytikaperispomeni.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-rhodasia.sc
-rhodasia.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilondialytikaperispomeni.sc
-upsilondialytikaperispomeni.sc
-upsilondialytikaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-alphaypogegrammeni.sc.ad.ss06
-alphavariaypogegrammeni.sc.ad.ss06
-alphaoxiaypogegrammeni.sc.ad.ss06
-alphapsiliypogegrammeni.sc.ad.ss06
-alphadasiaypogegrammeni.sc.ad.ss06
-alphapsilivariaypogegrammeni.sc.ad.ss06
-alphadasiavariaypogegrammeni.sc.ad.ss06
-alphapsilioxiaypogegrammeni.sc.ad.ss06
-alphadasiaoxiaypogegrammeni.sc.ad.ss06
-alphapsiliperispomeniypogegrammeni.sc.ad.ss06
-alphadasiaperispomeniypogegrammeni.sc.ad.ss06
-alphaperispomeniypogegrammeni.sc.ad.ss06
-etaypogegrammeni.sc.ad.ss06
-etavariaypogegrammeni.sc.ad.ss06
-etaoxiaypogegrammeni.sc.ad.ss06
-etapsiliypogegrammeni.sc.ad.ss06
-etadasiaypogegrammeni.sc.ad.ss06
-etapsilivariaypogegrammeni.sc.ad.ss06
-etadasiavariaypogegrammeni.sc.ad.ss06
-etapsilioxiaypogegrammeni.sc.ad.ss06
-etadasiaoxiaypogegrammeni.sc.ad.ss06
-etapsiliperispomeniypogegrammeni.sc.ad.ss06
-etadasiaperispomeniypogegrammeni.sc.ad.ss06
-etaperispomeniypogegrammeni.sc.ad.ss06
-omegaypogegrammeni.sc.ad.ss06
-omegavariaypogegrammeni.sc.ad.ss06
-omegaoxiaypogegrammeni.sc.ad.ss06
-omegapsiliypogegrammeni.sc.ad.ss06
-omegadasiaypogegrammeni.sc.ad.ss06
-omegapsilivariaypogegrammeni.sc.ad.ss06
-omegadasiavariaypogegrammeni.sc.ad.ss06
-omegapsilioxiaypogegrammeni.sc.ad.ss06
-omegadasiaoxiaypogegrammeni.sc.ad.ss06
-omegapsiliperispomeniypogegrammeni.sc.ad.ss06
-omegadasiaperispomeniypogegrammeni.sc.ad.ss06
-omegaperispomeniypogegrammeni.sc.ad.ss06
-iotatonos.sc.ss06
-iotadieresis.sc.ss06
-iotadieresistonos.sc.ss06
-upsilontonos.sc.ss06
-upsilondieresis.sc.ss06
-upsilondieresistonos.sc.ss06
-omicrontonos.sc.ss06
-omegatonos.sc.ss06
-alphatonos.sc.ss06
-epsilontonos.sc.ss06
-etatonos.sc.ss06
-alphapsili.sc.ss06
-alphadasia.sc.ss06
-alphapsilivaria.sc.ss06
-alphadasiavaria.sc.ss06
-alphapsilioxia.sc.ss06
-alphadasiaoxia.sc.ss06
-alphapsiliperispomeni.sc.ss06
-alphadasiaperispomeni.sc.ss06
-alphavaria.sc.ss06
-alphaoxia.sc.ss06
-alphaperispomeni.sc.ss06
-alphavrachy.sc.ss06
-alphamacron.sc.ss06
-alphaypogegrammeni.sc.ss06
-alphavariaypogegrammeni.sc.ss06
-alphaoxiaypogegrammeni.sc.ss06
-alphapsiliypogegrammeni.sc.ss06
-alphadasiaypogegrammeni.sc.ss06
-alphapsilivariaypogegrammeni.sc.ss06
-alphadasiavariaypogegrammeni.sc.ss06
-alphapsilioxiaypogegrammeni.sc.ss06
-alphadasiaoxiaypogegrammeni.sc.ss06
-alphapsiliperispomeniypogegrammeni.sc.ss06
-alphadasiaperispomeniypogegrammeni.sc.ss06
-alphaperispomeniypogegrammeni.sc.ss06
-epsilonpsili.sc.ss06
-epsilondasia.sc.ss06
-epsilonpsilivaria.sc.ss06
-epsilondasiavaria.sc.ss06
-epsilonpsilioxia.sc.ss06
-epsilondasiaoxia.sc.ss06
-epsilonvaria.sc.ss06
-epsilonoxia.sc.ss06
-etapsili.sc.ss06
-etadasia.sc.ss06
-etapsilivaria.sc.ss06
-etadasiavaria.sc.ss06
-etapsilioxia.sc.ss06
-etadasiaoxia.sc.ss06
-etapsiliperispomeni.sc.ss06
-etadasiaperispomeni.sc.ss06
-etavaria.sc.ss06
-etaoxia.sc.ss06
-etaperispomeni.sc.ss06
-etaypogegrammeni.sc.ss06
-etavariaypogegrammeni.sc.ss06
-etaoxiaypogegrammeni.sc.ss06
-etapsiliypogegrammeni.sc.ss06
-etadasiaypogegrammeni.sc.ss06
-etapsilivariaypogegrammeni.sc.ss06
-etadasiavariaypogegrammeni.sc.ss06
-etapsilioxiaypogegrammeni.sc.ss06
-etadasiaoxiaypogegrammeni.sc.ss06
-etapsiliperispomeniypogegrammeni.sc.ss06
-etadasiaperispomeniypogegrammeni.sc.ss06
-etaperispomeniypogegrammeni.sc.ss06
-iotapsili.sc.ss06
-iotadasia.sc.ss06
-iotapsilivaria.sc.ss06
-iotadasiavaria.sc.ss06
-iotapsilioxia.sc.ss06
-iotadasiaoxia.sc.ss06
-iotapsiliperispomeni.sc.ss06
-iotadasiaperispomeni.sc.ss06
-iotavaria.sc.ss06
-iotaoxia.sc.ss06
-iotaperispomeni.sc.ss06
-iotavrachy.sc.ss06
-iotamacron.sc.ss06
-iotadialytikavaria.sc.ss06
-iotadialytikaoxia.sc.ss06
-iotadialytikaperispomeni.sc.ss06
-omicronpsili.sc.ss06
-omicrondasia.sc.ss06
-omicronpsilivaria.sc.ss06
-omicrondasiavaria.sc.ss06
-omicronpsilioxia.sc.ss06
-omicrondasiaoxia.sc.ss06
-omicronvaria.sc.ss06
-omicronoxia.sc.ss06
-rhopsili.sc.ss06
-rhodasia.sc.ss06
-upsilonpsili.sc.ss06
-upsilondasia.sc.ss06
-upsilonpsilivaria.sc.ss06
-upsilondasiavaria.sc.ss06
-upsilonpsilioxia.sc.ss06
-upsilondasiaoxia.sc.ss06
-upsilonpsiliperispomeni.sc.ss06
-upsilondasiaperispomeni.sc.ss06
-upsilonvaria.sc.ss06
-upsilonoxia.sc.ss06
-upsilonperispomeni.sc.ss06
-upsilonvrachy.sc.ss06
-upsilonmacron.sc.ss06
-upsilondialytikavaria.sc.ss06
-upsilondialytikaoxia.sc.ss06
-upsilondialytikaperispomeni.sc.ss06
-omegapsili.sc.ss06
-omegadasia.sc.ss06
-omegapsilivaria.sc.ss06
-omegadasiavaria.sc.ss06
-omegapsilioxia.sc.ss06
-omegadasiaoxia.sc.ss06
-omegapsiliperispomeni.sc.ss06
-omegadasiaperispomeni.sc.ss06
-omegavaria.sc.ss06
-omegaoxia.sc.ss06
-omegaperispomeni.sc.ss06
-omegaypogegrammeni.sc.ss06
-omegavariaypogegrammeni.sc.ss06
-omegaoxiaypogegrammeni.sc.ss06
-omegapsiliypogegrammeni.sc.ss06
-omegadasiaypogegrammeni.sc.ss06
-omegapsilivariaypogegrammeni.sc.ss06
-omegadasiavariaypogegrammeni.sc.ss06
-omegapsilioxiaypogegrammeni.sc.ss06
-omegadasiaoxiaypogegrammeni.sc.ss06
-omegapsiliperispomeniypogegrammeni.sc.ss06
-omegadasiaperispomeniypogegrammeni.sc.ss06
-omegaperispomeniypogegrammeni.sc.ss06";
+code = "alphaypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012etaypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012omegaypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012alpha.sc\012beta.sc\012gamma.sc\012delta.sc\012epsilon.sc\012zeta.sc\012eta.sc\012theta.sc\012iota.sc\012kappa.sc\012lambda.sc\012mu.sc\012nu.sc\012xi.sc\012omicron.sc\012pi.sc\012rho.sc\012sigmafinal.sc\012sigma.sc\012tau.sc\012upsilon.sc\012phi.sc\012chi.sc\012psi.sc\012omega.sc\012iotatonos.sc\012iotadieresis.sc\012iotadieresistonos.sc\012upsilontonos.sc\012upsilondieresis.sc\012upsilondieresistonos.sc\012omicrontonos.sc\012omegatonos.sc\012alphatonos.sc\012epsilontonos.sc\012etatonos.sc\012kaiSymbol.sc\012alphapsili.sc\012alphadasia.sc\012alphapsilivaria.sc\012alphadasiavaria.sc\012alphapsilioxia.sc\012alphadasiaoxia.sc\012alphapsiliperispomeni.sc\012alphadasiaperispomeni.sc\012alphavaria.sc\012alphaoxia.sc\012alphaperispomeni.sc\012alphavrachy.sc\012alphamacron.sc\012alphaypogegrammeni.sc\012alphavariaypogegrammeni.sc\012alphaoxiaypogegrammeni.sc\012alphapsiliypogegrammeni.sc\012alphadasiaypogegrammeni.sc\012alphapsilivariaypogegrammeni.sc\012alphadasiavariaypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotadialytikaperispomeni.sc\012iotadialytikaperispomeni.sc\012iotadialytikaperispomeni.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012rhodasia.sc\012rhodasia.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilondialytikaperispomeni.sc\012upsilondialytikaperispomeni.sc\012upsilondialytikaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012alphaypogegrammeni.sc.ad.ss06\012alphavariaypogegrammeni.sc.ad.ss06\012alphaoxiaypogegrammeni.sc.ad.ss06\012alphapsiliypogegrammeni.sc.ad.ss06\012alphadasiaypogegrammeni.sc.ad.ss06\012alphapsilivariaypogegrammeni.sc.ad.ss06\012alphadasiavariaypogegrammeni.sc.ad.ss06\012alphapsilioxiaypogegrammeni.sc.ad.ss06\012alphadasiaoxiaypogegrammeni.sc.ad.ss06\012alphapsiliperispomeniypogegrammeni.sc.ad.ss06\012alphadasiaperispomeniypogegrammeni.sc.ad.ss06\012alphaperispomeniypogegrammeni.sc.ad.ss06\012etaypogegrammeni.sc.ad.ss06\012etavariaypogegrammeni.sc.ad.ss06\012etaoxiaypogegrammeni.sc.ad.ss06\012etapsiliypogegrammeni.sc.ad.ss06\012etadasiaypogegrammeni.sc.ad.ss06\012etapsilivariaypogegrammeni.sc.ad.ss06\012etadasiavariaypogegrammeni.sc.ad.ss06\012etapsilioxiaypogegrammeni.sc.ad.ss06\012etadasiaoxiaypogegrammeni.sc.ad.ss06\012etapsiliperispomeniypogegrammeni.sc.ad.ss06\012etadasiaperispomeniypogegrammeni.sc.ad.ss06\012etaperispomeniypogegrammeni.sc.ad.ss06\012omegaypogegrammeni.sc.ad.ss06\012omegavariaypogegrammeni.sc.ad.ss06\012omegaoxiaypogegrammeni.sc.ad.ss06\012omegapsiliypogegrammeni.sc.ad.ss06\012omegadasiaypogegrammeni.sc.ad.ss06\012omegapsilivariaypogegrammeni.sc.ad.ss06\012omegadasiavariaypogegrammeni.sc.ad.ss06\012omegapsilioxiaypogegrammeni.sc.ad.ss06\012omegadasiaoxiaypogegrammeni.sc.ad.ss06\012omegapsiliperispomeniypogegrammeni.sc.ad.ss06\012omegadasiaperispomeniypogegrammeni.sc.ad.ss06\012omegaperispomeniypogegrammeni.sc.ad.ss06\012iotatonos.sc.ss06\012iotadieresis.sc.ss06\012iotadieresistonos.sc.ss06\012upsilontonos.sc.ss06\012upsilondieresis.sc.ss06\012upsilondieresistonos.sc.ss06\012omicrontonos.sc.ss06\012omegatonos.sc.ss06\012alphatonos.sc.ss06\012epsilontonos.sc.ss06\012etatonos.sc.ss06\012alphapsili.sc.ss06\012alphadasia.sc.ss06\012alphapsilivaria.sc.ss06\012alphadasiavaria.sc.ss06\012alphapsilioxia.sc.ss06\012alphadasiaoxia.sc.ss06\012alphapsiliperispomeni.sc.ss06\012alphadasiaperispomeni.sc.ss06\012alphavaria.sc.ss06\012alphaoxia.sc.ss06\012alphaperispomeni.sc.ss06\012alphavrachy.sc.ss06\012alphamacron.sc.ss06\012alphaypogegrammeni.sc.ss06\012alphavariaypogegrammeni.sc.ss06\012alphaoxiaypogegrammeni.sc.ss06\012alphapsiliypogegrammeni.sc.ss06\012alphadasiaypogegrammeni.sc.ss06\012alphapsilivariaypogegrammeni.sc.ss06\012alphadasiavariaypogegrammeni.sc.ss06\012alphapsilioxiaypogegrammeni.sc.ss06\012alphadasiaoxiaypogegrammeni.sc.ss06\012alphapsiliperispomeniypogegrammeni.sc.ss06\012alphadasiaperispomeniypogegrammeni.sc.ss06\012alphaperispomeniypogegrammeni.sc.ss06\012epsilonpsili.sc.ss06\012epsilondasia.sc.ss06\012epsilonpsilivaria.sc.ss06\012epsilondasiavaria.sc.ss06\012epsilonpsilioxia.sc.ss06\012epsilondasiaoxia.sc.ss06\012epsilonvaria.sc.ss06\012epsilonoxia.sc.ss06\012etapsili.sc.ss06\012etadasia.sc.ss06\012etapsilivaria.sc.ss06\012etadasiavaria.sc.ss06\012etapsilioxia.sc.ss06\012etadasiaoxia.sc.ss06\012etapsiliperispomeni.sc.ss06\012etadasiaperispomeni.sc.ss06\012etavaria.sc.ss06\012etaoxia.sc.ss06\012etaperispomeni.sc.ss06\012etaypogegrammeni.sc.ss06\012etavariaypogegrammeni.sc.ss06\012etaoxiaypogegrammeni.sc.ss06\012etapsiliypogegrammeni.sc.ss06\012etadasiaypogegrammeni.sc.ss06\012etapsilivariaypogegrammeni.sc.ss06\012etadasiavariaypogegrammeni.sc.ss06\012etapsilioxiaypogegrammeni.sc.ss06\012etadasiaoxiaypogegrammeni.sc.ss06\012etapsiliperispomeniypogegrammeni.sc.ss06\012etadasiaperispomeniypogegrammeni.sc.ss06\012etaperispomeniypogegrammeni.sc.ss06\012iotapsili.sc.ss06\012iotadasia.sc.ss06\012iotapsilivaria.sc.ss06\012iotadasiavaria.sc.ss06\012iotapsilioxia.sc.ss06\012iotadasiaoxia.sc.ss06\012iotapsiliperispomeni.sc.ss06\012iotadasiaperispomeni.sc.ss06\012iotavaria.sc.ss06\012iotaoxia.sc.ss06\012iotaperispomeni.sc.ss06\012iotavrachy.sc.ss06\012iotamacron.sc.ss06\012iotadialytikavaria.sc.ss06\012iotadialytikaoxia.sc.ss06\012iotadialytikaperispomeni.sc.ss06\012omicronpsili.sc.ss06\012omicrondasia.sc.ss06\012omicronpsilivaria.sc.ss06\012omicrondasiavaria.sc.ss06\012omicronpsilioxia.sc.ss06\012omicrondasiaoxia.sc.ss06\012omicronvaria.sc.ss06\012omicronoxia.sc.ss06\012rhopsili.sc.ss06\012rhodasia.sc.ss06\012upsilonpsili.sc.ss06\012upsilondasia.sc.ss06\012upsilonpsilivaria.sc.ss06\012upsilondasiavaria.sc.ss06\012upsilonpsilioxia.sc.ss06\012upsilondasiaoxia.sc.ss06\012upsilonpsiliperispomeni.sc.ss06\012upsilondasiaperispomeni.sc.ss06\012upsilonvaria.sc.ss06\012upsilonoxia.sc.ss06\012upsilonperispomeni.sc.ss06\012upsilonvrachy.sc.ss06\012upsilonmacron.sc.ss06\012upsilondialytikavaria.sc.ss06\012upsilondialytikaoxia.sc.ss06\012upsilondialytikaperispomeni.sc.ss06\012omegapsili.sc.ss06\012omegadasia.sc.ss06\012omegapsilivaria.sc.ss06\012omegadasiavaria.sc.ss06\012omegapsilioxia.sc.ss06\012omegadasiaoxia.sc.ss06\012omegapsiliperispomeni.sc.ss06\012omegadasiaperispomeni.sc.ss06\012omegavaria.sc.ss06\012omegaoxia.sc.ss06\012omegaperispomeni.sc.ss06\012omegaypogegrammeni.sc.ss06\012omegavariaypogegrammeni.sc.ss06\012omegaoxiaypogegrammeni.sc.ss06\012omegapsiliypogegrammeni.sc.ss06\012omegadasiaypogegrammeni.sc.ss06\012omegapsilivariaypogegrammeni.sc.ss06\012omegadasiavariaypogegrammeni.sc.ss06\012omegapsilioxiaypogegrammeni.sc.ss06\012omegadasiaoxiaypogegrammeni.sc.ss06\012omegapsiliperispomeniypogegrammeni.sc.ss06\012omegadasiaperispomeniypogegrammeni.sc.ss06\012omegaperispomeniypogegrammeni.sc.ss06";
 name = grk_smallcaps;
 },
 {
@@ -874,800 +200,25 @@ designer = "Google Sans Authors";
 familyName = "Google Sans";
 featurePrefixes = (
 {
-code = "languagesystem DFLT dflt;
-languagesystem latn dflt;
-languagesystem cyrl dflt;
-languagesystem hebr dflt;
-
-languagesystem latn CAT;
-languagesystem latn ROM;
-languagesystem latn MOL;
-languagesystem latn SRB;
-languagesystem cyrl MKD;
-languagesystem cyrl BGR;
-languagesystem hebr IWR;
-
-@grk_UPPERCASE = [ Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega Alphatonos Epsilontonos Etatonos Iotatonos Omicrontonos Upsilontonos Omegatonos Iotadieresis Upsilondieresis ] ;
-
-@grk_lowercase = [ alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alphatonos epsilontonos etatonos iotatonos omicrontonos upsilontonos omegatonos iotadieresis upsilondieresis iotadieresistonos upsilondieresistonos sigmafinal ] ;
-
-@grk_smallcaps = [ alpha.sc beta.sc gamma.sc delta.sc epsilon.sc zeta.sc eta.sc theta.sc iota.sc kappa.sc lambda.sc mu.sc nu.sc xi.sc omicron.sc pi.sc rho.sc sigma.sc tau.sc upsilon.sc phi.sc chi.sc psi.sc omega.sc alphatonos.sc epsilontonos.sc etatonos.sc iotatonos.sc omicrontonos.sc upsilontonos.sc omegatonos.sc iotadieresis.sc upsilondieresis.sc iotadieresistonos.sc upsilondieresistonos.sc sigmafinal.sc ] ;
-
-";
+code = "languagesystem DFLT dflt;\012languagesystem latn dflt;\012languagesystem cyrl dflt;\012languagesystem hebr dflt;\012\012languagesystem latn CAT;\012languagesystem latn ROM;\012languagesystem latn MOL;\012languagesystem latn SRB;\012languagesystem cyrl MKD;\012languagesystem cyrl BGR;\012languagesystem hebr IWR;\012\012@grk_UPPERCASE = [ Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega Alphatonos Epsilontonos Etatonos Iotatonos Omicrontonos Upsilontonos Omegatonos Iotadieresis Upsilondieresis ] ;\012\012@grk_lowercase = [ alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alphatonos epsilontonos etatonos iotatonos omicrontonos upsilontonos omegatonos iotadieresis upsilondieresis iotadieresistonos upsilondieresistonos sigmafinal ] ;\012\012@grk_smallcaps = [ alpha.sc beta.sc gamma.sc delta.sc epsilon.sc zeta.sc eta.sc theta.sc iota.sc kappa.sc lambda.sc mu.sc nu.sc xi.sc omicron.sc pi.sc rho.sc sigma.sc tau.sc upsilon.sc phi.sc chi.sc psi.sc omega.sc alphatonos.sc epsilontonos.sc etatonos.sc iotatonos.sc omicrontonos.sc upsilontonos.sc omegatonos.sc iotadieresis.sc upsilondieresis.sc iotadieresistonos.sc upsilondieresistonos.sc sigmafinal.sc ] ;\012\012";
 name = Languagesystems;
 }
 );
 features = (
 {
-code = "    # ================
-    # BEGIN LATIN
-    # ================
-    
-    sub Ccedilla from [Ccedilla Ccedilla.alt];
-    sub Ccedilla.alt from [Ccedilla.alt Ccedilla];
-    sub euro from [euro euro.cap euro.tf];
-    sub euro.tf from [euro.tf euro euro.cap];
-    sub euro.cap from [euro.cap euro.tf euro];
-    sub G from [G G.alt G.logo];
-    sub G.logo from [G.logo G G.alt];
-    sub G.alt from [G.alt G.logo G];
-    sub Gbreve from [Gbreve Gbreve.alt];
-    sub Gbreve.alt from [Gbreve.alt Gbreve];
-    sub Gcircumflex from [Gcircumflex Gcircumflex.alt];
-    sub Gcircumflex.alt from [Gcircumflex.alt Gcircumflex];
-    sub Gdotaccent from [Gdotaccent Gdotaccent.alt];
-    sub Gdotaccent.alt from [Gdotaccent.alt Gdotaccent];
-    sub Gcommaaccent from [Gcommaaccent Gcommaaccent.alt];
-    sub Gcommaaccent.alt from [Gcommaaccent.alt Gcommaaccent];
-    sub I from [I I.alt];
-    sub I.alt from [I.alt I];
-    sub Iacute from [Iacute Iacute.alt];
-    sub Iacute.alt from [Iacute.alt Iacute];
-    sub Ibreve from [Ibreve Ibreve.alt];
-    sub Ibreve.alt from [Ibreve.alt Ibreve];
-    sub Icircumflex from [Icircumflex Icircumflex.alt];
-    sub Icircumflex.alt from [Icircumflex.alt Icircumflex];
-    sub Idieresis from [Idieresis Idieresis.alt];
-    sub Idieresis.alt from [Idieresis.alt Idieresis];
-    sub Idotaccent from [Idotaccent Idotaccent.alt];
-    sub Idotaccent.alt from [Idotaccent.alt Idotaccent];
-    sub Igrave from [Igrave Igrave.alt];
-    sub Igrave.alt from [Igrave.alt Igrave];
-    sub Imacron from [Imacron Imacron.alt];
-    sub Imacron.alt from [Imacron.alt Imacron];
-    sub Iogonek from [Iogonek Iogonek.alt];
-    sub Iogonek.alt from [Iogonek.alt Iogonek];
-    sub Itilde from [Itilde Itilde.alt];
-    sub Itilde.alt from [Itilde.alt Itilde];
-    sub J from [J J.alt];
-    sub J.alt from [J.alt J];
-    sub Jcircumflex from [Jcircumflex Jcircumflex.alt];
-    sub Jcircumflex.alt from [Jcircumflex.alt Jcircumflex];
-    sub K from [K K.alt];
-    sub K.alt from [K.alt K];
-    sub Kcommaaccent from [Kcommaaccent Kcommaaccent.alt];
-    sub Kcommaaccent.alt from [Kcommaaccent.alt Kcommaaccent];
-    sub M from [M M.alt];
-    sub M.alt from [M.alt M];
-    sub Q from [Q Q.alt];
-    sub Q.alt from [Q.alt Q];
-    sub R from [R R.alt];
-    sub R.alt from [R.alt R];
-    sub Racute from [Racute Racute.alt];
-    sub Racute.alt from [Racute.alt Racute];
-    sub Rcaron from [Rcaron Rcaron.alt];
-    sub Rcaron.alt from [Rcaron.alt Rcaron];
-    sub Rcommaaccent from [Rcommaaccent Rcommaaccent.alt];
-    sub Rcommaaccent.alt from [Rcommaaccent.alt Rcommaaccent];
-    sub Scedilla from [Scedilla Scedilla.alt];
-    sub Scedilla.alt from [Scedilla.alt Scedilla];
-    sub W from [W W.alt];
-    sub W.alt from [W.alt W];
-    sub Wacute from [Wacute Wacute.alt];
-    sub Wacute.alt from [Wacute.alt Wacute];
-    sub Wcircumflex from [Wcircumflex Wcircumflex.alt];
-    sub Wcircumflex.alt from [Wcircumflex.alt Wcircumflex];
-    sub Wdieresis from [Wdieresis Wdieresis.alt];
-    sub Wdieresis.alt from [Wdieresis.alt Wdieresis];
-    sub Wgrave from [Wgrave Wgrave.alt];
-    sub Wgrave.alt from [Wgrave.alt Wgrave];
-    sub a from [a a.alt];
-    sub a.alt from [a.alt a];
-    sub aacute from [aacute aacute.alt];
-    sub aacute.alt from [aacute.alt aacute];
-    sub abreve from [abreve abreve.alt];
-    sub abreve.alt from [abreve.alt abreve];
-    sub acircumflex from [acircumflex acircumflex.alt];
-    sub acircumflex.alt from [acircumflex.alt acircumflex];
-    sub acutecomb from [acutecomb acutecomb.cap];
-    sub acutecomb.cap from [acutecomb.cap acute];
-    sub adieresis from [adieresis adieresis.alt];
-    sub adieresis.alt from [adieresis.alt adieresis];
-    sub ae from [ae ae.alt];
-    sub ae.alt from [ae.alt ae];
-    sub aeacute from [aeacute aeacute.alt];
-    sub aeacute.alt from [aeacute.alt aeacute];
-    sub agrave from [agrave agrave.alt];
-    sub agrave.alt from [agrave.alt agrave];
-    sub amacron from [amacron amacron.alt];
-    sub amacron.alt from [amacron.alt amacron];
-    sub ampersand from [ampersand ampersand.alt];
-    sub ampersand.alt from [ampersand.alt ampersand];
-    sub aogonek from [aogonek aogonek.alt];
-    sub aogonek.alt from [aogonek.alt aogonek];
-    sub adotbelow from [adotbelow adotbelow.alt];
-    sub adotbelow.alt from [adotbelow.alt adotbelow];
-    sub ahookabove from [ahookabove ahookabove.alt];
-    sub ahookabove.alt from [ahookabove.alt ahookabove];
-    sub acircumflexacute from [acircumflexacute acircumflexacute.alt];
-    sub acircumflexacute.alt from [acircumflexacute.alt acircumflexacute];   
-    sub acircumflexgrave from [acircumflexgrave acircumflexgrave.alt];
-    sub acircumflexgrave.alt from [acircumflexgrave.alt acircumflexgrave];   
-    sub acircumflexhookabove from [acircumflexhookabove acircumflexhookabove.alt];
-    sub acircumflexhookabove.alt from [acircumflexhookabove.alt acircumflexhookabove];  
-    sub acircumflextilde from [acircumflextilde acircumflextilde.alt];
-    sub acircumflextilde.alt from [acircumflextilde.alt acircumflextilde];
-    sub acircumflexdotbelow from [acircumflexdotbelow acircumflexdotbelow.alt];
-    sub acircumflexdotbelow.alt from [acircumflexdotbelow.alt acircumflexdotbelow];    
-    sub abreveacute from [abreveacute abreveacute.alt];
-    sub abreveacute.alt from [abreveacute.alt abreveacute]; 
-    sub abrevegrave from [abrevegrave abrevegrave.alt];
-    sub abrevegrave.alt from [abrevegrave.alt abrevegrave]; 
-    sub abrevehookabove from [abrevehookabove abrevehookabove.alt];
-    sub abrevehookabove.alt from [abrevehookabove.alt abrevehookabove];   
-    sub abrevetilde from [abrevetilde abrevetilde.alt];
-    sub abrevetilde.alt from [abrevetilde.alt abrevetilde];   
-    sub abrevedotbelow from [abrevedotbelow abrevedotbelow.alt];
-    sub abrevedotbelow.alt from [abrevedotbelow.alt abrevedotbelow];            
-    sub quoteright from [quoteright quoteright.alt];
-    sub quoteright.alt from [quoteright.alt quoteright];
-    sub approxequal from [approxequal approxequal.tf];
-    sub approxequal.tf from [approxequal.tf approxequal];
-    sub aring from [aring aring.alt];
-    sub aring.alt from [aring.alt aring];
-    sub aringacute from [aringacute aringacute.alt];
-    sub aringacute.alt from [aringacute.alt aringacute];
-    sub at from [at at.cap];
-    sub at.cap from [at.cap at];
-    sub atilde from [atilde atilde.alt];
-    sub atilde.alt from [atilde.alt atilde];
-    sub braceleft from [braceleft braceleft.cap];
-    sub braceleft.cap from [braceleft.cap braceleft];
-    sub braceright from [braceright braceright.cap];
-    sub braceright.cap from [braceright.cap braceright];
-    sub bracketleft from [bracketleft bracketleft.cap];
-    sub bracketleft.cap from [bracketleft.cap bracketleft];
-    sub bracketright from [bracketright bracketright.cap];
-    sub bracketright.cap from [bracketright.cap bracketright];
-    sub brevecomb from [brevecomb brevecomb.cap];
-    sub brevecomb.cap from [brevecomb.cap brevecomb];
-    sub brevecombcy from [brevecombcy brevecombcy.cap brevecombcy.sc];
-    sub brevecombcy.cap from [brevecombcy.cap brevecombcy brevecombcy.sc];
-    sub brevecombcy.sc from [brevecombcy.sc brevecombcy brevecombcy.cap]; 
-    sub brevecomb_hookabovecomb from [brevecomb_hookabovecomb brevecomb_hookabovecomb.cap];
-    sub brevecomb_hookabovecomb.cap from [brevecomb_hookabovecomb.cap brevecomb_hookabovecomb];
-    sub bullet from [bullet bullet.cap];
-    sub bullet.cap from [bullet.cap bullet];
-    sub caroncomb from [caroncomb caron.alt caroncomb.cap];
-    sub caroncomb.cap from [caroncomb.cap caron caroncomb.alt];
-    sub caroncomb.alt from [caroncomb.alt caroncomb.alt.cap];
-    sub caroncomb.alt.cap from [caroncomb.alt.cap caroncomb.alt];    
-    sub caron.alt from [caron.alt caroncomb.cap caron];
-    sub ccedilla from [ccedilla ccedilla.alt];
-    sub ccedilla.alt from [ccedilla.alt ccedilla];
-    sub cedilla from [cedilla cedilla.alt];
-    sub cedilla.alt from [cedilla.alt cedilla];
-    sub cedillacomb from [cedillacomb cedillacomb.alt];
-    sub cedillacomb.alt from [cedillacomb.alt cedillacomb];    
-    sub cent from [cent cent.tf cent.cap];
-    sub cent.cap from [cent.cap cent cent.tf];
-    sub cent.tf from [cent.tf cent.cap cent];
-    sub circumflex from [circumflex circumflexcomb.cap];
-    sub circumflexcomb.cap from [circumflexcomb.cap circumflex];
-    sub circumflexcomb_hookabovecomb from [circumflexcomb_hookabovecomb circumflexcomb_hookabovecomb.cap];
-    sub circumflexcomb_hookabovecomb.cap from [circumflexcomb_hookabovecomb.cap circumflexcomb_hookabovecomb];
-    sub colon from [colon colon.tf];
-    sub colon.tf from [colon.tf colon];
-    sub comma from [comma comma.tf comma.alt];
-    sub comma.alt from [comma.alt comma comma.tf];
-    sub comma.tf from [comma.tf comma.alt comma];
-    sub copyright from [copyright copyright.alt];
-    sub copyright.alt from [copyright.alt copyright];
-    sub currency from [currency currency.cap currency.tf];
-    sub currency.tf from [currency.tf currency currency.cap];
-    sub currency.cap from [currency.cap currency.tf currency];
-    sub degree from [degree degree.cap];
-    sub degree.cap from [degree.cap degree];
-    sub dieresis from [dieresis dieresiscomb.cap];
-    sub dieresiscomb.cap from [dieresiscomb.cap dieresis];
-    sub dieresistonos from [dieresistonos];
-    sub divide from [divide divide.tf];
-    sub divide.tf from [divide.tf divide];
-    sub dollar from [dollar dollar.tf dollar.cap];
-    sub dollar.cap from [dollar.cap dollar dollar.tf];
-    sub dollar.tf from [dollar.tf dollar.cap dollar];
-    sub dotaccent from [dotaccent dotaccentcomb dotaccentcomb.cap];
-    sub dotaccentcomb.cap from [dotaccentcomb.cap dotaccentcomb dotaccent];
-    sub e from [e e.logo];
-    sub e.logo from [e.logo e];
-    sub eight from [eight eight.tf eight.cap eight.numerator eight.denominator];
-    sub eight.denominator from [eight.denominator eight eight.tf eight.cap eight.numerator];
-    sub eight.numerator from [eight.numerator eight.denominator eight eight.tf eight.cap];
-    sub eight.cap from [eight.cap eight.numerator eight.denominator eight eight.tf];
-    sub eight.tf from [eight.tf eight.cap eight.numerator eight.denominator eight];
-    sub emdash from [emdash emdash.cap];
-    sub emdash.cap from [emdash.cap emdash];
-    sub endash from [endash endash.cap];
-    sub endash.cap from [endash.cap endash];
-    sub equal from [equal equal.tf];
-    sub equal.tf from [equal.tf equal];
-    sub exclamdown from [exclamdown exclamdown.cap];
-    sub exclamdown.cap from [exclamdown.cap exclamdown];
-    sub f_f_j from [f_f_j f_f_j.alt];
-    sub f_f_j.alt from [f_f_j.alt f_f_j];
-    sub f_f_k from [f_f_k f_f_k.alt];
-    sub f_f_k.alt from [f_f_k.alt f_f_k];
-    sub f_f_t from [f_f_t f_f_t.alt];
-    sub f_f_t.alt from [f_f_t.alt f_f_t];
-    sub f_j from [f_j f_j.alt];
-    sub f_j.alt from [f_j.alt f_j];
-    sub f_k from [f_k f_k.alt];
-    sub f_k.alt from [f_k.alt f_k];
-    sub f_t from [f_t f_t.alt];
-    sub f_t.alt from [f_t.alt f_t];
-    sub five from [five five.cap five.tf five.numerator five.denominator];
-    sub five.denominator from [five.denominator five five.cap five.tf five.numerator];
-    sub five.numerator from [five.numerator five.denominator five five.cap five.tf];
-    sub five.tf from [five.tf five.numerator five.denominator five five.cap];
-    sub five.cap from [five.cap five.tf five.numerator five.denominator five];
-    sub florin from [florin florin.tf];
-    sub florin.tf from [florin.tf florin];
-    sub four from [four four.cap four.tf four.denominator four.numerator];
-    sub four.numerator from [four.numerator four four.cap four.tf four.denominator];
-    sub four.denominator from [four.denominator four.numerator four four.cap four.tf];
-    sub four.tf from [four.tf four.denominator four.numerator four four.cap];
-    sub four.cap from [four.cap four.tf four.denominator four.numerator four];
-    sub g from [g g.logo];
-    sub g.logo from [g.logo g];
-    sub grave from [grave gravecomb gravecomb.cap];
-    sub gravecomb.cap from [gravecomb.cap grave];
-    sub greater from [greater greater.tf];
-    sub greater.tf from [greater.tf greater];
-    sub greaterequal from [greaterequal greaterequal.tf];
-    sub greaterequal.tf from [greaterequal.tf greaterequal];
-    sub guillemetleft from [guillemetleft guillemetleft.cap];
-    sub guillemetleft.cap from [guillemetleft.cap guillemetleft];
-    sub guillemetright from [guillemetright guillemetright.cap];
-    sub guillemetright.cap from [guillemetright.cap guillemetright];
-    sub guilsinglleft from [guilsinglleft guilsinglleft.cap];
-    sub guilsinglleft.cap from [guilsinglleft.cap guilsinglleft];
-    sub guilsinglright from [guilsinglright guilsinglright.cap];
-    sub guilsinglright.cap from [guilsinglright.cap guilsinglright];
-	sub hookabovecomb from [hookabovecomb hookabovecomb.cap];
-    sub hookabovecomb.cap from [hookabovecomb.cap hookabovecomb];
-   	sub horncomb from [horncomb horncomb.cap];
-    sub horncomb.cap from [horncomb.cap horncomb];    
-    sub hungarumlaut from [hungarumlaut hungarumlautcomb hungarumlautcomb.cap];
-    sub hungarumlautcomb.cap from [hungarumlautcomb.cap hungarumlautcomb hungarumlaut];
-    sub hyphen from [hyphen hyphen.cap];
-    sub hyphen.cap from [hyphen.cap hyphen];
-    sub j from [j j.alt];
-    sub j.alt from [j.alt j];
-    sub jdotless from [jdotless.alt jdotless];
-    sub jdotless.alt from [jdotless.alt jdotless];
-    sub jcircumflex from [jcircumflex jcircumflex.alt];
-    sub jcircumflex.alt from [jcircumflex.alt jcircumflex];
-    sub k from [k k.alt];
-    sub k.alt from [k.alt k];
-    sub kcommaaccent from [kcommaaccent kcommaaccent.alt];
-    sub kcommaaccent.alt from [kcommaaccent.alt kcommaaccent];
-    sub l from [l l.logo];
-    sub l.logo from [l.logo l];
-    sub less from [less less.tf];
-    sub less.tf from [less.tf less];
-    sub lessequal from [lessequal lessequal.tf];
-    sub lessequal.tf from [lessequal.tf lessequal];
-    sub logicalnot from [logicalnot logicalnot.tf];
-    sub logicalnot.tf from [logicalnot.tf logicalnot];
-    sub macron from [macron macroncomb macroncomb.cap];
-    sub macroncomb.cap from [macroncomb.cap macroncomb macron];
-    sub minus from [minus minus.tf];
-    sub minus.tf from [minus.tf minus];
-    sub multiply from [multiply multiply.tf];
-    sub multiply.tf from [multiply.tf multiply];
-    sub nine from [nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt];
-    sub nine.alt from [nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator];
-    sub nine.numerator from [nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf];
-    sub nine.tf from [nine.tf nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap];
-    sub nine.alt.cap from [nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator nine.cap];
-    sub nine.cap from [nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator];
-    sub nine.denominator from [nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine];
-    sub notequal from [notequal notequal.tf];
-    sub notequal.tf from [notequal.tf notequal];
-    sub numbersign from [numbersign numbersign.tf numbersign.cap];
-    sub numbersign.cap from [numbersign.cap numbersign numbersign.tf];
-    sub numbersign.tf from [numbersign.tf numbersign.cap numbersign];
-    sub o from [o o.logo];
-    sub o.logo from [o.logo o];
-    sub one from [one one.alt one.cap one.numerator one.alt.cap one.denominator one.tf];
-    sub one.tf from [one.tf one one.alt one.cap one.numerator one.alt.cap one.denominator];
-    sub one.denominator from [one.denominator one.tf one one.alt one.cap one.numerator one.alt.cap];
-    sub one.alt.cap from [one.alt.cap one.denominator one.tf one one.alt one.cap one.numerator];
-    sub one.numerator from [one.numerator one.alt.cap one.denominator one.tf one one.alt one.cap];
-    sub one.cap from [one.cap one.numerator one.alt.cap one.denominator one.tf one one.alt];
-    sub one.alt from [one.alt one.cap one.numerator one.alt.cap one.denominator one.tf one];
-    sub parenleft from [parenleft parenleft.cap];
-    sub parenleft.cap from [parenleft.cap parenleft];
-    sub parenright from [parenright parenright.cap];
-    sub parenright.cap from [parenright.cap parenright];
-    sub percent from [percent percent.cap percent.tf];
-    sub percent.tf from [percent.tf percent percent.cap];
-    sub percent.cap from [percent.cap percent.tf percent];
-    sub period from [period period.tf];
-    sub period.tf from [period.tf period];
-    sub pertenthousand from [pertenthousand pertenthousand.cap];
-    sub pertenthousand.cap from [pertenthousand.cap pertenthousand];
-    sub perthousand from [perthousand perthousand.cap];
-    sub perthousand.cap from [perthousand.cap perthousand];
-    sub plus from [plus plus.tf];
-    sub plus.tf from [plus.tf plus];
-    sub plusminus from [plusminus plusminus.tf];
-    sub plusminus.tf from [plusminus.tf plusminus];
-    sub q from [q q.alt];
-    sub q.alt from [q.alt q];
-    sub questiondown from [questiondown questiondown.cap];
-    sub questiondown.cap from [questiondown.cap questiondown];
-    sub quotedblbase from [quotedblbase quotedblbase.alt];
-    sub quotedblbase.alt from [quotedblbase.alt quotedblbase];
-    sub quotedblleft from [quotedblleft quotedblleft.alt];
-    sub quotedblleft.alt from [quotedblleft.alt quotedblleft];
-    sub quotedblright from [quotedblright quotedblright.alt];
-    sub quotedblright.alt from [quotedblright.alt quotedblright];
-    sub quoteleft from [quoteleft quoteleft.alt];
-    sub quoteleft.alt from [quoteleft.alt quoteleft];
-    sub quoteright from [quoteright quoteright.alt];
-    sub quoteright.alt from [quoteright.alt quoteright];
-    sub quotesinglbase from [quotesinglbase quotesinglbase.alt];
-    sub quotesinglbase.alt from [quotesinglbase.alt quotesinglbase];
-    sub r from [r r.alt];
-    sub r.alt from [r.alt r];
-    sub r_t from [r_t r_t.alt];
-    sub r_t.alt from [r_t.alt r_t];
-    sub racute from [racute racute.alt];
-    sub racute.alt from [racute.alt racute];
-    sub rcaron from [rcaron rcaron.alt];
-    sub rcaron.alt from [rcaron.alt rcaron];
-    sub rcommaaccent from [rcommaaccent rcommaaccent.alt];    
-    sub rcommaaccent.alt from [rcommaaccent.alt rcommaaccent];
-    sub registered from [registered registered.alt];
-    sub registered.alt from [registered.alt registered];
-    sub ring from [ring ringcomb ringcomb.cap];
-    sub ringcomb.cap from [ringcomb.cap ringcomb ring];
-    sub scedilla from [scedilla scedilla.alt];
-    sub scedilla.alt from [scedilla.alt scedilla];
-    sub section from [section section.tf];
-    sub section.tf from [section.tf section];
-    sub semicolon from [semicolon semicolon.tf semicolon.alt];
-    sub semicolon.alt from [semicolon.alt semicolon semicolon.tf];
-    sub semicolon.tf from [semicolon.tf semicolon.alt semicolon];
-    sub seven from [seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator];
-    sub seven.denominator from [seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf];
-    sub seven.tf from [seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator];
-    sub seven.numerator from [seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt];
-    sub seven.alt from [seven.alt seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap];
-    sub seven.alt.cap from [seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven seven.cap];
-    sub seven.cap from [seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven];
-    sub six from [six six.numerator six.alt.cap six.cap six.tf six.denominator six.alt];
-    sub six.alt from [six.alt six six.numerator six.alt.cap six.cap six.tf six.denominator];
-    sub six.denominator from [six.denominator six.alt six six.numerator six.alt.cap six.cap six.tf];
-    sub six.tf from [six.tf six.denominator six.alt six six.numerator six.alt.cap six.cap];
-    sub six.cap from [six.cap six.tf six.denominator six.alt six six.numerator six.alt.cap];
-    sub six.alt.cap from [six.alt.cap six.cap six.tf six.denominator six.alt six six.numerator];
-    sub six.numerator from [six.numerator six.alt.cap six.cap six.tf six.denominator six.alt six];
-    sub space from [space space.tf];
-    sub space.tf from [space.tf space];
-    sub sterling from [sterling sterling.cap sterling.tf];
-    sub sterling.tf from [sterling.tf sterling sterling.cap];
-    sub sterling.cap from [sterling.cap sterling.tf sterling];
-    sub t from [t t.alt];
-    sub t.alt from [t.alt t];
-    sub tcedilla from [tcedilla tcedilla.alt tcedilla.alt.2];
-    sub tcedilla.alt from [tcedilla.alt tcedilla tcedilla.alt.2];
-    sub tcedilla.alt.2 from [tcedilla.alt.2 tcedilla.alt tcedilla];
-    sub tcommaaccent from [tcommaaccent tcommaaccent.alt];
-    sub tcommaaccent.alt from [tcommaaccent.alt tcommaaccent];
-    sub t_f from [t_f t_f.alt];
-    sub t_f.alt from [t_f.alt t_f];
-    sub t_t from [t_t t_t.alt];
-    sub t_t.alt from [t_t.alt t_t];
-    sub tbar from [tbar tbar.alt];
-    sub tbar.alt from [tbar.alt tbar];
-    sub tcaron from [tcaron tcaron.alt];
-    sub tcaron.alt from [tcaron.alt tcaron];
-    sub three from [three three.denominator three.numerator three.tf three.cap];
-    sub three.cap from [three.cap three three.denominator three.numerator three.tf];
-    sub three.tf from [three.tf three.cap three three.denominator three.numerator];
-    sub three.numerator from [three.numerator three.tf three.cap three three.denominator];
-    sub three.denominator from [three.denominator three.numerator three.tf three.cap three];
-    sub tilde from [tilde tildecomb tildecomb.cap];
-    sub tildecomb.cap from [tildecomb.cap tildecomb tilde];
-    sub trademark from [trademark trademark.alt2 trademark.alt trademark.alt3];
-    sub trademark.alt3 from [trademark.alt3 trademark trademark.alt2 trademark.alt];
-    sub trademark.alt from [trademark.alt trademark.alt3 trademark trademark.alt2];
-    sub trademark.alt2 from [trademark.alt2 trademark.alt trademark.alt3 trademark];
-    sub two from [two two.cap two.denominator two.tf two.numerator];
-    sub two.numerator from [two.numerator two two.cap two.denominator two.tf];
-    sub two.tf from [two.tf two.numerator two two.cap two.denominator];
-    sub two.denominator from [two.denominator two.tf two.numerator two two.cap];
-    sub two.cap from [two.cap two.denominator two.tf two.numerator two];
-    sub baht from [baht baht.cap];
-    sub baht.cap from [baht.cap baht];
-    sub franc from [franc franc.tf franc.cap];
-    sub franc.cap from [franc.cap franc franc.tf];
-    sub franc.tf from [franc.tf franc.cap franc];
-    sub lira from [lira lira.cap lira.tf];
-    sub lira.tf from [lira.tf lira lira.cap];
-    sub lira.cap from [lira.cap lira.tf lira];
-    sub won from [won won.tf won.cap];
-    sub won.cap from [won.cap won won.tf];
-    sub won.tf from [won.tf won.cap won];
-    sub dong from [dong dong.tf dong.cap];
-    sub dong.cap from [dong.cap dong dong.tf];
-    sub dong.tf from [dong.tf dong.cap dong];
-    sub tugrik from [tugrik tugrik.tf tugrik.cap];
-    sub tugrik.cap from [tugrik.cap tugrik tugrik.tf];
-    sub tugrik.tf from [tugrik.tf tugrik.cap tugrik];
-    sub peso from [peso peso.cap peso.tf];
-    sub peso.tf from [peso.tf peso peso.cap];
-    sub peso.cap from [peso.cap peso.tf peso];
-    sub tenge from [tenge tenge.cap tenge.tf];
-    sub tenge.tf from [tenge.tf tenge tenge.cap];
-    sub tenge.cap from [tenge.cap tenge.tf tenge];
-    sub rupeeIndian from [rupeeIndian rupeeIndian.cap rupeeIndian.tf];
-    sub rupeeIndian.tf from [rupeeIndian.tf rupeeIndian rupeeIndian.cap];
-    sub rupeeIndian.cap from [rupeeIndian.cap rupeeIndian.tf rupeeIndian];
-    sub liraTurkish from [liraTurkish liraTurkish.cap liraTurkish.tf];
-    sub liraTurkish.tf from [liraTurkish.tf liraTurkish liraTurkish.cap];
-    sub liraTurkish.cap from [liraTurkish.cap liraTurkish.tf liraTurkish];
-    sub ruble from [ruble ruble.cap ruble.tf];
-    sub ruble.tf from [ruble.tf ruble ruble.cap];
-    sub ruble.cap from [ruble.cap ruble.tf ruble];
-    sub centigrade from [centigrade centigrade.cap];
-    sub centigrade.cap from [centigrade.cap centigrade];
-    sub fahrenheit from [fahrenheit fahrenheit.cap];
-    sub fahrenheit.cap from [fahrenheit.cap fahrenheit];
-    sub published from [published published.alt];
-    sub published.alt from [published.alt published];
-    sub servicemark from [servicemark servicemark.alt3 servicemark.alt servicemark.alt2];
-    sub servicemark.alt2 from [servicemark.alt2 servicemark servicemark.alt3 servicemark.alt];
-    sub servicemark.alt from [servicemark.alt servicemark.alt2 servicemark servicemark.alt3];
-    sub servicemark.alt3 from [servicemark.alt3 servicemark.alt servicemark.alt2 servicemark];
-    sub y from [y y.alt];
-    sub y.alt from [y.alt y];
-    sub yacute from [yacute yacute.alt];
-    sub yacute.alt from [yacute.alt yacute];
-    sub ycircumflex from [ycircumflex ycircumflex.alt];
-    sub ycircumflex.alt from [ycircumflex.alt ycircumflex];
-    sub ydieresis from [ydieresis ydieresis.alt];
-    sub ydieresis.alt from [ydieresis.alt ydieresis];
-    sub ydotbelow from [ydotbelow ydotbelow.alt];
-    sub ydotbelow.alt from [ydotbelow.alt ydotbelow];    
-    sub yhookabove from [yhookabove yhookabove.alt];
-    sub yhookabove.alt from [yhookabove.alt yhookabove];   
-    sub ytilde from [ytilde ytilde.alt];
-    sub ytilde.alt from [ytilde.alt ytilde];    
-    sub yen from [yen yen.tf yen.cap];
-    sub yen.cap from [yen.cap yen yen.tf];
-    sub yen.tf from [yen.tf yen.cap yen];
-    sub ygrave from [ygrave ygrave.alt];
-    sub ygrave.alt from [ygrave.alt ygrave];
-    sub zero from [zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf];
-    sub zero.tf from [zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator];
-    sub zero.numerator from [zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt];
-    sub zero.alt from [zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator];
-    sub zero.denominator from [zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap];
-    sub zero.cap from [zero.cap zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap];
-    sub zero.alt.cap from [zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf zero];
-    
-    # ================
-    # END LATIN
-    # ================
-    
-    # ================
-    # BEGIN HEBREW
-    # ================
-    
-    feature jalt;
-    
-    # ================
-    # END HEBREW
-    # ================";
+code = "    # ================\012    # BEGIN LATIN\012    # ================\012    \012    sub Ccedilla from [Ccedilla Ccedilla.alt];\012    sub Ccedilla.alt from [Ccedilla.alt Ccedilla];\012    sub euro from [euro euro.cap euro.tf];\012    sub euro.tf from [euro.tf euro euro.cap];\012    sub euro.cap from [euro.cap euro.tf euro];\012    sub G from [G G.alt G.logo];\012    sub G.logo from [G.logo G G.alt];\012    sub G.alt from [G.alt G.logo G];\012    sub Gbreve from [Gbreve Gbreve.alt];\012    sub Gbreve.alt from [Gbreve.alt Gbreve];\012    sub Gcircumflex from [Gcircumflex Gcircumflex.alt];\012    sub Gcircumflex.alt from [Gcircumflex.alt Gcircumflex];\012    sub Gdotaccent from [Gdotaccent Gdotaccent.alt];\012    sub Gdotaccent.alt from [Gdotaccent.alt Gdotaccent];\012    sub Gcommaaccent from [Gcommaaccent Gcommaaccent.alt];\012    sub Gcommaaccent.alt from [Gcommaaccent.alt Gcommaaccent];\012    sub I from [I I.alt];\012    sub I.alt from [I.alt I];\012    sub Iacute from [Iacute Iacute.alt];\012    sub Iacute.alt from [Iacute.alt Iacute];\012    sub Ibreve from [Ibreve Ibreve.alt];\012    sub Ibreve.alt from [Ibreve.alt Ibreve];\012    sub Icircumflex from [Icircumflex Icircumflex.alt];\012    sub Icircumflex.alt from [Icircumflex.alt Icircumflex];\012    sub Idieresis from [Idieresis Idieresis.alt];\012    sub Idieresis.alt from [Idieresis.alt Idieresis];\012    sub Idotaccent from [Idotaccent Idotaccent.alt];\012    sub Idotaccent.alt from [Idotaccent.alt Idotaccent];\012    sub Igrave from [Igrave Igrave.alt];\012    sub Igrave.alt from [Igrave.alt Igrave];\012    sub Imacron from [Imacron Imacron.alt];\012    sub Imacron.alt from [Imacron.alt Imacron];\012    sub Iogonek from [Iogonek Iogonek.alt];\012    sub Iogonek.alt from [Iogonek.alt Iogonek];\012    sub Itilde from [Itilde Itilde.alt];\012    sub Itilde.alt from [Itilde.alt Itilde];\012    sub J from [J J.alt];\012    sub J.alt from [J.alt J];\012    sub Jcircumflex from [Jcircumflex Jcircumflex.alt];\012    sub Jcircumflex.alt from [Jcircumflex.alt Jcircumflex];\012    sub K from [K K.alt];\012    sub K.alt from [K.alt K];\012    sub Kcommaaccent from [Kcommaaccent Kcommaaccent.alt];\012    sub Kcommaaccent.alt from [Kcommaaccent.alt Kcommaaccent];\012    sub M from [M M.alt];\012    sub M.alt from [M.alt M];\012    sub Q from [Q Q.alt];\012    sub Q.alt from [Q.alt Q];\012    sub R from [R R.alt];\012    sub R.alt from [R.alt R];\012    sub Racute from [Racute Racute.alt];\012    sub Racute.alt from [Racute.alt Racute];\012    sub Rcaron from [Rcaron Rcaron.alt];\012    sub Rcaron.alt from [Rcaron.alt Rcaron];\012    sub Rcommaaccent from [Rcommaaccent Rcommaaccent.alt];\012    sub Rcommaaccent.alt from [Rcommaaccent.alt Rcommaaccent];\012    sub Scedilla from [Scedilla Scedilla.alt];\012    sub Scedilla.alt from [Scedilla.alt Scedilla];\012    sub W from [W W.alt];\012    sub W.alt from [W.alt W];\012    sub Wacute from [Wacute Wacute.alt];\012    sub Wacute.alt from [Wacute.alt Wacute];\012    sub Wcircumflex from [Wcircumflex Wcircumflex.alt];\012    sub Wcircumflex.alt from [Wcircumflex.alt Wcircumflex];\012    sub Wdieresis from [Wdieresis Wdieresis.alt];\012    sub Wdieresis.alt from [Wdieresis.alt Wdieresis];\012    sub Wgrave from [Wgrave Wgrave.alt];\012    sub Wgrave.alt from [Wgrave.alt Wgrave];\012    sub a from [a a.alt];\012    sub a.alt from [a.alt a];\012    sub aacute from [aacute aacute.alt];\012    sub aacute.alt from [aacute.alt aacute];\012    sub abreve from [abreve abreve.alt];\012    sub abreve.alt from [abreve.alt abreve];\012    sub acircumflex from [acircumflex acircumflex.alt];\012    sub acircumflex.alt from [acircumflex.alt acircumflex];\012    sub acutecomb from [acutecomb acutecomb.cap];\012    sub acutecomb.cap from [acutecomb.cap acute];\012    sub adieresis from [adieresis adieresis.alt];\012    sub adieresis.alt from [adieresis.alt adieresis];\012    sub ae from [ae ae.alt];\012    sub ae.alt from [ae.alt ae];\012    sub aeacute from [aeacute aeacute.alt];\012    sub aeacute.alt from [aeacute.alt aeacute];\012    sub agrave from [agrave agrave.alt];\012    sub agrave.alt from [agrave.alt agrave];\012    sub amacron from [amacron amacron.alt];\012    sub amacron.alt from [amacron.alt amacron];\012    sub ampersand from [ampersand ampersand.alt];\012    sub ampersand.alt from [ampersand.alt ampersand];\012    sub aogonek from [aogonek aogonek.alt];\012    sub aogonek.alt from [aogonek.alt aogonek];\012    sub adotbelow from [adotbelow adotbelow.alt];\012    sub adotbelow.alt from [adotbelow.alt adotbelow];\012    sub ahookabove from [ahookabove ahookabove.alt];\012    sub ahookabove.alt from [ahookabove.alt ahookabove];\012    sub acircumflexacute from [acircumflexacute acircumflexacute.alt];\012    sub acircumflexacute.alt from [acircumflexacute.alt acircumflexacute];   \012    sub acircumflexgrave from [acircumflexgrave acircumflexgrave.alt];\012    sub acircumflexgrave.alt from [acircumflexgrave.alt acircumflexgrave];   \012    sub acircumflexhookabove from [acircumflexhookabove acircumflexhookabove.alt];\012    sub acircumflexhookabove.alt from [acircumflexhookabove.alt acircumflexhookabove];  \012    sub acircumflextilde from [acircumflextilde acircumflextilde.alt];\012    sub acircumflextilde.alt from [acircumflextilde.alt acircumflextilde];\012    sub acircumflexdotbelow from [acircumflexdotbelow acircumflexdotbelow.alt];\012    sub acircumflexdotbelow.alt from [acircumflexdotbelow.alt acircumflexdotbelow];    \012    sub abreveacute from [abreveacute abreveacute.alt];\012    sub abreveacute.alt from [abreveacute.alt abreveacute]; \012    sub abrevegrave from [abrevegrave abrevegrave.alt];\012    sub abrevegrave.alt from [abrevegrave.alt abrevegrave]; \012    sub abrevehookabove from [abrevehookabove abrevehookabove.alt];\012    sub abrevehookabove.alt from [abrevehookabove.alt abrevehookabove];   \012    sub abrevetilde from [abrevetilde abrevetilde.alt];\012    sub abrevetilde.alt from [abrevetilde.alt abrevetilde];   \012    sub abrevedotbelow from [abrevedotbelow abrevedotbelow.alt];\012    sub abrevedotbelow.alt from [abrevedotbelow.alt abrevedotbelow];            \012    sub quoteright from [quoteright quoteright.alt];\012    sub quoteright.alt from [quoteright.alt quoteright];\012    sub approxequal from [approxequal approxequal.tf];\012    sub approxequal.tf from [approxequal.tf approxequal];\012    sub aring from [aring aring.alt];\012    sub aring.alt from [aring.alt aring];\012    sub aringacute from [aringacute aringacute.alt];\012    sub aringacute.alt from [aringacute.alt aringacute];\012    sub at from [at at.cap];\012    sub at.cap from [at.cap at];\012    sub atilde from [atilde atilde.alt];\012    sub atilde.alt from [atilde.alt atilde];\012    sub braceleft from [braceleft braceleft.cap];\012    sub braceleft.cap from [braceleft.cap braceleft];\012    sub braceright from [braceright braceright.cap];\012    sub braceright.cap from [braceright.cap braceright];\012    sub bracketleft from [bracketleft bracketleft.cap];\012    sub bracketleft.cap from [bracketleft.cap bracketleft];\012    sub bracketright from [bracketright bracketright.cap];\012    sub bracketright.cap from [bracketright.cap bracketright];\012    sub brevecomb from [brevecomb brevecomb.cap];\012    sub brevecomb.cap from [brevecomb.cap brevecomb];\012    sub brevecombcy from [brevecombcy brevecombcy.cap brevecombcy.sc];\012    sub brevecombcy.cap from [brevecombcy.cap brevecombcy brevecombcy.sc];\012    sub brevecombcy.sc from [brevecombcy.sc brevecombcy brevecombcy.cap]; \012    sub brevecomb_hookabovecomb from [brevecomb_hookabovecomb brevecomb_hookabovecomb.cap];\012    sub brevecomb_hookabovecomb.cap from [brevecomb_hookabovecomb.cap brevecomb_hookabovecomb];\012    sub bullet from [bullet bullet.cap];\012    sub bullet.cap from [bullet.cap bullet];\012    sub caroncomb from [caroncomb caron.alt caroncomb.cap];\012    sub caroncomb.cap from [caroncomb.cap caron caroncomb.alt];\012    sub caroncomb.alt from [caroncomb.alt caroncomb.alt.cap];\012    sub caroncomb.alt.cap from [caroncomb.alt.cap caroncomb.alt];    \012    sub caron.alt from [caron.alt caroncomb.cap caron];\012    sub ccedilla from [ccedilla ccedilla.alt];\012    sub ccedilla.alt from [ccedilla.alt ccedilla];\012    sub cedilla from [cedilla cedilla.alt];\012    sub cedilla.alt from [cedilla.alt cedilla];\012    sub cedillacomb from [cedillacomb cedillacomb.alt];\012    sub cedillacomb.alt from [cedillacomb.alt cedillacomb];    \012    sub cent from [cent cent.tf cent.cap];\012    sub cent.cap from [cent.cap cent cent.tf];\012    sub cent.tf from [cent.tf cent.cap cent];\012    sub circumflex from [circumflex circumflexcomb.cap];\012    sub circumflexcomb.cap from [circumflexcomb.cap circumflex];\012    sub circumflexcomb_hookabovecomb from [circumflexcomb_hookabovecomb circumflexcomb_hookabovecomb.cap];\012    sub circumflexcomb_hookabovecomb.cap from [circumflexcomb_hookabovecomb.cap circumflexcomb_hookabovecomb];\012    sub colon from [colon colon.tf];\012    sub colon.tf from [colon.tf colon];\012    sub comma from [comma comma.tf comma.alt];\012    sub comma.alt from [comma.alt comma comma.tf];\012    sub comma.tf from [comma.tf comma.alt comma];\012    sub copyright from [copyright copyright.alt];\012    sub copyright.alt from [copyright.alt copyright];\012    sub currency from [currency currency.cap currency.tf];\012    sub currency.tf from [currency.tf currency currency.cap];\012    sub currency.cap from [currency.cap currency.tf currency];\012    sub degree from [degree degree.cap];\012    sub degree.cap from [degree.cap degree];\012    sub dieresis from [dieresis dieresiscomb.cap];\012    sub dieresiscomb.cap from [dieresiscomb.cap dieresis];\012    sub dieresistonos from [dieresistonos];\012    sub divide from [divide divide.tf];\012    sub divide.tf from [divide.tf divide];\012    sub dollar from [dollar dollar.tf dollar.cap];\012    sub dollar.cap from [dollar.cap dollar dollar.tf];\012    sub dollar.tf from [dollar.tf dollar.cap dollar];\012    sub dotaccent from [dotaccent dotaccentcomb dotaccentcomb.cap];\012    sub dotaccentcomb.cap from [dotaccentcomb.cap dotaccentcomb dotaccent];\012    sub e from [e e.logo];\012    sub e.logo from [e.logo e];\012    sub eight from [eight eight.tf eight.cap eight.numerator eight.denominator];\012    sub eight.denominator from [eight.denominator eight eight.tf eight.cap eight.numerator];\012    sub eight.numerator from [eight.numerator eight.denominator eight eight.tf eight.cap];\012    sub eight.cap from [eight.cap eight.numerator eight.denominator eight eight.tf];\012    sub eight.tf from [eight.tf eight.cap eight.numerator eight.denominator eight];\012    sub emdash from [emdash emdash.cap];\012    sub emdash.cap from [emdash.cap emdash];\012    sub endash from [endash endash.cap];\012    sub endash.cap from [endash.cap endash];\012    sub equal from [equal equal.tf];\012    sub equal.tf from [equal.tf equal];\012    sub exclamdown from [exclamdown exclamdown.cap];\012    sub exclamdown.cap from [exclamdown.cap exclamdown];\012    sub f_f_j from [f_f_j f_f_j.alt];\012    sub f_f_j.alt from [f_f_j.alt f_f_j];\012    sub f_f_k from [f_f_k f_f_k.alt];\012    sub f_f_k.alt from [f_f_k.alt f_f_k];\012    sub f_f_t from [f_f_t f_f_t.alt];\012    sub f_f_t.alt from [f_f_t.alt f_f_t];\012    sub f_j from [f_j f_j.alt];\012    sub f_j.alt from [f_j.alt f_j];\012    sub f_k from [f_k f_k.alt];\012    sub f_k.alt from [f_k.alt f_k];\012    sub f_t from [f_t f_t.alt];\012    sub f_t.alt from [f_t.alt f_t];\012    sub five from [five five.cap five.tf five.numerator five.denominator];\012    sub five.denominator from [five.denominator five five.cap five.tf five.numerator];\012    sub five.numerator from [five.numerator five.denominator five five.cap five.tf];\012    sub five.tf from [five.tf five.numerator five.denominator five five.cap];\012    sub five.cap from [five.cap five.tf five.numerator five.denominator five];\012    sub florin from [florin florin.tf];\012    sub florin.tf from [florin.tf florin];\012    sub four from [four four.cap four.tf four.denominator four.numerator];\012    sub four.numerator from [four.numerator four four.cap four.tf four.denominator];\012    sub four.denominator from [four.denominator four.numerator four four.cap four.tf];\012    sub four.tf from [four.tf four.denominator four.numerator four four.cap];\012    sub four.cap from [four.cap four.tf four.denominator four.numerator four];\012    sub g from [g g.logo];\012    sub g.logo from [g.logo g];\012    sub grave from [grave gravecomb gravecomb.cap];\012    sub gravecomb.cap from [gravecomb.cap grave];\012    sub greater from [greater greater.tf];\012    sub greater.tf from [greater.tf greater];\012    sub greaterequal from [greaterequal greaterequal.tf];\012    sub greaterequal.tf from [greaterequal.tf greaterequal];\012    sub guillemetleft from [guillemetleft guillemetleft.cap];\012    sub guillemetleft.cap from [guillemetleft.cap guillemetleft];\012    sub guillemetright from [guillemetright guillemetright.cap];\012    sub guillemetright.cap from [guillemetright.cap guillemetright];\012    sub guilsinglleft from [guilsinglleft guilsinglleft.cap];\012    sub guilsinglleft.cap from [guilsinglleft.cap guilsinglleft];\012    sub guilsinglright from [guilsinglright guilsinglright.cap];\012    sub guilsinglright.cap from [guilsinglright.cap guilsinglright];\012	sub hookabovecomb from [hookabovecomb hookabovecomb.cap];\012    sub hookabovecomb.cap from [hookabovecomb.cap hookabovecomb];\012   	sub horncomb from [horncomb horncomb.cap];\012    sub horncomb.cap from [horncomb.cap horncomb];    \012    sub hungarumlaut from [hungarumlaut hungarumlautcomb hungarumlautcomb.cap];\012    sub hungarumlautcomb.cap from [hungarumlautcomb.cap hungarumlautcomb hungarumlaut];\012    sub hyphen from [hyphen hyphen.cap];\012    sub hyphen.cap from [hyphen.cap hyphen];\012    sub j from [j j.alt];\012    sub j.alt from [j.alt j];\012    sub jdotless from [jdotless.alt jdotless];\012    sub jdotless.alt from [jdotless.alt jdotless];\012    sub jcircumflex from [jcircumflex jcircumflex.alt];\012    sub jcircumflex.alt from [jcircumflex.alt jcircumflex];\012    sub k from [k k.alt];\012    sub k.alt from [k.alt k];\012    sub kcommaaccent from [kcommaaccent kcommaaccent.alt];\012    sub kcommaaccent.alt from [kcommaaccent.alt kcommaaccent];\012    sub l from [l l.logo];\012    sub l.logo from [l.logo l];\012    sub less from [less less.tf];\012    sub less.tf from [less.tf less];\012    sub lessequal from [lessequal lessequal.tf];\012    sub lessequal.tf from [lessequal.tf lessequal];\012    sub logicalnot from [logicalnot logicalnot.tf];\012    sub logicalnot.tf from [logicalnot.tf logicalnot];\012    sub macron from [macron macroncomb macroncomb.cap];\012    sub macroncomb.cap from [macroncomb.cap macroncomb macron];\012    sub minus from [minus minus.tf];\012    sub minus.tf from [minus.tf minus];\012    sub multiply from [multiply multiply.tf];\012    sub multiply.tf from [multiply.tf multiply];\012    sub nine from [nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt];\012    sub nine.alt from [nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator];\012    sub nine.numerator from [nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf];\012    sub nine.tf from [nine.tf nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap];\012    sub nine.alt.cap from [nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator nine.cap];\012    sub nine.cap from [nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator];\012    sub nine.denominator from [nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine];\012    sub notequal from [notequal notequal.tf];\012    sub notequal.tf from [notequal.tf notequal];\012    sub numbersign from [numbersign numbersign.tf numbersign.cap];\012    sub numbersign.cap from [numbersign.cap numbersign numbersign.tf];\012    sub numbersign.tf from [numbersign.tf numbersign.cap numbersign];\012    sub o from [o o.logo];\012    sub o.logo from [o.logo o];\012    sub one from [one one.alt one.cap one.numerator one.alt.cap one.denominator one.tf];\012    sub one.tf from [one.tf one one.alt one.cap one.numerator one.alt.cap one.denominator];\012    sub one.denominator from [one.denominator one.tf one one.alt one.cap one.numerator one.alt.cap];\012    sub one.alt.cap from [one.alt.cap one.denominator one.tf one one.alt one.cap one.numerator];\012    sub one.numerator from [one.numerator one.alt.cap one.denominator one.tf one one.alt one.cap];\012    sub one.cap from [one.cap one.numerator one.alt.cap one.denominator one.tf one one.alt];\012    sub one.alt from [one.alt one.cap one.numerator one.alt.cap one.denominator one.tf one];\012    sub parenleft from [parenleft parenleft.cap];\012    sub parenleft.cap from [parenleft.cap parenleft];\012    sub parenright from [parenright parenright.cap];\012    sub parenright.cap from [parenright.cap parenright];\012    sub percent from [percent percent.cap percent.tf];\012    sub percent.tf from [percent.tf percent percent.cap];\012    sub percent.cap from [percent.cap percent.tf percent];\012    sub period from [period period.tf];\012    sub period.tf from [period.tf period];\012    sub pertenthousand from [pertenthousand pertenthousand.cap];\012    sub pertenthousand.cap from [pertenthousand.cap pertenthousand];\012    sub perthousand from [perthousand perthousand.cap];\012    sub perthousand.cap from [perthousand.cap perthousand];\012    sub plus from [plus plus.tf];\012    sub plus.tf from [plus.tf plus];\012    sub plusminus from [plusminus plusminus.tf];\012    sub plusminus.tf from [plusminus.tf plusminus];\012    sub q from [q q.alt];\012    sub q.alt from [q.alt q];\012    sub questiondown from [questiondown questiondown.cap];\012    sub questiondown.cap from [questiondown.cap questiondown];\012    sub quotedblbase from [quotedblbase quotedblbase.alt];\012    sub quotedblbase.alt from [quotedblbase.alt quotedblbase];\012    sub quotedblleft from [quotedblleft quotedblleft.alt];\012    sub quotedblleft.alt from [quotedblleft.alt quotedblleft];\012    sub quotedblright from [quotedblright quotedblright.alt];\012    sub quotedblright.alt from [quotedblright.alt quotedblright];\012    sub quoteleft from [quoteleft quoteleft.alt];\012    sub quoteleft.alt from [quoteleft.alt quoteleft];\012    sub quoteright from [quoteright quoteright.alt];\012    sub quoteright.alt from [quoteright.alt quoteright];\012    sub quotesinglbase from [quotesinglbase quotesinglbase.alt];\012    sub quotesinglbase.alt from [quotesinglbase.alt quotesinglbase];\012    sub r from [r r.alt];\012    sub r.alt from [r.alt r];\012    sub r_t from [r_t r_t.alt];\012    sub r_t.alt from [r_t.alt r_t];\012    sub racute from [racute racute.alt];\012    sub racute.alt from [racute.alt racute];\012    sub rcaron from [rcaron rcaron.alt];\012    sub rcaron.alt from [rcaron.alt rcaron];\012    sub rcommaaccent from [rcommaaccent rcommaaccent.alt];    \012    sub rcommaaccent.alt from [rcommaaccent.alt rcommaaccent];\012    sub registered from [registered registered.alt];\012    sub registered.alt from [registered.alt registered];\012    sub ring from [ring ringcomb ringcomb.cap];\012    sub ringcomb.cap from [ringcomb.cap ringcomb ring];\012    sub scedilla from [scedilla scedilla.alt];\012    sub scedilla.alt from [scedilla.alt scedilla];\012    sub section from [section section.tf];\012    sub section.tf from [section.tf section];\012    sub semicolon from [semicolon semicolon.tf semicolon.alt];\012    sub semicolon.alt from [semicolon.alt semicolon semicolon.tf];\012    sub semicolon.tf from [semicolon.tf semicolon.alt semicolon];\012    sub seven from [seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator];\012    sub seven.denominator from [seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf];\012    sub seven.tf from [seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator];\012    sub seven.numerator from [seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt];\012    sub seven.alt from [seven.alt seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap];\012    sub seven.alt.cap from [seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven seven.cap];\012    sub seven.cap from [seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven];\012    sub six from [six six.numerator six.alt.cap six.cap six.tf six.denominator six.alt];\012    sub six.alt from [six.alt six six.numerator six.alt.cap six.cap six.tf six.denominator];\012    sub six.denominator from [six.denominator six.alt six six.numerator six.alt.cap six.cap six.tf];\012    sub six.tf from [six.tf six.denominator six.alt six six.numerator six.alt.cap six.cap];\012    sub six.cap from [six.cap six.tf six.denominator six.alt six six.numerator six.alt.cap];\012    sub six.alt.cap from [six.alt.cap six.cap six.tf six.denominator six.alt six six.numerator];\012    sub six.numerator from [six.numerator six.alt.cap six.cap six.tf six.denominator six.alt six];\012    sub space from [space space.tf];\012    sub space.tf from [space.tf space];\012    sub sterling from [sterling sterling.cap sterling.tf];\012    sub sterling.tf from [sterling.tf sterling sterling.cap];\012    sub sterling.cap from [sterling.cap sterling.tf sterling];\012    sub t from [t t.alt];\012    sub t.alt from [t.alt t];\012    sub tcedilla from [tcedilla tcedilla.alt tcedilla.alt.2];\012    sub tcedilla.alt from [tcedilla.alt tcedilla tcedilla.alt.2];\012    sub tcedilla.alt.2 from [tcedilla.alt.2 tcedilla.alt tcedilla];\012    sub tcommaaccent from [tcommaaccent tcommaaccent.alt];\012    sub tcommaaccent.alt from [tcommaaccent.alt tcommaaccent];\012    sub t_f from [t_f t_f.alt];\012    sub t_f.alt from [t_f.alt t_f];\012    sub t_t from [t_t t_t.alt];\012    sub t_t.alt from [t_t.alt t_t];\012    sub tbar from [tbar tbar.alt];\012    sub tbar.alt from [tbar.alt tbar];\012    sub tcaron from [tcaron tcaron.alt];\012    sub tcaron.alt from [tcaron.alt tcaron];\012    sub three from [three three.denominator three.numerator three.tf three.cap];\012    sub three.cap from [three.cap three three.denominator three.numerator three.tf];\012    sub three.tf from [three.tf three.cap three three.denominator three.numerator];\012    sub three.numerator from [three.numerator three.tf three.cap three three.denominator];\012    sub three.denominator from [three.denominator three.numerator three.tf three.cap three];\012    sub tilde from [tilde tildecomb tildecomb.cap];\012    sub tildecomb.cap from [tildecomb.cap tildecomb tilde];\012    sub trademark from [trademark trademark.alt2 trademark.alt trademark.alt3];\012    sub trademark.alt3 from [trademark.alt3 trademark trademark.alt2 trademark.alt];\012    sub trademark.alt from [trademark.alt trademark.alt3 trademark trademark.alt2];\012    sub trademark.alt2 from [trademark.alt2 trademark.alt trademark.alt3 trademark];\012    sub two from [two two.cap two.denominator two.tf two.numerator];\012    sub two.numerator from [two.numerator two two.cap two.denominator two.tf];\012    sub two.tf from [two.tf two.numerator two two.cap two.denominator];\012    sub two.denominator from [two.denominator two.tf two.numerator two two.cap];\012    sub two.cap from [two.cap two.denominator two.tf two.numerator two];\012    sub baht from [baht baht.cap];\012    sub baht.cap from [baht.cap baht];\012    sub franc from [franc franc.tf franc.cap];\012    sub franc.cap from [franc.cap franc franc.tf];\012    sub franc.tf from [franc.tf franc.cap franc];\012    sub lira from [lira lira.cap lira.tf];\012    sub lira.tf from [lira.tf lira lira.cap];\012    sub lira.cap from [lira.cap lira.tf lira];\012    sub won from [won won.tf won.cap];\012    sub won.cap from [won.cap won won.tf];\012    sub won.tf from [won.tf won.cap won];\012    sub dong from [dong dong.tf dong.cap];\012    sub dong.cap from [dong.cap dong dong.tf];\012    sub dong.tf from [dong.tf dong.cap dong];\012    sub tugrik from [tugrik tugrik.tf tugrik.cap];\012    sub tugrik.cap from [tugrik.cap tugrik tugrik.tf];\012    sub tugrik.tf from [tugrik.tf tugrik.cap tugrik];\012    sub peso from [peso peso.cap peso.tf];\012    sub peso.tf from [peso.tf peso peso.cap];\012    sub peso.cap from [peso.cap peso.tf peso];\012    sub tenge from [tenge tenge.cap tenge.tf];\012    sub tenge.tf from [tenge.tf tenge tenge.cap];\012    sub tenge.cap from [tenge.cap tenge.tf tenge];\012    sub rupeeIndian from [rupeeIndian rupeeIndian.cap rupeeIndian.tf];\012    sub rupeeIndian.tf from [rupeeIndian.tf rupeeIndian rupeeIndian.cap];\012    sub rupeeIndian.cap from [rupeeIndian.cap rupeeIndian.tf rupeeIndian];\012    sub liraTurkish from [liraTurkish liraTurkish.cap liraTurkish.tf];\012    sub liraTurkish.tf from [liraTurkish.tf liraTurkish liraTurkish.cap];\012    sub liraTurkish.cap from [liraTurkish.cap liraTurkish.tf liraTurkish];\012    sub ruble from [ruble ruble.cap ruble.tf];\012    sub ruble.tf from [ruble.tf ruble ruble.cap];\012    sub ruble.cap from [ruble.cap ruble.tf ruble];\012    sub centigrade from [centigrade centigrade.cap];\012    sub centigrade.cap from [centigrade.cap centigrade];\012    sub fahrenheit from [fahrenheit fahrenheit.cap];\012    sub fahrenheit.cap from [fahrenheit.cap fahrenheit];\012    sub published from [published published.alt];\012    sub published.alt from [published.alt published];\012    sub servicemark from [servicemark servicemark.alt3 servicemark.alt servicemark.alt2];\012    sub servicemark.alt2 from [servicemark.alt2 servicemark servicemark.alt3 servicemark.alt];\012    sub servicemark.alt from [servicemark.alt servicemark.alt2 servicemark servicemark.alt3];\012    sub servicemark.alt3 from [servicemark.alt3 servicemark.alt servicemark.alt2 servicemark];\012    sub y from [y y.alt];\012    sub y.alt from [y.alt y];\012    sub yacute from [yacute yacute.alt];\012    sub yacute.alt from [yacute.alt yacute];\012    sub ycircumflex from [ycircumflex ycircumflex.alt];\012    sub ycircumflex.alt from [ycircumflex.alt ycircumflex];\012    sub ydieresis from [ydieresis ydieresis.alt];\012    sub ydieresis.alt from [ydieresis.alt ydieresis];\012    sub ydotbelow from [ydotbelow ydotbelow.alt];\012    sub ydotbelow.alt from [ydotbelow.alt ydotbelow];    \012    sub yhookabove from [yhookabove yhookabove.alt];\012    sub yhookabove.alt from [yhookabove.alt yhookabove];   \012    sub ytilde from [ytilde ytilde.alt];\012    sub ytilde.alt from [ytilde.alt ytilde];    \012    sub yen from [yen yen.tf yen.cap];\012    sub yen.cap from [yen.cap yen yen.tf];\012    sub yen.tf from [yen.tf yen.cap yen];\012    sub ygrave from [ygrave ygrave.alt];\012    sub ygrave.alt from [ygrave.alt ygrave];\012    sub zero from [zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf];\012    sub zero.tf from [zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator];\012    sub zero.numerator from [zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt];\012    sub zero.alt from [zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator];\012    sub zero.denominator from [zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap];\012    sub zero.cap from [zero.cap zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap];\012    sub zero.alt.cap from [zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf zero];\012    \012    # ================\012    # END LATIN\012    # ================\012    \012    # ================\012    # BEGIN HEBREW\012    # ================\012    \012    feature jalt;\012    \012    # ================\012    # END HEBREW\012    # ================";
 name = aalt;
 },
 {
-code = "# ===============
-# BEGIN LATIN
-# ===============
-
-lookup ccmp_Other_1 {
-	@CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb commaturnedabovecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];
-	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb];
-	sub [i j]' @CombiningTopAccents by [idotless jdotless];
-	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];
-	@Markscomb = [tonos psili koronis dasia dasiavaria psilioxia dasiaoxia psiliperispomeni dasiaperispomeni dialytikavaria dialytikaperispomeni varia oxia perispomeni psilivaria dialytikaoxia];
-	@MarkscombCase = [tonos.case psili.case koronis.case dasia.case dasiavaria.case psilioxia.case dasiaoxia.case psiliperispomeni.case dasiaperispomeni.case dialytikavaria.case dialytikaperispomeni.case varia.case oxia.case perispomeni.case psilivaria.case dialytikaoxia.case];
-	sub @Markscomb @Markscomb' by @MarkscombCase;
-	sub @Uppercase @Markscomb' by @MarkscombCase;
-} ccmp_Other_1;
-
-lookup ccmp_Other_2 {
-	sub @Markscomb' @MarkscombCase by @MarkscombCase;
-	sub @MarkscombCase @Markscomb' by @MarkscombCase;
-} ccmp_Other_2;
-
-lookup ccmp_latn_1 {
-	lookupflag 0;
-	sub brevecomb acutecomb by brevecomb_acutecomb;
-	sub brevecomb.cap acutecomb.cap by brevecomb_acutecomb.cap;
-	sub brevecomb.sc acutecomb.sc by brevecomb_acutecomb.sc;
-	sub brevecomb gravecomb by brevecomb_gravecomb;
-	sub brevecomb.cap gravecomb.cap by brevecomb_gravecomb.cap;
-	sub brevecomb.sc gravecomb.sc by brevecomb_gravecomb.sc;
-	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;
-	sub brevecomb.cap hookabovecomb.cap by brevecomb_hookabovecomb.cap;
-	sub brevecomb.sc hookabovecomb.sc by brevecomb_hookabovecomb.sc;
-	sub brevecomb tildecomb by brevecomb_tildecomb;
-	sub brevecomb.cap tildecomb.cap by brevecomb_tildecomb.cap;
-	sub brevecomb.sc tildecomb.sc by brevecomb_tildecomb.sc;
-	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;
-	sub circumflexcomb.cap acutecomb.cap by circumflexcomb_acutecomb.cap;
-	sub circumflexcomb.sc acutecomb.sc by circumflexcomb_acutecomb.sc;
-	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;
-	sub circumflexcomb.cap gravecomb.cap by circumflexcomb_gravecomb.cap;
-	sub circumflexcomb.sc gravecomb.sc by circumflexcomb_gravecomb.sc;
-	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;
-	sub circumflexcomb.cap hookabovecomb.cap by circumflexcomb_hookabovecomb.cap;
-	sub circumflexcomb.sc hookabovecomb.sc by circumflexcomb_hookabovecomb.sc;
-	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;
-	sub circumflexcomb.cap tildecomb.cap by circumflexcomb_tildecomb.cap;
-	sub circumflexcomb.sc tildecomb.sc by circumflexcomb_tildecomb.sc;
-} ccmp_latn_1;
-
-# ===============
-# END LATIN
-# ===============
-
-# ===============
-# BEGIN HEBREW
-# ===============
-
-lookup hb_shinDots {
-	lookupflag 0;
-	lookupflag UseMarkFilteringSet @hb_shinDots;
-	sub shin-hb shindot-hb by shinshindot-hb;
-	sub shin-hb sindot-hb by shinsindot-hb;
-} hb_shinDots;
-
-lookup hb_dagesh {
-	lookupflag 0;
-	lookupflag MarkAttachmentType @hb_dagesh; 
-	sub alef-hb dagesh-hb by alefdagesh-hb;
-	sub bet-hb dagesh-hb by betdagesh-hb;
-	sub gimel-hb dagesh-hb by gimeldagesh-hb;
-	sub dalet-hb dagesh-hb by daletdagesh-hb;
-	sub he-hb dagesh-hb by hedagesh-hb;
-	sub vav-hb dagesh-hb by vavdagesh-hb;
-	sub zayin-hb dagesh-hb by zayindagesh-hb;
-	sub tet-hb dagesh-hb by tetdagesh-hb;
-	sub yod-hb dagesh-hb by yoddagesh-hb;
-	sub kaf-hb dagesh-hb by kafdagesh-hb;
-	sub finalkaf-hb dagesh-hb by finalkafdagesh-hb;
-	sub lamed-hb dagesh-hb by lameddagesh-hb;
-	sub mem-hb dagesh-hb by memdagesh-hb;
-	sub nun-hb dagesh-hb by nundagesh-hb;
-	sub samekh-hb dagesh-hb by samekhdagesh-hb;
-	sub pe-hb dagesh-hb by pedagesh-hb;
-	sub finalpe-hb dagesh-hb by finalpedagesh-hb;
-	sub tsadi-hb dagesh-hb by tsadidagesh-hb;
-	sub qof-hb dagesh-hb by qofdagesh-hb;
-	sub resh-hb dagesh-hb by reshdagesh-hb;
-	sub shinsindot-hb dagesh-hb by shindageshsindot-hb;
-	sub shinshindot-hb dagesh-hb by shindageshshindot-hb;
-	sub shin-hb dagesh-hb by shindagesh-hb;
-	sub tav-hb dagesh-hb by tavdagesh-hb;
-} hb_dagesh;
-	
-lookup hb_diacriticReplacements {
-	lookupflag 0;
-	lookupflag UseMarkFilteringSet @hb_diacriticMarks;
-	sub alef-hb patah-hb by alefpatah-hb;
-	sub alef-hb qamats-hb by alefqamats-hb;
-	sub finalkafdagesh-hb qamats-hb by finalkafdagesh_qamats-hb;
-	sub finalkafdagesh-hb sheva-hb by finalkafdagesh_sheva-hb;	
-	sub finalkaf-hb qamats-hb by finalkaf_qamats-hb;
-	sub finalkaf-hb sheva-hb by finalkaf_sheva-hb;
-	sub vav-hb holam-hb by vavholam-hb;
-	sub lameddagesh-hb holam-hb by lamed_dagesh_holam-hb;
-	sub lamed-hb holam-hb by lamed_holam-hb;
-} hb_diacriticReplacements;
-
-
-lookup hb_rafe {
-	lookupflag 0;
-# 	lookupflag UseMarkFilteringSet @hb_diacriticMarks;
-	sub pe-hb rafe-hb by perafe-hb;
-	sub kaf-hb rafe-hb by kafrafe-hb;
-	sub bet-hb rafe-hb by betrafe-hb;
-} hb_rafe;	
-
-lookup hb_siluqLeft {
-	# cantillation replacements		
-	sub hatafsegol-hb siluqleft-hb by hatafsegol_siluqleft-hb;
-	sub hatafpatah-hb siluqleft-hb by hatafpatah_siluqleft-hb;
-	sub hatafqamats-hb siluqleft-hb by hatafqamats_siluqleft-hb; 
-} hb_siluqLeft;
-
-#If specific letters appear at the end of the word, the cantillation will be replaced by a final alternative
-lookup hb_finalCantillationForms {
-	ignore sub @hb_finalCantillationLetters @hb_finalCantillationSrc' @hb_AllHebrewLetters;
-	sub @hb_finalCantillationLetters @hb_finalCantillationSrc' by @hb_finalCantillationDst;
-} hb_finalCantillationForms;
-
-# ==============
-# END HEBREW
-# ==============
-
-";
+code = "# ===============\012# BEGIN LATIN\012# ===============\012\012lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb commaturnedabovecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012	@Markscomb = [tonos psili koronis dasia dasiavaria psilioxia dasiaoxia psiliperispomeni dasiaperispomeni dialytikavaria dialytikaperispomeni varia oxia perispomeni psilivaria dialytikaoxia];\012	@MarkscombCase = [tonos.case psili.case koronis.case dasia.case dasiavaria.case psilioxia.case dasiaoxia.case psiliperispomeni.case dasiaperispomeni.case dialytikavaria.case dialytikaperispomeni.case varia.case oxia.case perispomeni.case psilivaria.case dialytikaoxia.case];\012	sub @Markscomb @Markscomb' by @MarkscombCase;\012	sub @Uppercase @Markscomb' by @MarkscombCase;\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	sub @Markscomb' @MarkscombCase by @MarkscombCase;\012	sub @MarkscombCase @Markscomb' by @MarkscombCase;\012} ccmp_Other_2;\012\012lookup ccmp_latn_1 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb.cap acutecomb.cap by brevecomb_acutecomb.cap;\012	sub brevecomb.sc acutecomb.sc by brevecomb_acutecomb.sc;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb.cap gravecomb.cap by brevecomb_gravecomb.cap;\012	sub brevecomb.sc gravecomb.sc by brevecomb_gravecomb.sc;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb.cap hookabovecomb.cap by brevecomb_hookabovecomb.cap;\012	sub brevecomb.sc hookabovecomb.sc by brevecomb_hookabovecomb.sc;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub brevecomb.cap tildecomb.cap by brevecomb_tildecomb.cap;\012	sub brevecomb.sc tildecomb.sc by brevecomb_tildecomb.sc;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb.cap acutecomb.cap by circumflexcomb_acutecomb.cap;\012	sub circumflexcomb.sc acutecomb.sc by circumflexcomb_acutecomb.sc;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb.cap gravecomb.cap by circumflexcomb_gravecomb.cap;\012	sub circumflexcomb.sc gravecomb.sc by circumflexcomb_gravecomb.sc;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb.cap hookabovecomb.cap by circumflexcomb_hookabovecomb.cap;\012	sub circumflexcomb.sc hookabovecomb.sc by circumflexcomb_hookabovecomb.sc;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012	sub circumflexcomb.cap tildecomb.cap by circumflexcomb_tildecomb.cap;\012	sub circumflexcomb.sc tildecomb.sc by circumflexcomb_tildecomb.sc;\012} ccmp_latn_1;\012\012# ===============\012# END LATIN\012# ===============\012\012# ===============\012# BEGIN HEBREW\012# ===============\012\012lookup hb_shinDots {\012	lookupflag 0;\012	lookupflag UseMarkFilteringSet @hb_shinDots;\012	sub shin-hb shindot-hb by shinshindot-hb;\012	sub shin-hb sindot-hb by shinsindot-hb;\012} hb_shinDots;\012\012lookup hb_dagesh {\012	lookupflag 0;\012	lookupflag MarkAttachmentType @hb_dagesh; \012	sub alef-hb dagesh-hb by alefdagesh-hb;\012	sub bet-hb dagesh-hb by betdagesh-hb;\012	sub gimel-hb dagesh-hb by gimeldagesh-hb;\012	sub dalet-hb dagesh-hb by daletdagesh-hb;\012	sub he-hb dagesh-hb by hedagesh-hb;\012	sub vav-hb dagesh-hb by vavdagesh-hb;\012	sub zayin-hb dagesh-hb by zayindagesh-hb;\012	sub tet-hb dagesh-hb by tetdagesh-hb;\012	sub yod-hb dagesh-hb by yoddagesh-hb;\012	sub kaf-hb dagesh-hb by kafdagesh-hb;\012	sub finalkaf-hb dagesh-hb by finalkafdagesh-hb;\012	sub lamed-hb dagesh-hb by lameddagesh-hb;\012	sub mem-hb dagesh-hb by memdagesh-hb;\012	sub nun-hb dagesh-hb by nundagesh-hb;\012	sub samekh-hb dagesh-hb by samekhdagesh-hb;\012	sub pe-hb dagesh-hb by pedagesh-hb;\012	sub finalpe-hb dagesh-hb by finalpedagesh-hb;\012	sub tsadi-hb dagesh-hb by tsadidagesh-hb;\012	sub qof-hb dagesh-hb by qofdagesh-hb;\012	sub resh-hb dagesh-hb by reshdagesh-hb;\012	sub shinsindot-hb dagesh-hb by shindageshsindot-hb;\012	sub shinshindot-hb dagesh-hb by shindageshshindot-hb;\012	sub shin-hb dagesh-hb by shindagesh-hb;\012	sub tav-hb dagesh-hb by tavdagesh-hb;\012} hb_dagesh;\012	\012lookup hb_diacriticReplacements {\012	lookupflag 0;\012	lookupflag UseMarkFilteringSet @hb_diacriticMarks;\012	sub alef-hb patah-hb by alefpatah-hb;\012	sub alef-hb qamats-hb by alefqamats-hb;\012	sub finalkafdagesh-hb qamats-hb by finalkafdagesh_qamats-hb;\012	sub finalkafdagesh-hb sheva-hb by finalkafdagesh_sheva-hb;	\012	sub finalkaf-hb qamats-hb by finalkaf_qamats-hb;\012	sub finalkaf-hb sheva-hb by finalkaf_sheva-hb;\012	sub vav-hb holam-hb by vavholam-hb;\012	sub lameddagesh-hb holam-hb by lamed_dagesh_holam-hb;\012	sub lamed-hb holam-hb by lamed_holam-hb;\012} hb_diacriticReplacements;\012\012\012lookup hb_rafe {\012	lookupflag 0;\012# 	lookupflag UseMarkFilteringSet @hb_diacriticMarks;\012	sub pe-hb rafe-hb by perafe-hb;\012	sub kaf-hb rafe-hb by kafrafe-hb;\012	sub bet-hb rafe-hb by betrafe-hb;\012} hb_rafe;	\012\012lookup hb_siluqLeft {\012	# cantillation replacements		\012	sub hatafsegol-hb siluqleft-hb by hatafsegol_siluqleft-hb;\012	sub hatafpatah-hb siluqleft-hb by hatafpatah_siluqleft-hb;\012	sub hatafqamats-hb siluqleft-hb by hatafqamats_siluqleft-hb; \012} hb_siluqLeft;\012\012#If specific letters appear at the end of the word, the cantillation will be replaced by a final alternative\012lookup hb_finalCantillationForms {\012	ignore sub @hb_finalCantillationLetters @hb_finalCantillationSrc' @hb_AllHebrewLetters;\012	sub @hb_finalCantillationLetters @hb_finalCantillationSrc' by @hb_finalCantillationDst;\012} hb_finalCantillationForms;\012\012# ==============\012# END HEBREW\012# ==============\012\012";
 name = ccmp;
 },
 {
-code = "sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;
-script latn;
-language CAT;
-sub  L' periodcentered' L by Ldot;
-language ROM;
-sub Scedilla by Scommaaccent;
-sub scedilla by scommaaccent;
-sub Tcedilla by Tcommaaccent;
-sub tcedilla by tcommaaccent;
-language MOL;
-sub Scedilla by Scommaaccent;
-sub scedilla by scommaaccent;
-sub Tcedilla by Tcommaaccent;
-sub tcedilla by tcommaaccent;
-
-script cyrl;
-language SRB;
-sub ge-cy by ge-cy.loclMKD;
-sub be-cy by be-cy.loclSRB;
-sub de-cy by de-cy.loclSRB;
-sub pe-cy by pe-cy.loclSRB;
-sub te-cy by te-cy.loclSRB;
-sub sha-cy by sha-cy.loclSRB;
-language MKD;
-sub ge-cy by ge-cy.loclMKD;
-sub gje-cy by gje-cy.loclMKD;
-sub be-cy by be-cy.loclSRB;
-sub de-cy by de-cy.loclSRB;
-sub pe-cy by pe-cy.loclSRB;
-sub te-cy by te-cy.loclSRB;
-sub sha-cy by sha-cy.loclSRB;
-language CHU;
-sub Esdescender-cy by Esdescender-cy.loclCHU;
-sub esdescender-cy by esdescender-cy.loclCHU;
-sub esdescender-cy.sc by esdescender-cy.loclCHU.sc;
-language BSH;
-sub Ghestroke-cy by Ghestroke-cy.loclBSH;
-sub Zedescender-cy by Zedescender-cy.loclBSH;
-sub Esdescender-cy by Esdescender-cy.loclBSH;
-sub ghestroke-cy by ghestroke-cy.loclBSH;
-sub zedescender-cy by zedescender-cy.loclBSH;
-sub esdescender-cy by esdescender-cy.loclBSH;
-sub ghestroke-cy.sc by ghestroke-cy.loclBSH.sc;
-sub zedescender-cy.sc by zedescender-cy.loclBSH.sc;
-sub esdescender-cy.sc by esdescender-cy.loclBSH.sc;
-language BGR;
-sub De-cy by De-cy.loclBGR;
-sub El-cy by El-cy.loclBGR;
-sub Ef-cy by Ef-cy.loclBGR;
-sub ve-cy by ve-cy.loclBGR;
-sub ge-cy by ge-cy.loclBGR;
-sub de-cy by de-cy.loclBGR;
-sub zhe-cy by zhe-cy.loclBGR;
-sub ze-cy by ze-cy.loclBGR;
-sub ii-cy by ii-cy.loclBGR;
-sub iishort-cy by iishort-cy.loclBGR;
-sub iigrave-cy by iigrave-cy.loclBGR;
-sub ka-cy by ka-cy.loclBGR;
-sub el-cy by el-cy.loclBGR;
-sub ef-cy by ef-cy.loclBGR;
-sub pe-cy by pe-cy.loclBGR;
-sub te-cy by te-cy.loclBGR;
-sub tse-cy by tse-cy.loclBGR;
-sub sha-cy by sha-cy.loclBGR;
-sub shcha-cy by shcha-cy.loclBGR;
-sub softsign-cy by softsign-cy.loclBGR;
-sub hardsign-cy by hardsign-cy.loclBGR;
-sub iu-cy by iu-cy.loclBGR;
-sub yeru-cy by yeru-cy.loclBGR;
-sub de-cy.sc by de-cy.loclBGR.sc;
-sub el-cy.sc by el-cy.loclBGR.sc;
-sub ef-cy.sc by ef-cy.loclBGR.sc;
-";
+code = "sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;\012script latn;\012language CAT;\012sub  L' periodcentered' L by Ldot;\012language ROM;\012sub Scedilla by Scommaaccent;\012sub scedilla by scommaaccent;\012sub Tcedilla by Tcommaaccent;\012sub tcedilla by tcommaaccent;\012language MOL;\012sub Scedilla by Scommaaccent;\012sub scedilla by scommaaccent;\012sub Tcedilla by Tcommaaccent;\012sub tcedilla by tcommaaccent;\012\012script cyrl;\012language SRB;\012sub ge-cy by ge-cy.loclMKD;\012sub be-cy by be-cy.loclSRB;\012sub de-cy by de-cy.loclSRB;\012sub pe-cy by pe-cy.loclSRB;\012sub te-cy by te-cy.loclSRB;\012sub sha-cy by sha-cy.loclSRB;\012language MKD;\012sub ge-cy by ge-cy.loclMKD;\012sub gje-cy by gje-cy.loclMKD;\012sub be-cy by be-cy.loclSRB;\012sub de-cy by de-cy.loclSRB;\012sub pe-cy by pe-cy.loclSRB;\012sub te-cy by te-cy.loclSRB;\012sub sha-cy by sha-cy.loclSRB;\012language CHU;\012sub Esdescender-cy by Esdescender-cy.loclCHU;\012sub esdescender-cy by esdescender-cy.loclCHU;\012sub esdescender-cy.sc by esdescender-cy.loclCHU.sc;\012language BSH;\012sub Ghestroke-cy by Ghestroke-cy.loclBSH;\012sub Zedescender-cy by Zedescender-cy.loclBSH;\012sub Esdescender-cy by Esdescender-cy.loclBSH;\012sub ghestroke-cy by ghestroke-cy.loclBSH;\012sub zedescender-cy by zedescender-cy.loclBSH;\012sub esdescender-cy by esdescender-cy.loclBSH;\012sub ghestroke-cy.sc by ghestroke-cy.loclBSH.sc;\012sub zedescender-cy.sc by zedescender-cy.loclBSH.sc;\012sub esdescender-cy.sc by esdescender-cy.loclBSH.sc;\012language BGR;\012sub De-cy by De-cy.loclBGR;\012sub El-cy by El-cy.loclBGR;\012sub Ef-cy by Ef-cy.loclBGR;\012sub ve-cy by ve-cy.loclBGR;\012sub ge-cy by ge-cy.loclBGR;\012sub de-cy by de-cy.loclBGR;\012sub zhe-cy by zhe-cy.loclBGR;\012sub ze-cy by ze-cy.loclBGR;\012sub ii-cy by ii-cy.loclBGR;\012sub iishort-cy by iishort-cy.loclBGR;\012sub iigrave-cy by iigrave-cy.loclBGR;\012sub ka-cy by ka-cy.loclBGR;\012sub el-cy by el-cy.loclBGR;\012sub ef-cy by ef-cy.loclBGR;\012sub pe-cy by pe-cy.loclBGR;\012sub te-cy by te-cy.loclBGR;\012sub tse-cy by tse-cy.loclBGR;\012sub sha-cy by sha-cy.loclBGR;\012sub shcha-cy by shcha-cy.loclBGR;\012sub softsign-cy by softsign-cy.loclBGR;\012sub hardsign-cy by hardsign-cy.loclBGR;\012sub iu-cy by iu-cy.loclBGR;\012sub yeru-cy by yeru-cy.loclBGR;\012sub de-cy.sc by de-cy.loclBGR.sc;\012sub el-cy.sc by el-cy.loclBGR.sc;\012sub ef-cy.sc by ef-cy.loclBGR.sc;\012";
 name = locl;
 },
 {
-code = "    lookup FractionBar {
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures slash;
-        ignore sub slash @figures @figures slash';
-        ignore sub slash' @figures @figures slash;
-        ignore sub slash @figures slash';
-        ignore sub slash' @figures slash;
-        ignore sub slash slash';
-        ignore sub slash' slash;
-        sub @figures slash' @figures by fraction;
-    } FractionBar;
-
-    lookup Numerator1 {
-        sub @figures' fraction by @figuresNumerator;
-    } Numerator1;
-
-    lookup Numerator2 {
-        sub @figures' @figuresNumerator fraction by @figuresNumerator;
-    } Numerator2;
-
-    lookup Numerator3 {
-        sub @figures' @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator3;
-
-    lookup Numerator4 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator4;
-
-    lookup Numerator5 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator5;
-
-    lookup Numerator6 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator6;
-
-    lookup Numerator7 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator7;
-
-    lookup Numerator8 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator8;
-
-    lookup Numerator9 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator9;
-
-    lookup Numerator10 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator10;
-
-    lookup Denominator {
-        sub [fraction @figuresDenominator] @figures' by @figuresDenominator;
-    } Denominator;
-
-    sub @figures space' @figuresNumerator by thinspace;";
+code = "    lookup FractionBar {\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures slash;\012        ignore sub slash @figures @figures slash';\012        ignore sub slash' @figures @figures slash;\012        ignore sub slash @figures slash';\012        ignore sub slash' @figures slash;\012        ignore sub slash slash';\012        ignore sub slash' slash;\012        sub @figures slash' @figures by fraction;\012    } FractionBar;\012\012    lookup Numerator1 {\012        sub @figures' fraction by @figuresNumerator;\012    } Numerator1;\012\012    lookup Numerator2 {\012        sub @figures' @figuresNumerator fraction by @figuresNumerator;\012    } Numerator2;\012\012    lookup Numerator3 {\012        sub @figures' @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator3;\012\012    lookup Numerator4 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator4;\012\012    lookup Numerator5 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator5;\012\012    lookup Numerator6 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator6;\012\012    lookup Numerator7 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator7;\012\012    lookup Numerator8 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator8;\012\012    lookup Numerator9 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator9;\012\012    lookup Numerator10 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator10;\012\012    lookup Denominator {\012        sub [fraction @figuresDenominator] @figures' by @figuresDenominator;\012    } Denominator;\012\012    sub @figures space' @figuresNumerator by thinspace;";
 name = frac;
 },
 {
@@ -1679,1741 +230,97 @@ code = "sub @figures by @figuresDenominator;";
 name = dnom;
 },
 {
-code = "sub @figures_tab by @figures;
-sub @symbols_tab by @symbols;";
+code = "sub @figures_tab by @figures;\012sub @symbols_tab by @symbols;";
 name = lnum;
 },
 {
-code = "sub @figures by @figures_tab;
-sub @symbols by @symbols_tab;";
+code = "sub @figures by @figures_tab;\012sub @symbols by @symbols_tab;";
 name = tnum;
 },
 {
-code = "sub [A a] by ordfeminine;
-sub [O o] by ordmasculine;";
+code = "sub [A a] by ordfeminine;\012sub [O o] by ordmasculine;";
 name = ordn;
 },
 {
-code = "sub @cap_off by @cap_on;
-
-sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;";
+code = "sub @cap_off by @cap_on;\012\012sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;";
 name = case;
 },
 {
-code = "featureNames {
-    name \"Micro Caps\";
-    name 1 \"Micro Caps\";
-};
-sub A by a.sc.ss04;
-sub B by b.sc.ss04;
-sub C by c.sc.ss04;
-sub D by d.sc.ss04;
-sub E by e.sc.ss04;
-sub F by f.sc.ss04;
-sub G by g.sc.ss04;
-sub H by h.sc.ss04;
-sub I by i.sc.ss04;
-sub J by j.sc.ss04;
-sub K by k.sc.ss04;
-sub L by l.sc.ss04;
-sub M by m.sc.ss04;
-sub N by n.sc.ss04;
-sub O by o.sc.ss04;
-sub P by p.sc.ss04;
-sub Q by q.sc.ss04;
-sub R by r.sc.ss04;
-sub S by s.sc.ss04;
-sub T by t.sc.ss04;
-sub U by u.sc.ss04;
-sub V by v.sc.ss04;
-sub W by w.sc.ss04;
-sub X by x.sc.ss04;
-sub Y by y.sc.ss04;
-sub Z by z.sc.ss04;
-sub a by a.sc.lc.ss04;
-sub b by b.sc.lc.ss04;
-sub c by c.sc.lc.ss04;
-sub d by d.sc.lc.ss04;
-sub e by e.sc.lc.ss04;
-sub f by f.sc.lc.ss04;
-sub g by g.sc.lc.ss04;
-sub h by h.sc.lc.ss04;
-sub i by i.sc.lc.ss04;
-sub j by j.sc.lc.ss04;
-sub k by k.sc.lc.ss04;
-sub l by l.sc.lc.ss04;
-sub m by m.sc.lc.ss04;
-sub n by n.sc.lc.ss04;
-sub o by o.sc.lc.ss04;
-sub p by p.sc.lc.ss04;
-sub q by q.sc.lc.ss04;
-sub r by r.sc.lc.ss04;
-sub s by s.sc.lc.ss04;
-sub t by t.sc.lc.ss04;
-sub u by u.sc.lc.ss04;
-sub v by v.sc.lc.ss04;
-sub w by w.sc.lc.ss04;
-sub x by x.sc.lc.ss04;
-sub y by y.sc.lc.ss04;
-sub z by z.sc.lc.ss04;
-sub zero.sc by zero.sc.ss04;
-sub one.sc by one.sc.ss04;
-sub two.sc by two.sc.ss04;
-sub three.sc by three.sc.ss04;
-sub four.sc by four.sc.ss04;
-sub five.sc by five.sc.ss04;
-sub six.sc by six.sc.ss04;
-sub seven.sc by seven.sc.ss04;
-sub eight.sc by eight.sc.ss04;
-sub nine.sc by nine.sc.ss04;
-";
+code = "featureNames {\012    name \"Micro Caps\";\012    name 1 \"Micro Caps\";\012};\012sub A by a.sc.ss04;\012sub B by b.sc.ss04;\012sub C by c.sc.ss04;\012sub D by d.sc.ss04;\012sub E by e.sc.ss04;\012sub F by f.sc.ss04;\012sub G by g.sc.ss04;\012sub H by h.sc.ss04;\012sub I by i.sc.ss04;\012sub J by j.sc.ss04;\012sub K by k.sc.ss04;\012sub L by l.sc.ss04;\012sub M by m.sc.ss04;\012sub N by n.sc.ss04;\012sub O by o.sc.ss04;\012sub P by p.sc.ss04;\012sub Q by q.sc.ss04;\012sub R by r.sc.ss04;\012sub S by s.sc.ss04;\012sub T by t.sc.ss04;\012sub U by u.sc.ss04;\012sub V by v.sc.ss04;\012sub W by w.sc.ss04;\012sub X by x.sc.ss04;\012sub Y by y.sc.ss04;\012sub Z by z.sc.ss04;\012sub a by a.sc.lc.ss04;\012sub b by b.sc.lc.ss04;\012sub c by c.sc.lc.ss04;\012sub d by d.sc.lc.ss04;\012sub e by e.sc.lc.ss04;\012sub f by f.sc.lc.ss04;\012sub g by g.sc.lc.ss04;\012sub h by h.sc.lc.ss04;\012sub i by i.sc.lc.ss04;\012sub j by j.sc.lc.ss04;\012sub k by k.sc.lc.ss04;\012sub l by l.sc.lc.ss04;\012sub m by m.sc.lc.ss04;\012sub n by n.sc.lc.ss04;\012sub o by o.sc.lc.ss04;\012sub p by p.sc.lc.ss04;\012sub q by q.sc.lc.ss04;\012sub r by r.sc.lc.ss04;\012sub s by s.sc.lc.ss04;\012sub t by t.sc.lc.ss04;\012sub u by u.sc.lc.ss04;\012sub v by v.sc.lc.ss04;\012sub w by w.sc.lc.ss04;\012sub x by x.sc.lc.ss04;\012sub y by y.sc.lc.ss04;\012sub z by z.sc.lc.ss04;\012sub zero.sc by zero.sc.ss04;\012sub one.sc by one.sc.ss04;\012sub two.sc by two.sc.ss04;\012sub three.sc by three.sc.ss04;\012sub four.sc by four.sc.ss04;\012sub five.sc by five.sc.ss04;\012sub six.sc by six.sc.ss04;\012sub seven.sc by seven.sc.ss04;\012sub eight.sc by eight.sc.ss04;\012sub nine.sc by nine.sc.ss04;\012";
 name = ss04;
 },
 {
-code = "    sub f f b by f_f_b;
-    sub f f h by f_f_h;
-    sub f f i by f_f_i;
-    sub f f j by f_f_j;
-    sub f f k by f_f_k;
-    sub f f l by f_f_l;
-    sub f f t by f_f_t;
-    sub r f f by r_f_f;
-    sub f b by f_b;
-    sub f f by f_f;
-    sub f h by f_h;
-    sub f i by f_i;
-    sub f j by f_j;
-    sub f k by f_k;
-    sub f l by f_l;
-    sub f t by f_t;
-    sub r f by r_f;
-    sub r t by r_t;
-    sub t f by t_f;
-    sub t t by t_t;
-    sub [G g] o o g l e underscore l o g o by Google.logo;
-    
-    sub [G g] o o g l e l o g o l i g a t u r e by Google.logo;
-    sub G l o g o l i g a t u r e by G.logo;
-    sub o l o g o l i g a t u r e by o.logo;
-    sub g l o g o l i g a t u r e by g.logo;
-    sub l l o g o l i g a t u r e by l.logo;
-    sub e l o g o l i g a t u r e by e.logo;";
+code = "    sub f f b by f_f_b;\012    sub f f h by f_f_h;\012    sub f f i by f_f_i;\012    sub f f j by f_f_j;\012    sub f f k by f_f_k;\012    sub f f l by f_f_l;\012    sub f f t by f_f_t;\012    sub r f f by r_f_f;\012    sub f b by f_b;\012    sub f f by f_f;\012    sub f h by f_h;\012    sub f i by f_i;\012    sub f j by f_j;\012    sub f k by f_k;\012    sub f l by f_l;\012    sub f t by f_t;\012    sub r f by r_f;\012    sub r t by r_t;\012    sub t f by t_f;\012    sub t t by t_t;\012    sub [G g] o o g l e underscore l o g o by Google.logo;\012    \012    sub [G g] o o g l e l o g o l i g a t u r e by Google.logo;\012    sub G l o g o l i g a t u r e by G.logo;\012    sub o l o g o l i g a t u r e by o.logo;\012    sub g l o g o l i g a t u r e by g.logo;\012    sub l l o g o l i g a t u r e by l.logo;\012    sub e l o g o l i g a t u r e by e.logo;";
 name = liga;
 },
 {
 automatic = 1;
-code = "sub one by onesuperior;
-sub two by twosuperior;
-sub three by threesuperior;
-sub four by foursuperior;
-sub zero by zerosuperior;
-sub five by fivesuperior;
-sub six by sixsuperior;
-sub seven by sevensuperior;
-sub eight by eightsuperior;
-sub nine by ninesuperior;
-";
+code = "sub one by onesuperior;\012sub two by twosuperior;\012sub three by threesuperior;\012sub four by foursuperior;\012sub zero by zerosuperior;\012sub five by fivesuperior;\012sub six by sixsuperior;\012sub seven by sevensuperior;\012sub eight by eightsuperior;\012sub nine by ninesuperior;\012";
 name = sups;
 },
 {
 automatic = 1;
-code = "sub zero by zeroinferior;
-sub one by oneinferior;
-sub two by twoinferior;
-sub three by threeinferior;
-sub four by fourinferior;
-sub five by fiveinferior;
-sub six by sixinferior;
-sub seven by seveninferior;
-sub eight by eightinferior;
-sub nine by nineinferior;
-";
+code = "sub zero by zeroinferior;\012sub one by oneinferior;\012sub two by twoinferior;\012sub three by threeinferior;\012sub four by fourinferior;\012sub five by fiveinferior;\012sub six by sixinferior;\012sub seven by seveninferior;\012sub eight by eightinferior;\012sub nine by nineinferior;\012";
 name = subs;
 },
 {
 automatic = 1;
-code = "sub zero by zeroinferior;
-sub one by oneinferior;
-sub two by twoinferior;
-sub three by threeinferior;
-sub four by fourinferior;
-sub five by fiveinferior;
-sub six by sixinferior;
-sub seven by seveninferior;
-sub eight by eightinferior;
-sub nine by nineinferior;
-";
+code = "sub zero by zeroinferior;\012sub one by oneinferior;\012sub two by twoinferior;\012sub three by threeinferior;\012sub four by fourinferior;\012sub five by fiveinferior;\012sub six by sixinferior;\012sub seven by seveninferior;\012sub eight by eightinferior;\012sub nine by nineinferior;\012";
 name = sinf;
 },
 {
 automatic = 1;
-code = "sub zero.tf by zero;
-sub one.tf by one;
-sub two.tf by two;
-sub three.tf by three;
-sub four.tf by four;
-sub five.tf by five;
-sub six.tf by six;
-sub seven.tf by seven;
-sub eight.tf by eight;
-sub nine.tf by nine;
-sub period.tf by period;
-sub comma.tf by comma;
-sub colon.tf by colon;
-sub semicolon.tf by semicolon;
-sub numbersign.tf by numbersign;
-sub space.tf by space;
-sub cent.tf by cent;
-sub currency.tf by currency;
-sub dollar.tf by dollar;
-sub dong.tf by dong;
-sub euro.tf by euro;
-sub florin.tf by florin;
-sub franc.tf by franc;
-sub lira.tf by lira;
-sub liraTurkish.tf by liraTurkish;
-sub peso.tf by peso;
-sub ruble.tf by ruble;
-sub rupeeIndian.tf by rupeeIndian;
-sub sterling.tf by sterling;
-sub tenge.tf by tenge;
-sub tugrik.tf by tugrik;
-sub won.tf by won;
-sub yen.tf by yen;
-sub plus.tf by plus;
-sub minus.tf by minus;
-sub multiply.tf by multiply;
-sub divide.tf by divide;
-sub equal.tf by equal;
-sub notequal.tf by notequal;
-sub greater.tf by greater;
-sub less.tf by less;
-sub greaterequal.tf by greaterequal;
-sub lessequal.tf by lessequal;
-sub plusminus.tf by plusminus;
-sub approxequal.tf by approxequal;
-sub logicalnot.tf by logicalnot;
-sub percent.tf by percent;
-sub section.tf by section;
-";
+code = "sub zero.tf by zero;\012sub one.tf by one;\012sub two.tf by two;\012sub three.tf by three;\012sub four.tf by four;\012sub five.tf by five;\012sub six.tf by six;\012sub seven.tf by seven;\012sub eight.tf by eight;\012sub nine.tf by nine;\012sub period.tf by period;\012sub comma.tf by comma;\012sub colon.tf by colon;\012sub semicolon.tf by semicolon;\012sub numbersign.tf by numbersign;\012sub space.tf by space;\012sub cent.tf by cent;\012sub currency.tf by currency;\012sub dollar.tf by dollar;\012sub dong.tf by dong;\012sub euro.tf by euro;\012sub florin.tf by florin;\012sub franc.tf by franc;\012sub lira.tf by lira;\012sub liraTurkish.tf by liraTurkish;\012sub peso.tf by peso;\012sub ruble.tf by ruble;\012sub rupeeIndian.tf by rupeeIndian;\012sub sterling.tf by sterling;\012sub tenge.tf by tenge;\012sub tugrik.tf by tugrik;\012sub won.tf by won;\012sub yen.tf by yen;\012sub plus.tf by plus;\012sub minus.tf by minus;\012sub multiply.tf by multiply;\012sub divide.tf by divide;\012sub equal.tf by equal;\012sub notequal.tf by notequal;\012sub greater.tf by greater;\012sub less.tf by less;\012sub greaterequal.tf by greaterequal;\012sub lessequal.tf by lessequal;\012sub plusminus.tf by plusminus;\012sub approxequal.tf by approxequal;\012sub logicalnot.tf by logicalnot;\012sub percent.tf by percent;\012sub section.tf by section;\012";
 name = pnum;
 },
 {
 automatic = 1;
-code = "sub A by a.sc;
-sub Aacute by aacute.sc;
-sub Abreve by abreve.sc;
-sub Abreveacute by abreveacute.sc;
-sub Abrevedotbelow by abrevedotbelow.sc;
-sub Abrevegrave by abrevegrave.sc;
-sub Abrevehookabove by abrevehookabove.sc;
-sub Abrevetilde by abrevetilde.sc;
-sub Acaron by acaron.sc;
-sub Acircumflex by acircumflex.sc;
-sub Acircumflexacute by acircumflexacute.sc;
-sub Acircumflexdotbelow by acircumflexdotbelow.sc;
-sub Acircumflexgrave by acircumflexgrave.sc;
-sub Acircumflexhookabove by acircumflexhookabove.sc;
-sub Acircumflextilde by acircumflextilde.sc;
-sub Adieresis by adieresis.sc;
-sub Adotbelow by adotbelow.sc;
-sub Agrave by agrave.sc;
-sub Ahookabove by ahookabove.sc;
-sub Amacron by amacron.sc;
-sub Aogonek by aogonek.sc;
-sub Aring by aring.sc;
-sub Aringacute by aringacute.sc;
-sub Atilde by atilde.sc;
-sub AE by ae.sc;
-sub AEacute by aeacute.sc;
-sub B by b.sc;
-sub C by c.sc;
-sub Cacute by cacute.sc;
-sub Ccaron by ccaron.sc;
-sub Ccedilla by ccedilla.sc;
-sub Ccircumflex by ccircumflex.sc;
-sub Cdotaccent by cdotaccent.sc;
-sub D by d.sc;
-sub Eth by eth.sc;
-sub Dcaron by dcaron.sc;
-sub Dcroat by dcroat.sc;
-sub E by e.sc;
-sub Eacute by eacute.sc;
-sub Ebreve by ebreve.sc;
-sub Ecaron by ecaron.sc;
-sub Ecircumflex by ecircumflex.sc;
-sub Ecircumflexacute by ecircumflexacute.sc;
-sub Ecircumflexdotbelow by ecircumflexdotbelow.sc;
-sub Ecircumflexgrave by ecircumflexgrave.sc;
-sub Ecircumflexhookabove by ecircumflexhookabove.sc;
-sub Ecircumflextilde by ecircumflextilde.sc;
-sub Edieresis by edieresis.sc;
-sub Edotaccent by edotaccent.sc;
-sub Edotbelow by edotbelow.sc;
-sub Egrave by egrave.sc;
-sub Ehookabove by ehookabove.sc;
-sub Emacron by emacron.sc;
-sub Eogonek by eogonek.sc;
-sub Etilde by etilde.sc;
-sub F by f.sc;
-sub G by g.sc;
-sub Gbreve by gbreve.sc;
-sub Gcircumflex by gcircumflex.sc;
-sub Gcommaaccent by gcommaaccent.sc;
-sub Gdotaccent by gdotaccent.sc;
-sub H by h.sc;
-sub Hbar by hbar.sc;
-sub Hcircumflex by hcircumflex.sc;
-sub I by i.sc;
-sub Iacute by iacute.sc;
-sub Ibreve by ibreve.sc;
-sub Icircumflex by icircumflex.sc;
-sub Idieresis by idieresis.sc;
-sub Idotaccent by idotaccent.sc;
-sub Idotbelow by idotbelow.sc;
-sub Igrave by igrave.sc;
-sub Ihookabove by ihookabove.sc;
-sub Imacron by imacron.sc;
-sub Iogonek by iogonek.sc;
-sub Itilde by itilde.sc;
-sub J by j.sc;
-sub Jcircumflex by jcircumflex.sc;
-sub K by k.sc;
-sub Kcommaaccent by kcommaaccent.sc;
-sub L by l.sc;
-sub Lacute by lacute.sc;
-sub Lcaron by lcaron.sc;
-sub Lcommaaccent by lcommaaccent.sc;
-sub Ldot by ldot.sc;
-sub Lslash by lslash.sc;
-sub M by m.sc;
-sub N by n.sc;
-sub Nacute by nacute.sc;
-sub Ncaron by ncaron.sc;
-sub Ncommaaccent by ncommaaccent.sc;
-sub Eng by eng.sc;
-sub Ntilde by ntilde.sc;
-sub O by o.sc;
-sub Oacute by oacute.sc;
-sub Obreve by obreve.sc;
-sub Ocircumflex by ocircumflex.sc;
-sub Ocircumflexacute by ocircumflexacute.sc;
-sub Ocircumflexdotbelow by ocircumflexdotbelow.sc;
-sub Ocircumflexgrave by ocircumflexgrave.sc;
-sub Ocircumflexhookabove by ocircumflexhookabove.sc;
-sub Ocircumflextilde by ocircumflextilde.sc;
-sub Odieresis by odieresis.sc;
-sub Odotbelow by odotbelow.sc;
-sub Ograve by ograve.sc;
-sub Ohookabove by ohookabove.sc;
-sub Ohorn by ohorn.sc;
-sub Ohornacute by ohornacute.sc;
-sub Ohorndotbelow by ohorndotbelow.sc;
-sub Ohorngrave by ohorngrave.sc;
-sub Ohornhookabove by ohornhookabove.sc;
-sub Ohorntilde by ohorntilde.sc;
-sub Ohungarumlaut by ohungarumlaut.sc;
-sub Omacron by omacron.sc;
-sub Oslash by oslash.sc;
-sub Oslashacute by oslashacute.sc;
-sub Otilde by otilde.sc;
-sub OE by oe.sc;
-sub P by p.sc;
-sub Thorn by thorn.sc;
-sub Q by q.sc;
-sub R by r.sc;
-sub Racute by racute.sc;
-sub Rcaron by rcaron.sc;
-sub Rcommaaccent by rcommaaccent.sc;
-sub S by s.sc;
-sub Sacute by sacute.sc;
-sub Scaron by scaron.sc;
-sub Scedilla by scedilla.sc;
-sub Scircumflex by scircumflex.sc;
-sub Scommaaccent by scommaaccent.sc;
-sub T by t.sc;
-sub Tbar by tbar.sc;
-sub Tcaron by tcaron.sc;
-sub Tcedilla by tcedilla.sc;
-sub Tcommaaccent by tcommaaccent.sc;
-sub U by u.sc;
-sub Uacute by uacute.sc;
-sub Ubreve by ubreve.sc;
-sub Ucircumflex by ucircumflex.sc;
-sub Udieresis by udieresis.sc;
-sub Udotbelow by udotbelow.sc;
-sub Ugrave by ugrave.sc;
-sub Uhookabove by uhookabove.sc;
-sub Uhorn by uhorn.sc;
-sub Uhornacute by uhornacute.sc;
-sub Uhorndotbelow by uhorndotbelow.sc;
-sub Uhorngrave by uhorngrave.sc;
-sub Uhornhookabove by uhornhookabove.sc;
-sub Uhorntilde by uhorntilde.sc;
-sub Uhungarumlaut by uhungarumlaut.sc;
-sub Umacron by umacron.sc;
-sub Uogonek by uogonek.sc;
-sub Uring by uring.sc;
-sub Utilde by utilde.sc;
-sub V by v.sc;
-sub W by w.sc;
-sub Wacute by wacute.sc;
-sub Wcircumflex by wcircumflex.sc;
-sub Wdieresis by wdieresis.sc;
-sub Wgrave by wgrave.sc;
-sub X by x.sc;
-sub Y by y.sc;
-sub Yacute by yacute.sc;
-sub Ycircumflex by ycircumflex.sc;
-sub Ydieresis by ydieresis.sc;
-sub Ydotbelow by ydotbelow.sc;
-sub Ygrave by ygrave.sc;
-sub Yhookabove by yhookabove.sc;
-sub Ytilde by ytilde.sc;
-sub Z by z.sc;
-sub Zacute by zacute.sc;
-sub Zcaron by zcaron.sc;
-sub Zdotaccent by zdotaccent.sc;
-sub A-cy by a-cy.sc;
-sub Be-cy by be-cy.sc;
-sub Ve-cy by ve-cy.sc;
-sub Ge-cy by ge-cy.sc;
-sub Gje-cy by gje-cy.sc;
-sub Gheupturn-cy by gheupturn-cy.sc;
-sub De-cy by de-cy.sc;
-sub Ie-cy by ie-cy.sc;
-sub Iegrave-cy by iegrave-cy.sc;
-sub Io-cy by io-cy.sc;
-sub Zhe-cy by zhe-cy.sc;
-sub Ze-cy by ze-cy.sc;
-sub Ii-cy by ii-cy.sc;
-sub Iishort-cy by iishort-cy.sc;
-sub Iigrave-cy by iigrave-cy.sc;
-sub Iishorttail-cy by iishorttail-cy.sc;
-sub Ka-cy by ka-cy.sc;
-sub Kje-cy by kje-cy.sc;
-sub El-cy by el-cy.sc;
-sub Em-cy by em-cy.sc;
-sub En-cy by en-cy.sc;
-sub O-cy by o-cy.sc;
-sub Pe-cy by pe-cy.sc;
-sub Er-cy by er-cy.sc;
-sub Es-cy by es-cy.sc;
-sub Te-cy by te-cy.sc;
-sub U-cy by u-cy.sc;
-sub Ushort-cy by ushort-cy.sc;
-sub Ef-cy by ef-cy.sc;
-sub Ha-cy by ha-cy.sc;
-sub Che-cy by che-cy.sc;
-sub Tse-cy by tse-cy.sc;
-sub Sha-cy by sha-cy.sc;
-sub Shcha-cy by shcha-cy.sc;
-sub Dzhe-cy by dzhe-cy.sc;
-sub Softsign-cy by softsign-cy.sc;
-sub Hardsign-cy by hardsign-cy.sc;
-sub Yeru-cy by yeru-cy.sc;
-sub Lje-cy by lje-cy.sc;
-sub Nje-cy by nje-cy.sc;
-sub Dze-cy by dze-cy.sc;
-sub E-cy by e-cy.sc;
-sub Ereversed-cy by ereversed-cy.sc;
-sub I-cy by i-cy.sc;
-sub Yi-cy by yi-cy.sc;
-sub Je-cy by je-cy.sc;
-sub Tshe-cy by tshe-cy.sc;
-sub Iu-cy by iu-cy.sc;
-sub Ia-cy by ia-cy.sc;
-sub Dje-cy by dje-cy.sc;
-sub Yat-cy by yat-cy.sc;
-sub Yusbig-cy by yusbig-cy.sc;
-sub Fita-cy by fita-cy.sc;
-sub Izhitsa-cy by izhitsa-cy.sc;
-sub Ghestroke-cy by ghestroke-cy.sc;
-sub Ghemiddlehook-cy by ghemiddlehook-cy.sc;
-sub Zhedescender-cy by zhedescender-cy.sc;
-sub Zedescender-cy by zedescender-cy.sc;
-sub Kadescender-cy by kadescender-cy.sc;
-sub Kaverticalstroke-cy by kaverticalstroke-cy.sc;
-sub Kastroke-cy by kastroke-cy.sc;
-sub Kabashkir-cy by kabashkir-cy.sc;
-sub Endescender-cy by endescender-cy.sc;
-sub Enghe-cy by enghe-cy.sc;
-sub Pedescender-cy by pedescender-cy.sc;
-sub Haabkhasian-cy by haabkhasian-cy.sc;
-sub Esdescender-cy by esdescender-cy.sc;
-sub Tedescender-cy by tedescender-cy.sc;
-sub Ustraight-cy by ustraight-cy.sc;
-sub Ustraightstroke-cy by ustraightstroke-cy.sc;
-sub Hadescender-cy by hadescender-cy.sc;
-sub Tetse-cy by tetse-cy.sc;
-sub Chedescender-cy by chedescender-cy.sc;
-sub Cheverticalstroke-cy by cheverticalstroke-cy.sc;
-sub Shha-cy by shha-cy.sc;
-sub Shhadescender-cy by shhadescender-cy.sc;
-sub Cheabkhasian-cy by cheabkhasian-cy.sc;
-sub Chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;
-sub Palochka-cy by palochka-cy.sc;
-sub Zhebreve-cy by zhebreve-cy.sc;
-sub Kahook-cy by kahook-cy.sc;
-sub Eltail-cy by eltail-cy.sc;
-sub Enhook-cy by enhook-cy.sc;
-sub Entail-cy by entail-cy.sc;
-sub Chekhakassian-cy by chekhakassian-cy.sc;
-sub Emtail-cy by emtail-cy.sc;
-sub Abreve-cy by abreve-cy.sc;
-sub Adieresis-cy by adieresis-cy.sc;
-sub Aie-cy by aie-cy.sc;
-sub Iebreve-cy by iebreve-cy.sc;
-sub Schwa-cy by schwa-cy.sc;
-sub Schwadieresis-cy by schwadieresis-cy.sc;
-sub Zhedieresis-cy by zhedieresis-cy.sc;
-sub Zedieresis-cy by zedieresis-cy.sc;
-sub Dzeabkhasian-cy by dzeabkhasian-cy.sc;
-sub Imacron-cy by imacron-cy.sc;
-sub Idieresis-cy by idieresis-cy.sc;
-sub Odieresis-cy by odieresis-cy.sc;
-sub Obarred-cy by obarred-cy.sc;
-sub Obarreddieresis-cy by obarreddieresis-cy.sc;
-sub Edieresis-cy by edieresis-cy.sc;
-sub Umacron-cy by umacron-cy.sc;
-sub Udieresis-cy by udieresis-cy.sc;
-sub Uhungarumlaut-cy by uhungarumlaut-cy.sc;
-sub Chedieresis-cy by chedieresis-cy.sc;
-sub Gedescender-cy by gedescender-cy.sc;
-sub Yerudieresis-cy by yerudieresis-cy.sc;
-sub Gestrokehook-cy by gestrokehook-cy.sc;
-sub Hahook-cy by hahook-cy.sc;
-sub Hastroke-cy by hastroke-cy.sc;
-sub Reversedze-cy by reversedze-cy.sc;
-sub Elhook-cy by elhook-cy.sc;
-sub Qa-cy by qa-cy.sc;
-sub We-cy by we-cy.sc;
-sub Semisoftsign-cy by semisoftsign-cy.sc;
-sub Ertick-cy by ertick-cy.sc;
-sub EnLeftHook-cy by enlefthook-cy.sc;
-sub Eldescender-cy by eldescender-cy.sc;
-sub De-cy.loclBGR by de-cy.loclBGR.sc;
-sub El-cy.loclBGR by el-cy.loclBGR.sc;
-sub Ef-cy.loclBGR by ef-cy.loclBGR.sc;
-sub Ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;
-sub Zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;
-sub Esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;
-sub Esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;
-sub Alpha by alpha.sc;
-sub Beta by beta.sc;
-sub Gamma by gamma.sc;
-sub Delta by delta.sc;
-sub Epsilon by epsilon.sc;
-sub Zeta by zeta.sc;
-sub Eta by eta.sc;
-sub Theta by theta.sc;
-sub Iota by iota.sc;
-sub Kappa by kappa.sc;
-sub Lambda by lambda.sc;
-sub Mu by mu.sc;
-sub Nu by nu.sc;
-sub Xi by xi.sc;
-sub Omicron by omicron.sc;
-sub Pi by pi.sc;
-sub Rho by rho.sc;
-sub Sigma by sigma.sc;
-sub Tau by tau.sc;
-sub Upsilon by upsilon.sc;
-sub Phi by phi.sc;
-sub Chi by chi.sc;
-sub Psi by psi.sc;
-sub Omega by omega.sc;
-sub Alphatonos by alphatonos.sc;
-sub Epsilontonos by epsilontonos.sc;
-sub Etatonos by etatonos.sc;
-sub Iotatonos by iotatonos.sc;
-sub Omicrontonos by omicrontonos.sc;
-sub Upsilontonos by upsilontonos.sc;
-sub Omegatonos by omegatonos.sc;
-sub Iotadieresis by iotadieresis.sc;
-sub Upsilondieresis by upsilondieresis.sc;
-sub KaiSymbol by kaiSymbol.sc;
-sub Alphapsili by alphapsili.sc;
-sub Alphadasia by alphadasia.sc;
-sub Alphapsilivaria by alphapsilivaria.sc;
-sub Alphadasiavaria by alphadasiavaria.sc;
-sub Alphapsilioxia by alphapsilioxia.sc;
-sub Alphadasiaoxia by alphadasiaoxia.sc;
-sub Alphapsiliperispomeni by alphapsiliperispomeni.sc;
-sub Alphadasiaperispomeni by alphadasiaperispomeni.sc;
-sub Alphavaria by alphavaria.sc;
-sub Alphaoxia by alphaoxia.sc;
-sub Alphavrachy by alphavrachy.sc;
-sub Alphamacron by alphamacron.sc;
-sub Alphaprosgegrammeni by alphaypogegrammeni.sc;
-sub Alphapsiliprosgegrammeni by alphapsiliypogegrammeni.sc;
-sub Alphadasiaprosgegrammeni by alphadasiaypogegrammeni.sc;
-sub Alphapsilivariaprosgegrammeni by alphapsilivariaypogegrammeni.sc;
-sub Alphadasiavariaprosgegrammeni by alphadasiavariaypogegrammeni.sc;
-sub Alphapsilioxiaprosgegrammeni by alphapsilioxiaypogegrammeni.sc;
-sub Alphadasiaoxiaprosgegrammeni by alphadasiaoxiaypogegrammeni.sc;
-sub Alphapsiliperispomeniprosgegrammeni by alphapsiliperispomeniypogegrammeni.sc;
-sub Alphadasiaperispomeniprosgegrammeni by alphadasiaperispomeniypogegrammeni.sc;
-sub Epsilonpsili by epsilonpsili.sc;
-sub Epsilondasia by epsilondasia.sc;
-sub Epsilonpsilivaria by epsilonpsilivaria.sc;
-sub Epsilondasiavaria by epsilondasiavaria.sc;
-sub Epsilonpsilioxia by epsilonpsilioxia.sc;
-sub Epsilondasiaoxia by epsilondasiaoxia.sc;
-sub Epsilonvaria by epsilonvaria.sc;
-sub Epsilonoxia by epsilonoxia.sc;
-sub Etapsili by etapsili.sc;
-sub Etadasia by etadasia.sc;
-sub Etapsilivaria by etapsilivaria.sc;
-sub Etadasiavaria by etadasiavaria.sc;
-sub Etapsilioxia by etapsilioxia.sc;
-sub Etadasiaoxia by etadasiaoxia.sc;
-sub Etapsiliperispomeni by etapsiliperispomeni.sc;
-sub Etadasiaperispomeni by etadasiaperispomeni.sc;
-sub Etavaria by etavaria.sc;
-sub Etaoxia by etaoxia.sc;
-sub Etaprosgegrammeni by etaypogegrammeni.sc;
-sub Etapsiliprosgegrammeni by etapsiliypogegrammeni.sc;
-sub Etadasiaprosgegrammeni by etadasiaypogegrammeni.sc;
-sub Etapsilivariaprosgegrammeni by etapsilivariaypogegrammeni.sc;
-sub Etadasiavariaprosgegrammeni by etadasiavariaypogegrammeni.sc;
-sub Etapsilioxiaprosgegrammeni by etapsilioxiaypogegrammeni.sc;
-sub Etadasiaoxiaprosgegrammeni by etadasiaoxiaypogegrammeni.sc;
-sub Etapsiliperispomeniprosgegrammeni by etapsiliperispomeniypogegrammeni.sc;
-sub Etadasiaperispomeniprosgegrammeni by etadasiaperispomeniypogegrammeni.sc;
-sub Iotapsili by iotapsili.sc;
-sub Iotadasia by iotadasia.sc;
-sub Iotapsilivaria by iotapsilivaria.sc;
-sub Iotadasiavaria by iotadasiavaria.sc;
-sub Iotapsilioxia by iotapsilioxia.sc;
-sub Iotadasiaoxia by iotadasiaoxia.sc;
-sub Iotapsiliperispomeni by iotapsiliperispomeni.sc;
-sub Iotadasiaperispomeni by iotadasiaperispomeni.sc;
-sub Iotavaria by iotavaria.sc;
-sub Iotaoxia by iotaoxia.sc;
-sub Iotavrachy by iotavrachy.sc;
-sub Iotamacron by iotamacron.sc;
-sub Omicronpsili by omicronpsili.sc;
-sub Omicrondasia by omicrondasia.sc;
-sub Omicronpsilivaria by omicronpsilivaria.sc;
-sub Omicrondasiavaria by omicrondasiavaria.sc;
-sub Omicronpsilioxia by omicronpsilioxia.sc;
-sub Omicrondasiaoxia by omicrondasiaoxia.sc;
-sub Omicronvaria by omicronvaria.sc;
-sub Omicronoxia by omicronoxia.sc;
-sub Rhodasia by rhodasia.sc;
-sub Upsilondasia by upsilondasia.sc;
-sub Upsilondasiavaria by upsilondasiavaria.sc;
-sub Upsilondasiaoxia by upsilondasiaoxia.sc;
-sub Upsilondasiaperispomeni by upsilondasiaperispomeni.sc;
-sub Upsilonvaria by upsilonvaria.sc;
-sub Upsilonoxia by upsilonoxia.sc;
-sub Upsilonvrachy by upsilonvrachy.sc;
-sub Upsilonmacron by upsilonmacron.sc;
-sub Omegapsili by omegapsili.sc;
-sub Omegadasia by omegadasia.sc;
-sub Omegapsilivaria by omegapsilivaria.sc;
-sub Omegadasiavaria by omegadasiavaria.sc;
-sub Omegapsilioxia by omegapsilioxia.sc;
-sub Omegadasiaoxia by omegadasiaoxia.sc;
-sub Omegapsiliperispomeni by omegapsiliperispomeni.sc;
-sub Omegadasiaperispomeni by omegadasiaperispomeni.sc;
-sub Omegavaria by omegavaria.sc;
-sub Omegaoxia by omegaoxia.sc;
-sub Omegaprosgegrammeni by omegaypogegrammeni.sc;
-sub Omegapsiliprosgegrammeni by omegapsiliypogegrammeni.sc;
-sub Omegadasiaprosgegrammeni by omegadasiaypogegrammeni.sc;
-sub Omegapsilivariaprosgegrammeni by omegapsilivariaypogegrammeni.sc;
-sub Omegadasiavariaprosgegrammeni by omegadasiavariaypogegrammeni.sc;
-sub Omegapsilioxiaprosgegrammeni by omegapsilioxiaypogegrammeni.sc;
-sub Omegadasiaoxiaprosgegrammeni by omegadasiaoxiaypogegrammeni.sc;
-sub Omegapsiliperispomeniprosgegrammeni by omegapsiliperispomeniypogegrammeni.sc;
-sub Omegadasiaperispomeniprosgegrammeni by omegadasiaperispomeniypogegrammeni.sc;
-sub zero by zero.sc;
-sub one by one.sc;
-sub two by two.sc;
-sub three by three.sc;
-sub four by four.sc;
-sub five by five.sc;
-sub six by six.sc;
-sub seven by seven.sc;
-sub eight by eight.sc;
-sub nine by nine.sc;
-sub anoteleia by anoteleia.sc;
-sub dieresiscomb by dieresiscomb.sc;
-sub dotaccentcomb by dotaccentcomb.sc;
-sub gravecomb by gravecomb.sc;
-sub acutecomb by acutecomb.sc;
-sub hungarumlautcomb by hungarumlautcomb.sc;
-sub circumflexcomb by circumflexcomb.sc;
-sub caroncomb by caroncomb.sc;
-sub brevecomb by brevecomb.sc;
-sub ringcomb by ringcomb.sc;
-sub tildecomb by tildecomb.sc;
-sub macroncomb by macroncomb.sc;
-sub hookabovecomb by hookabovecomb.sc;
-sub tonos by tonos.sc;
-sub dieresistonos by dieresistonos.sc;
-sub psili by psili.sc;
-sub koronis by koronis.sc;
-sub dasia by dasia.sc;
-sub psilivaria by psilivaria.sc;
-sub dasiavaria by dasiavaria.sc;
-sub psilioxia by psilioxia.sc;
-sub dasiaoxia by dasiaoxia.sc;
-sub psiliperispomeni by psiliperispomeni.sc;
-sub dasiaperispomeni by dasiaperispomeni.sc;
-sub dialytikavaria by dialytikavaria.sc;
-sub dialytikaoxia by dialytikaoxia.sc;
-sub dialytikaperispomeni by dialytikaperispomeni.sc;
-sub varia by varia.sc;
-sub oxia by oxia.sc;
-sub perispomeni by perispomeni.sc;
-sub brevecomb_acutecomb by brevecomb_acutecomb.sc;
-sub brevecomb_gravecomb by brevecomb_gravecomb.sc;
-sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;
-sub brevecomb_tildecomb by brevecomb_tildecomb.sc;
-sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;
-sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;
-sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;
-sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;
-sub brevecombcy by brevecombcy.sc;
-";
+code = "sub A by a.sc;\012sub Aacute by aacute.sc;\012sub Abreve by abreve.sc;\012sub Abreveacute by abreveacute.sc;\012sub Abrevedotbelow by abrevedotbelow.sc;\012sub Abrevegrave by abrevegrave.sc;\012sub Abrevehookabove by abrevehookabove.sc;\012sub Abrevetilde by abrevetilde.sc;\012sub Acaron by acaron.sc;\012sub Acircumflex by acircumflex.sc;\012sub Acircumflexacute by acircumflexacute.sc;\012sub Acircumflexdotbelow by acircumflexdotbelow.sc;\012sub Acircumflexgrave by acircumflexgrave.sc;\012sub Acircumflexhookabove by acircumflexhookabove.sc;\012sub Acircumflextilde by acircumflextilde.sc;\012sub Adieresis by adieresis.sc;\012sub Adotbelow by adotbelow.sc;\012sub Agrave by agrave.sc;\012sub Ahookabove by ahookabove.sc;\012sub Amacron by amacron.sc;\012sub Aogonek by aogonek.sc;\012sub Aring by aring.sc;\012sub Aringacute by aringacute.sc;\012sub Atilde by atilde.sc;\012sub AE by ae.sc;\012sub AEacute by aeacute.sc;\012sub B by b.sc;\012sub C by c.sc;\012sub Cacute by cacute.sc;\012sub Ccaron by ccaron.sc;\012sub Ccedilla by ccedilla.sc;\012sub Ccircumflex by ccircumflex.sc;\012sub Cdotaccent by cdotaccent.sc;\012sub D by d.sc;\012sub Eth by eth.sc;\012sub Dcaron by dcaron.sc;\012sub Dcroat by dcroat.sc;\012sub E by e.sc;\012sub Eacute by eacute.sc;\012sub Ebreve by ebreve.sc;\012sub Ecaron by ecaron.sc;\012sub Ecircumflex by ecircumflex.sc;\012sub Ecircumflexacute by ecircumflexacute.sc;\012sub Ecircumflexdotbelow by ecircumflexdotbelow.sc;\012sub Ecircumflexgrave by ecircumflexgrave.sc;\012sub Ecircumflexhookabove by ecircumflexhookabove.sc;\012sub Ecircumflextilde by ecircumflextilde.sc;\012sub Edieresis by edieresis.sc;\012sub Edotaccent by edotaccent.sc;\012sub Edotbelow by edotbelow.sc;\012sub Egrave by egrave.sc;\012sub Ehookabove by ehookabove.sc;\012sub Emacron by emacron.sc;\012sub Eogonek by eogonek.sc;\012sub Etilde by etilde.sc;\012sub F by f.sc;\012sub G by g.sc;\012sub Gbreve by gbreve.sc;\012sub Gcircumflex by gcircumflex.sc;\012sub Gcommaaccent by gcommaaccent.sc;\012sub Gdotaccent by gdotaccent.sc;\012sub H by h.sc;\012sub Hbar by hbar.sc;\012sub Hcircumflex by hcircumflex.sc;\012sub I by i.sc;\012sub Iacute by iacute.sc;\012sub Ibreve by ibreve.sc;\012sub Icircumflex by icircumflex.sc;\012sub Idieresis by idieresis.sc;\012sub Idotaccent by idotaccent.sc;\012sub Idotbelow by idotbelow.sc;\012sub Igrave by igrave.sc;\012sub Ihookabove by ihookabove.sc;\012sub Imacron by imacron.sc;\012sub Iogonek by iogonek.sc;\012sub Itilde by itilde.sc;\012sub J by j.sc;\012sub Jcircumflex by jcircumflex.sc;\012sub K by k.sc;\012sub Kcommaaccent by kcommaaccent.sc;\012sub L by l.sc;\012sub Lacute by lacute.sc;\012sub Lcaron by lcaron.sc;\012sub Lcommaaccent by lcommaaccent.sc;\012sub Ldot by ldot.sc;\012sub Lslash by lslash.sc;\012sub M by m.sc;\012sub N by n.sc;\012sub Nacute by nacute.sc;\012sub Ncaron by ncaron.sc;\012sub Ncommaaccent by ncommaaccent.sc;\012sub Eng by eng.sc;\012sub Ntilde by ntilde.sc;\012sub O by o.sc;\012sub Oacute by oacute.sc;\012sub Obreve by obreve.sc;\012sub Ocircumflex by ocircumflex.sc;\012sub Ocircumflexacute by ocircumflexacute.sc;\012sub Ocircumflexdotbelow by ocircumflexdotbelow.sc;\012sub Ocircumflexgrave by ocircumflexgrave.sc;\012sub Ocircumflexhookabove by ocircumflexhookabove.sc;\012sub Ocircumflextilde by ocircumflextilde.sc;\012sub Odieresis by odieresis.sc;\012sub Odotbelow by odotbelow.sc;\012sub Ograve by ograve.sc;\012sub Ohookabove by ohookabove.sc;\012sub Ohorn by ohorn.sc;\012sub Ohornacute by ohornacute.sc;\012sub Ohorndotbelow by ohorndotbelow.sc;\012sub Ohorngrave by ohorngrave.sc;\012sub Ohornhookabove by ohornhookabove.sc;\012sub Ohorntilde by ohorntilde.sc;\012sub Ohungarumlaut by ohungarumlaut.sc;\012sub Omacron by omacron.sc;\012sub Oslash by oslash.sc;\012sub Oslashacute by oslashacute.sc;\012sub Otilde by otilde.sc;\012sub OE by oe.sc;\012sub P by p.sc;\012sub Thorn by thorn.sc;\012sub Q by q.sc;\012sub R by r.sc;\012sub Racute by racute.sc;\012sub Rcaron by rcaron.sc;\012sub Rcommaaccent by rcommaaccent.sc;\012sub S by s.sc;\012sub Sacute by sacute.sc;\012sub Scaron by scaron.sc;\012sub Scedilla by scedilla.sc;\012sub Scircumflex by scircumflex.sc;\012sub Scommaaccent by scommaaccent.sc;\012sub T by t.sc;\012sub Tbar by tbar.sc;\012sub Tcaron by tcaron.sc;\012sub Tcedilla by tcedilla.sc;\012sub Tcommaaccent by tcommaaccent.sc;\012sub U by u.sc;\012sub Uacute by uacute.sc;\012sub Ubreve by ubreve.sc;\012sub Ucircumflex by ucircumflex.sc;\012sub Udieresis by udieresis.sc;\012sub Udotbelow by udotbelow.sc;\012sub Ugrave by ugrave.sc;\012sub Uhookabove by uhookabove.sc;\012sub Uhorn by uhorn.sc;\012sub Uhornacute by uhornacute.sc;\012sub Uhorndotbelow by uhorndotbelow.sc;\012sub Uhorngrave by uhorngrave.sc;\012sub Uhornhookabove by uhornhookabove.sc;\012sub Uhorntilde by uhorntilde.sc;\012sub Uhungarumlaut by uhungarumlaut.sc;\012sub Umacron by umacron.sc;\012sub Uogonek by uogonek.sc;\012sub Uring by uring.sc;\012sub Utilde by utilde.sc;\012sub V by v.sc;\012sub W by w.sc;\012sub Wacute by wacute.sc;\012sub Wcircumflex by wcircumflex.sc;\012sub Wdieresis by wdieresis.sc;\012sub Wgrave by wgrave.sc;\012sub X by x.sc;\012sub Y by y.sc;\012sub Yacute by yacute.sc;\012sub Ycircumflex by ycircumflex.sc;\012sub Ydieresis by ydieresis.sc;\012sub Ydotbelow by ydotbelow.sc;\012sub Ygrave by ygrave.sc;\012sub Yhookabove by yhookabove.sc;\012sub Ytilde by ytilde.sc;\012sub Z by z.sc;\012sub Zacute by zacute.sc;\012sub Zcaron by zcaron.sc;\012sub Zdotaccent by zdotaccent.sc;\012sub A-cy by a-cy.sc;\012sub Be-cy by be-cy.sc;\012sub Ve-cy by ve-cy.sc;\012sub Ge-cy by ge-cy.sc;\012sub Gje-cy by gje-cy.sc;\012sub Gheupturn-cy by gheupturn-cy.sc;\012sub De-cy by de-cy.sc;\012sub Ie-cy by ie-cy.sc;\012sub Iegrave-cy by iegrave-cy.sc;\012sub Io-cy by io-cy.sc;\012sub Zhe-cy by zhe-cy.sc;\012sub Ze-cy by ze-cy.sc;\012sub Ii-cy by ii-cy.sc;\012sub Iishort-cy by iishort-cy.sc;\012sub Iigrave-cy by iigrave-cy.sc;\012sub Iishorttail-cy by iishorttail-cy.sc;\012sub Ka-cy by ka-cy.sc;\012sub Kje-cy by kje-cy.sc;\012sub El-cy by el-cy.sc;\012sub Em-cy by em-cy.sc;\012sub En-cy by en-cy.sc;\012sub O-cy by o-cy.sc;\012sub Pe-cy by pe-cy.sc;\012sub Er-cy by er-cy.sc;\012sub Es-cy by es-cy.sc;\012sub Te-cy by te-cy.sc;\012sub U-cy by u-cy.sc;\012sub Ushort-cy by ushort-cy.sc;\012sub Ef-cy by ef-cy.sc;\012sub Ha-cy by ha-cy.sc;\012sub Che-cy by che-cy.sc;\012sub Tse-cy by tse-cy.sc;\012sub Sha-cy by sha-cy.sc;\012sub Shcha-cy by shcha-cy.sc;\012sub Dzhe-cy by dzhe-cy.sc;\012sub Softsign-cy by softsign-cy.sc;\012sub Hardsign-cy by hardsign-cy.sc;\012sub Yeru-cy by yeru-cy.sc;\012sub Lje-cy by lje-cy.sc;\012sub Nje-cy by nje-cy.sc;\012sub Dze-cy by dze-cy.sc;\012sub E-cy by e-cy.sc;\012sub Ereversed-cy by ereversed-cy.sc;\012sub I-cy by i-cy.sc;\012sub Yi-cy by yi-cy.sc;\012sub Je-cy by je-cy.sc;\012sub Tshe-cy by tshe-cy.sc;\012sub Iu-cy by iu-cy.sc;\012sub Ia-cy by ia-cy.sc;\012sub Dje-cy by dje-cy.sc;\012sub Yat-cy by yat-cy.sc;\012sub Yusbig-cy by yusbig-cy.sc;\012sub Fita-cy by fita-cy.sc;\012sub Izhitsa-cy by izhitsa-cy.sc;\012sub Ghestroke-cy by ghestroke-cy.sc;\012sub Ghemiddlehook-cy by ghemiddlehook-cy.sc;\012sub Zhedescender-cy by zhedescender-cy.sc;\012sub Zedescender-cy by zedescender-cy.sc;\012sub Kadescender-cy by kadescender-cy.sc;\012sub Kaverticalstroke-cy by kaverticalstroke-cy.sc;\012sub Kastroke-cy by kastroke-cy.sc;\012sub Kabashkir-cy by kabashkir-cy.sc;\012sub Endescender-cy by endescender-cy.sc;\012sub Enghe-cy by enghe-cy.sc;\012sub Pedescender-cy by pedescender-cy.sc;\012sub Haabkhasian-cy by haabkhasian-cy.sc;\012sub Esdescender-cy by esdescender-cy.sc;\012sub Tedescender-cy by tedescender-cy.sc;\012sub Ustraight-cy by ustraight-cy.sc;\012sub Ustraightstroke-cy by ustraightstroke-cy.sc;\012sub Hadescender-cy by hadescender-cy.sc;\012sub Tetse-cy by tetse-cy.sc;\012sub Chedescender-cy by chedescender-cy.sc;\012sub Cheverticalstroke-cy by cheverticalstroke-cy.sc;\012sub Shha-cy by shha-cy.sc;\012sub Shhadescender-cy by shhadescender-cy.sc;\012sub Cheabkhasian-cy by cheabkhasian-cy.sc;\012sub Chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;\012sub Palochka-cy by palochka-cy.sc;\012sub Zhebreve-cy by zhebreve-cy.sc;\012sub Kahook-cy by kahook-cy.sc;\012sub Eltail-cy by eltail-cy.sc;\012sub Enhook-cy by enhook-cy.sc;\012sub Entail-cy by entail-cy.sc;\012sub Chekhakassian-cy by chekhakassian-cy.sc;\012sub Emtail-cy by emtail-cy.sc;\012sub Abreve-cy by abreve-cy.sc;\012sub Adieresis-cy by adieresis-cy.sc;\012sub Aie-cy by aie-cy.sc;\012sub Iebreve-cy by iebreve-cy.sc;\012sub Schwa-cy by schwa-cy.sc;\012sub Schwadieresis-cy by schwadieresis-cy.sc;\012sub Zhedieresis-cy by zhedieresis-cy.sc;\012sub Zedieresis-cy by zedieresis-cy.sc;\012sub Dzeabkhasian-cy by dzeabkhasian-cy.sc;\012sub Imacron-cy by imacron-cy.sc;\012sub Idieresis-cy by idieresis-cy.sc;\012sub Odieresis-cy by odieresis-cy.sc;\012sub Obarred-cy by obarred-cy.sc;\012sub Obarreddieresis-cy by obarreddieresis-cy.sc;\012sub Edieresis-cy by edieresis-cy.sc;\012sub Umacron-cy by umacron-cy.sc;\012sub Udieresis-cy by udieresis-cy.sc;\012sub Uhungarumlaut-cy by uhungarumlaut-cy.sc;\012sub Chedieresis-cy by chedieresis-cy.sc;\012sub Gedescender-cy by gedescender-cy.sc;\012sub Yerudieresis-cy by yerudieresis-cy.sc;\012sub Gestrokehook-cy by gestrokehook-cy.sc;\012sub Hahook-cy by hahook-cy.sc;\012sub Hastroke-cy by hastroke-cy.sc;\012sub Reversedze-cy by reversedze-cy.sc;\012sub Elhook-cy by elhook-cy.sc;\012sub Qa-cy by qa-cy.sc;\012sub We-cy by we-cy.sc;\012sub Semisoftsign-cy by semisoftsign-cy.sc;\012sub Ertick-cy by ertick-cy.sc;\012sub EnLeftHook-cy by enlefthook-cy.sc;\012sub Eldescender-cy by eldescender-cy.sc;\012sub De-cy.loclBGR by de-cy.loclBGR.sc;\012sub El-cy.loclBGR by el-cy.loclBGR.sc;\012sub Ef-cy.loclBGR by ef-cy.loclBGR.sc;\012sub Ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;\012sub Zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;\012sub Esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;\012sub Esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;\012sub Alpha by alpha.sc;\012sub Beta by beta.sc;\012sub Gamma by gamma.sc;\012sub Delta by delta.sc;\012sub Epsilon by epsilon.sc;\012sub Zeta by zeta.sc;\012sub Eta by eta.sc;\012sub Theta by theta.sc;\012sub Iota by iota.sc;\012sub Kappa by kappa.sc;\012sub Lambda by lambda.sc;\012sub Mu by mu.sc;\012sub Nu by nu.sc;\012sub Xi by xi.sc;\012sub Omicron by omicron.sc;\012sub Pi by pi.sc;\012sub Rho by rho.sc;\012sub Sigma by sigma.sc;\012sub Tau by tau.sc;\012sub Upsilon by upsilon.sc;\012sub Phi by phi.sc;\012sub Chi by chi.sc;\012sub Psi by psi.sc;\012sub Omega by omega.sc;\012sub Alphatonos by alphatonos.sc;\012sub Epsilontonos by epsilontonos.sc;\012sub Etatonos by etatonos.sc;\012sub Iotatonos by iotatonos.sc;\012sub Omicrontonos by omicrontonos.sc;\012sub Upsilontonos by upsilontonos.sc;\012sub Omegatonos by omegatonos.sc;\012sub Iotadieresis by iotadieresis.sc;\012sub Upsilondieresis by upsilondieresis.sc;\012sub KaiSymbol by kaiSymbol.sc;\012sub Alphapsili by alphapsili.sc;\012sub Alphadasia by alphadasia.sc;\012sub Alphapsilivaria by alphapsilivaria.sc;\012sub Alphadasiavaria by alphadasiavaria.sc;\012sub Alphapsilioxia by alphapsilioxia.sc;\012sub Alphadasiaoxia by alphadasiaoxia.sc;\012sub Alphapsiliperispomeni by alphapsiliperispomeni.sc;\012sub Alphadasiaperispomeni by alphadasiaperispomeni.sc;\012sub Alphavaria by alphavaria.sc;\012sub Alphaoxia by alphaoxia.sc;\012sub Alphavrachy by alphavrachy.sc;\012sub Alphamacron by alphamacron.sc;\012sub Alphaprosgegrammeni by alphaypogegrammeni.sc;\012sub Alphapsiliprosgegrammeni by alphapsiliypogegrammeni.sc;\012sub Alphadasiaprosgegrammeni by alphadasiaypogegrammeni.sc;\012sub Alphapsilivariaprosgegrammeni by alphapsilivariaypogegrammeni.sc;\012sub Alphadasiavariaprosgegrammeni by alphadasiavariaypogegrammeni.sc;\012sub Alphapsilioxiaprosgegrammeni by alphapsilioxiaypogegrammeni.sc;\012sub Alphadasiaoxiaprosgegrammeni by alphadasiaoxiaypogegrammeni.sc;\012sub Alphapsiliperispomeniprosgegrammeni by alphapsiliperispomeniypogegrammeni.sc;\012sub Alphadasiaperispomeniprosgegrammeni by alphadasiaperispomeniypogegrammeni.sc;\012sub Epsilonpsili by epsilonpsili.sc;\012sub Epsilondasia by epsilondasia.sc;\012sub Epsilonpsilivaria by epsilonpsilivaria.sc;\012sub Epsilondasiavaria by epsilondasiavaria.sc;\012sub Epsilonpsilioxia by epsilonpsilioxia.sc;\012sub Epsilondasiaoxia by epsilondasiaoxia.sc;\012sub Epsilonvaria by epsilonvaria.sc;\012sub Epsilonoxia by epsilonoxia.sc;\012sub Etapsili by etapsili.sc;\012sub Etadasia by etadasia.sc;\012sub Etapsilivaria by etapsilivaria.sc;\012sub Etadasiavaria by etadasiavaria.sc;\012sub Etapsilioxia by etapsilioxia.sc;\012sub Etadasiaoxia by etadasiaoxia.sc;\012sub Etapsiliperispomeni by etapsiliperispomeni.sc;\012sub Etadasiaperispomeni by etadasiaperispomeni.sc;\012sub Etavaria by etavaria.sc;\012sub Etaoxia by etaoxia.sc;\012sub Etaprosgegrammeni by etaypogegrammeni.sc;\012sub Etapsiliprosgegrammeni by etapsiliypogegrammeni.sc;\012sub Etadasiaprosgegrammeni by etadasiaypogegrammeni.sc;\012sub Etapsilivariaprosgegrammeni by etapsilivariaypogegrammeni.sc;\012sub Etadasiavariaprosgegrammeni by etadasiavariaypogegrammeni.sc;\012sub Etapsilioxiaprosgegrammeni by etapsilioxiaypogegrammeni.sc;\012sub Etadasiaoxiaprosgegrammeni by etadasiaoxiaypogegrammeni.sc;\012sub Etapsiliperispomeniprosgegrammeni by etapsiliperispomeniypogegrammeni.sc;\012sub Etadasiaperispomeniprosgegrammeni by etadasiaperispomeniypogegrammeni.sc;\012sub Iotapsili by iotapsili.sc;\012sub Iotadasia by iotadasia.sc;\012sub Iotapsilivaria by iotapsilivaria.sc;\012sub Iotadasiavaria by iotadasiavaria.sc;\012sub Iotapsilioxia by iotapsilioxia.sc;\012sub Iotadasiaoxia by iotadasiaoxia.sc;\012sub Iotapsiliperispomeni by iotapsiliperispomeni.sc;\012sub Iotadasiaperispomeni by iotadasiaperispomeni.sc;\012sub Iotavaria by iotavaria.sc;\012sub Iotaoxia by iotaoxia.sc;\012sub Iotavrachy by iotavrachy.sc;\012sub Iotamacron by iotamacron.sc;\012sub Omicronpsili by omicronpsili.sc;\012sub Omicrondasia by omicrondasia.sc;\012sub Omicronpsilivaria by omicronpsilivaria.sc;\012sub Omicrondasiavaria by omicrondasiavaria.sc;\012sub Omicronpsilioxia by omicronpsilioxia.sc;\012sub Omicrondasiaoxia by omicrondasiaoxia.sc;\012sub Omicronvaria by omicronvaria.sc;\012sub Omicronoxia by omicronoxia.sc;\012sub Rhodasia by rhodasia.sc;\012sub Upsilondasia by upsilondasia.sc;\012sub Upsilondasiavaria by upsilondasiavaria.sc;\012sub Upsilondasiaoxia by upsilondasiaoxia.sc;\012sub Upsilondasiaperispomeni by upsilondasiaperispomeni.sc;\012sub Upsilonvaria by upsilonvaria.sc;\012sub Upsilonoxia by upsilonoxia.sc;\012sub Upsilonvrachy by upsilonvrachy.sc;\012sub Upsilonmacron by upsilonmacron.sc;\012sub Omegapsili by omegapsili.sc;\012sub Omegadasia by omegadasia.sc;\012sub Omegapsilivaria by omegapsilivaria.sc;\012sub Omegadasiavaria by omegadasiavaria.sc;\012sub Omegapsilioxia by omegapsilioxia.sc;\012sub Omegadasiaoxia by omegadasiaoxia.sc;\012sub Omegapsiliperispomeni by omegapsiliperispomeni.sc;\012sub Omegadasiaperispomeni by omegadasiaperispomeni.sc;\012sub Omegavaria by omegavaria.sc;\012sub Omegaoxia by omegaoxia.sc;\012sub Omegaprosgegrammeni by omegaypogegrammeni.sc;\012sub Omegapsiliprosgegrammeni by omegapsiliypogegrammeni.sc;\012sub Omegadasiaprosgegrammeni by omegadasiaypogegrammeni.sc;\012sub Omegapsilivariaprosgegrammeni by omegapsilivariaypogegrammeni.sc;\012sub Omegadasiavariaprosgegrammeni by omegadasiavariaypogegrammeni.sc;\012sub Omegapsilioxiaprosgegrammeni by omegapsilioxiaypogegrammeni.sc;\012sub Omegadasiaoxiaprosgegrammeni by omegadasiaoxiaypogegrammeni.sc;\012sub Omegapsiliperispomeniprosgegrammeni by omegapsiliperispomeniypogegrammeni.sc;\012sub Omegadasiaperispomeniprosgegrammeni by omegadasiaperispomeniypogegrammeni.sc;\012sub zero by zero.sc;\012sub one by one.sc;\012sub two by two.sc;\012sub three by three.sc;\012sub four by four.sc;\012sub five by five.sc;\012sub six by six.sc;\012sub seven by seven.sc;\012sub eight by eight.sc;\012sub nine by nine.sc;\012sub anoteleia by anoteleia.sc;\012sub dieresiscomb by dieresiscomb.sc;\012sub dotaccentcomb by dotaccentcomb.sc;\012sub gravecomb by gravecomb.sc;\012sub acutecomb by acutecomb.sc;\012sub hungarumlautcomb by hungarumlautcomb.sc;\012sub circumflexcomb by circumflexcomb.sc;\012sub caroncomb by caroncomb.sc;\012sub brevecomb by brevecomb.sc;\012sub ringcomb by ringcomb.sc;\012sub tildecomb by tildecomb.sc;\012sub macroncomb by macroncomb.sc;\012sub hookabovecomb by hookabovecomb.sc;\012sub tonos by tonos.sc;\012sub dieresistonos by dieresistonos.sc;\012sub psili by psili.sc;\012sub koronis by koronis.sc;\012sub dasia by dasia.sc;\012sub psilivaria by psilivaria.sc;\012sub dasiavaria by dasiavaria.sc;\012sub psilioxia by psilioxia.sc;\012sub dasiaoxia by dasiaoxia.sc;\012sub psiliperispomeni by psiliperispomeni.sc;\012sub dasiaperispomeni by dasiaperispomeni.sc;\012sub dialytikavaria by dialytikavaria.sc;\012sub dialytikaoxia by dialytikaoxia.sc;\012sub dialytikaperispomeni by dialytikaperispomeni.sc;\012sub varia by varia.sc;\012sub oxia by oxia.sc;\012sub perispomeni by perispomeni.sc;\012sub brevecomb_acutecomb by brevecomb_acutecomb.sc;\012sub brevecomb_gravecomb by brevecomb_gravecomb.sc;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;\012sub brevecomb_tildecomb by brevecomb_tildecomb.sc;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;\012sub brevecombcy by brevecombcy.sc;\012";
 name = c2sc;
 },
 {
 automatic = 1;
-code = "sub a by a.sc;
-sub aacute by aacute.sc;
-sub abreve by abreve.sc;
-sub abreveacute by abreveacute.sc;
-sub abrevedotbelow by abrevedotbelow.sc;
-sub abrevegrave by abrevegrave.sc;
-sub abrevehookabove by abrevehookabove.sc;
-sub abrevetilde by abrevetilde.sc;
-sub acircumflex by acircumflex.sc;
-sub acircumflexacute by acircumflexacute.sc;
-sub acircumflexdotbelow by acircumflexdotbelow.sc;
-sub acircumflexgrave by acircumflexgrave.sc;
-sub acircumflexhookabove by acircumflexhookabove.sc;
-sub acircumflextilde by acircumflextilde.sc;
-sub adieresis by adieresis.sc;
-sub adotbelow by adotbelow.sc;
-sub agrave by agrave.sc;
-sub ahookabove by ahookabove.sc;
-sub amacron by amacron.sc;
-sub aogonek by aogonek.sc;
-sub aring by aring.sc;
-sub aringacute by aringacute.sc;
-sub atilde by atilde.sc;
-sub ae by ae.sc;
-sub aeacute by aeacute.sc;
-sub b by b.sc;
-sub c by c.sc;
-sub cacute by cacute.sc;
-sub ccaron by ccaron.sc;
-sub ccedilla by ccedilla.sc;
-sub ccircumflex by ccircumflex.sc;
-sub cdotaccent by cdotaccent.sc;
-sub d by d.sc;
-sub eth by eth.sc;
-sub dcaron by dcaron.sc;
-sub dcroat by dcroat.sc;
-sub e by e.sc;
-sub eacute by eacute.sc;
-sub ebreve by ebreve.sc;
-sub ecaron by ecaron.sc;
-sub ecircumflex by ecircumflex.sc;
-sub ecircumflexacute by ecircumflexacute.sc;
-sub ecircumflexdotbelow by ecircumflexdotbelow.sc;
-sub ecircumflexgrave by ecircumflexgrave.sc;
-sub ecircumflexhookabove by ecircumflexhookabove.sc;
-sub ecircumflextilde by ecircumflextilde.sc;
-sub edieresis by edieresis.sc;
-sub edotaccent by edotaccent.sc;
-sub edotbelow by edotbelow.sc;
-sub egrave by egrave.sc;
-sub ehookabove by ehookabove.sc;
-sub emacron by emacron.sc;
-sub eogonek by eogonek.sc;
-sub etilde by etilde.sc;
-sub f by f.sc;
-sub g by g.sc;
-sub gbreve by gbreve.sc;
-sub gcircumflex by gcircumflex.sc;
-sub gcommaaccent by gcommaaccent.sc;
-sub gdotaccent by gdotaccent.sc;
-sub h by h.sc;
-sub hbar by hbar.sc;
-sub hcircumflex by hcircumflex.sc;
-sub i by i.sc;
-sub iacute by iacute.sc;
-sub ibreve by ibreve.sc;
-sub icircumflex by icircumflex.sc;
-sub idieresis by idieresis.sc;
-sub idotbelow by idotbelow.sc;
-sub igrave by igrave.sc;
-sub ihookabove by ihookabove.sc;
-sub imacron by imacron.sc;
-sub iogonek by iogonek.sc;
-sub itilde by itilde.sc;
-sub j by j.sc;
-sub jcircumflex by jcircumflex.sc;
-sub k by k.sc;
-sub kcommaaccent by kcommaaccent.sc;
-sub l by l.sc;
-sub lacute by lacute.sc;
-sub lcaron by lcaron.sc;
-sub lcommaaccent by lcommaaccent.sc;
-sub lslash by lslash.sc;
-sub m by m.sc;
-sub n by n.sc;
-sub nacute by nacute.sc;
-sub ncaron by ncaron.sc;
-sub ncommaaccent by ncommaaccent.sc;
-sub eng by eng.sc;
-sub ntilde by ntilde.sc;
-sub o by o.sc;
-sub oacute by oacute.sc;
-sub obreve by obreve.sc;
-sub ocircumflex by ocircumflex.sc;
-sub ocircumflexacute by ocircumflexacute.sc;
-sub ocircumflexdotbelow by ocircumflexdotbelow.sc;
-sub ocircumflexgrave by ocircumflexgrave.sc;
-sub ocircumflexhookabove by ocircumflexhookabove.sc;
-sub ocircumflextilde by ocircumflextilde.sc;
-sub odieresis by odieresis.sc;
-sub odotbelow by odotbelow.sc;
-sub ograve by ograve.sc;
-sub ohookabove by ohookabove.sc;
-sub ohorn by ohorn.sc;
-sub ohornacute by ohornacute.sc;
-sub ohorndotbelow by ohorndotbelow.sc;
-sub ohorngrave by ohorngrave.sc;
-sub ohornhookabove by ohornhookabove.sc;
-sub ohorntilde by ohorntilde.sc;
-sub ohungarumlaut by ohungarumlaut.sc;
-sub omacron by omacron.sc;
-sub oslash by oslash.sc;
-sub oslashacute by oslashacute.sc;
-sub otilde by otilde.sc;
-sub oe by oe.sc;
-sub p by p.sc;
-sub thorn by thorn.sc;
-sub q by q.sc;
-sub r by r.sc;
-sub racute by racute.sc;
-sub rcaron by rcaron.sc;
-sub rcommaaccent by rcommaaccent.sc;
-sub s by s.sc;
-sub sacute by sacute.sc;
-sub scaron by scaron.sc;
-sub scedilla by scedilla.sc;
-sub scircumflex by scircumflex.sc;
-sub scommaaccent by scommaaccent.sc;
-sub t by t.sc;
-sub tbar by tbar.sc;
-sub tcaron by tcaron.sc;
-sub tcedilla by tcedilla.sc;
-sub tcommaaccent by tcommaaccent.sc;
-sub u by u.sc;
-sub uacute by uacute.sc;
-sub ubreve by ubreve.sc;
-sub ucircumflex by ucircumflex.sc;
-sub udieresis by udieresis.sc;
-sub udotbelow by udotbelow.sc;
-sub ugrave by ugrave.sc;
-sub uhookabove by uhookabove.sc;
-sub uhorn by uhorn.sc;
-sub uhornacute by uhornacute.sc;
-sub uhorndotbelow by uhorndotbelow.sc;
-sub uhorngrave by uhorngrave.sc;
-sub uhornhookabove by uhornhookabove.sc;
-sub uhorntilde by uhorntilde.sc;
-sub uhungarumlaut by uhungarumlaut.sc;
-sub umacron by umacron.sc;
-sub uogonek by uogonek.sc;
-sub uring by uring.sc;
-sub utilde by utilde.sc;
-sub v by v.sc;
-sub w by w.sc;
-sub wacute by wacute.sc;
-sub wcircumflex by wcircumflex.sc;
-sub wdieresis by wdieresis.sc;
-sub wgrave by wgrave.sc;
-sub x by x.sc;
-sub y by y.sc;
-sub yacute by yacute.sc;
-sub ycircumflex by ycircumflex.sc;
-sub ydieresis by ydieresis.sc;
-sub ydotbelow by ydotbelow.sc;
-sub ygrave by ygrave.sc;
-sub yhookabove by yhookabove.sc;
-sub ytilde by ytilde.sc;
-sub z by z.sc;
-sub zacute by zacute.sc;
-sub zcaron by zcaron.sc;
-sub zdotaccent by zdotaccent.sc;
-sub a-cy by a-cy.sc;
-sub be-cy by be-cy.sc;
-sub ve-cy by ve-cy.sc;
-sub ge-cy by ge-cy.sc;
-sub gje-cy by gje-cy.sc;
-sub gheupturn-cy by gheupturn-cy.sc;
-sub de-cy by de-cy.sc;
-sub ie-cy by ie-cy.sc;
-sub iegrave-cy by iegrave-cy.sc;
-sub io-cy by io-cy.sc;
-sub zhe-cy by zhe-cy.sc;
-sub ze-cy by ze-cy.sc;
-sub ii-cy by ii-cy.sc;
-sub iishort-cy by iishort-cy.sc;
-sub iigrave-cy by iigrave-cy.sc;
-sub iishorttail-cy by iishorttail-cy.sc;
-sub ka-cy by ka-cy.sc;
-sub kje-cy by kje-cy.sc;
-sub el-cy by el-cy.sc;
-sub em-cy by em-cy.sc;
-sub en-cy by en-cy.sc;
-sub o-cy by o-cy.sc;
-sub pe-cy by pe-cy.sc;
-sub er-cy by er-cy.sc;
-sub es-cy by es-cy.sc;
-sub te-cy by te-cy.sc;
-sub u-cy by u-cy.sc;
-sub ushort-cy by ushort-cy.sc;
-sub ef-cy by ef-cy.sc;
-sub ha-cy by ha-cy.sc;
-sub che-cy by che-cy.sc;
-sub tse-cy by tse-cy.sc;
-sub sha-cy by sha-cy.sc;
-sub shcha-cy by shcha-cy.sc;
-sub dzhe-cy by dzhe-cy.sc;
-sub softsign-cy by softsign-cy.sc;
-sub hardsign-cy by hardsign-cy.sc;
-sub yeru-cy by yeru-cy.sc;
-sub lje-cy by lje-cy.sc;
-sub nje-cy by nje-cy.sc;
-sub dze-cy by dze-cy.sc;
-sub e-cy by e-cy.sc;
-sub ereversed-cy by ereversed-cy.sc;
-sub i-cy by i-cy.sc;
-sub yi-cy by yi-cy.sc;
-sub je-cy by je-cy.sc;
-sub tshe-cy by tshe-cy.sc;
-sub iu-cy by iu-cy.sc;
-sub ia-cy by ia-cy.sc;
-sub dje-cy by dje-cy.sc;
-sub yat-cy by yat-cy.sc;
-sub yusbig-cy by yusbig-cy.sc;
-sub fita-cy by fita-cy.sc;
-sub izhitsa-cy by izhitsa-cy.sc;
-sub ghestroke-cy by ghestroke-cy.sc;
-sub ghemiddlehook-cy by ghemiddlehook-cy.sc;
-sub zhedescender-cy by zhedescender-cy.sc;
-sub zedescender-cy by zedescender-cy.sc;
-sub kadescender-cy by kadescender-cy.sc;
-sub kaverticalstroke-cy by kaverticalstroke-cy.sc;
-sub kastroke-cy by kastroke-cy.sc;
-sub kabashkir-cy by kabashkir-cy.sc;
-sub endescender-cy by endescender-cy.sc;
-sub enghe-cy by enghe-cy.sc;
-sub pedescender-cy by pedescender-cy.sc;
-sub haabkhasian-cy by haabkhasian-cy.sc;
-sub esdescender-cy by esdescender-cy.sc;
-sub tedescender-cy by tedescender-cy.sc;
-sub ustraight-cy by ustraight-cy.sc;
-sub ustraightstroke-cy by ustraightstroke-cy.sc;
-sub hadescender-cy by hadescender-cy.sc;
-sub tetse-cy by tetse-cy.sc;
-sub chedescender-cy by chedescender-cy.sc;
-sub cheverticalstroke-cy by cheverticalstroke-cy.sc;
-sub shha-cy by shha-cy.sc;
-sub shhadescender-cy by shhadescender-cy.sc;
-sub cheabkhasian-cy by cheabkhasian-cy.sc;
-sub chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;
-sub palochka-cy by palochka-cy.sc;
-sub zhebreve-cy by zhebreve-cy.sc;
-sub kahook-cy by kahook-cy.sc;
-sub eltail-cy by eltail-cy.sc;
-sub enhook-cy by enhook-cy.sc;
-sub entail-cy by entail-cy.sc;
-sub chekhakassian-cy by chekhakassian-cy.sc;
-sub emtail-cy by emtail-cy.sc;
-sub abreve-cy by abreve-cy.sc;
-sub adieresis-cy by adieresis-cy.sc;
-sub aie-cy by aie-cy.sc;
-sub iebreve-cy by iebreve-cy.sc;
-sub schwa-cy by schwa-cy.sc;
-sub schwadieresis-cy by schwadieresis-cy.sc;
-sub zhedieresis-cy by zhedieresis-cy.sc;
-sub zedieresis-cy by zedieresis-cy.sc;
-sub dzeabkhasian-cy by dzeabkhasian-cy.sc;
-sub imacron-cy by imacron-cy.sc;
-sub idieresis-cy by idieresis-cy.sc;
-sub odieresis-cy by odieresis-cy.sc;
-sub obarred-cy by obarred-cy.sc;
-sub obarreddieresis-cy by obarreddieresis-cy.sc;
-sub edieresis-cy by edieresis-cy.sc;
-sub umacron-cy by umacron-cy.sc;
-sub udieresis-cy by udieresis-cy.sc;
-sub uhungarumlaut-cy by uhungarumlaut-cy.sc;
-sub chedieresis-cy by chedieresis-cy.sc;
-sub gedescender-cy by gedescender-cy.sc;
-sub yerudieresis-cy by yerudieresis-cy.sc;
-sub gestrokehook-cy by gestrokehook-cy.sc;
-sub hahook-cy by hahook-cy.sc;
-sub hastroke-cy by hastroke-cy.sc;
-sub reversedze-cy by reversedze-cy.sc;
-sub elhook-cy by elhook-cy.sc;
-sub qa-cy by qa-cy.sc;
-sub we-cy by we-cy.sc;
-sub semisoftsign-cy by semisoftsign-cy.sc;
-sub ertick-cy by ertick-cy.sc;
-sub enlefthook-cy by enlefthook-cy.sc;
-sub eldescender-cy by eldescender-cy.sc;
-sub ve-cy.loclBGR by ve-cy.sc;
-sub ge-cy.loclBGR by ge-cy.sc;
-sub de-cy.loclBGR by de-cy.loclBGR.sc;
-sub zhe-cy.loclBGR by zhe-cy.sc;
-sub ze-cy.loclBGR by ze-cy.sc;
-sub ii-cy.loclBGR by ii-cy.sc;
-sub iishort-cy.loclBGR by iishort-cy.sc;
-sub iigrave-cy.loclBGR by iigrave-cy.sc;
-sub ka-cy.loclBGR by ka-cy.sc;
-sub el-cy.loclBGR by el-cy.loclBGR.sc;
-sub pe-cy.loclBGR by pe-cy.sc;
-sub te-cy.loclBGR by te-cy.sc;
-sub ef-cy.loclBGR by ef-cy.loclBGR.sc;
-sub tse-cy.loclBGR by tse-cy.sc;
-sub sha-cy.loclBGR by sha-cy.sc;
-sub shcha-cy.loclBGR by shcha-cy.sc;
-sub softsign-cy.loclBGR by softsign-cy.sc;
-sub hardsign-cy.loclBGR by hardsign-cy.sc;
-sub yeru-cy.loclBGR by yeru-cy.sc;
-sub iu-cy.loclBGR by iu-cy.sc;
-sub ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;
-sub zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;
-sub esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;
-sub esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;
-sub ge-cy.loclMKD by ge-cy.sc;
-sub gje-cy.loclMKD by gje-cy.sc;
-sub be-cy.loclSRB by be-cy.sc;
-sub ge-cy.loclSRB by ge-cy.sc;
-sub de-cy.loclSRB by de-cy.sc;
-sub pe-cy.loclSRB by pe-cy.sc;
-sub te-cy.loclSRB by te-cy.sc;
-sub sha-cy.loclSRB by sha-cy.sc;
-sub alpha by alpha.sc;
-sub beta by beta.sc;
-sub gamma by gamma.sc;
-sub delta by delta.sc;
-sub epsilon by epsilon.sc;
-sub zeta by zeta.sc;
-sub eta by eta.sc;
-sub theta by theta.sc;
-sub iota by iota.sc;
-sub kappa by kappa.sc;
-sub lambda by lambda.sc;
-sub mu by mu.sc;
-sub nu by nu.sc;
-sub xi by xi.sc;
-sub omicron by omicron.sc;
-sub pi by pi.sc;
-sub rho by rho.sc;
-sub sigmafinal by sigmafinal.sc;
-sub sigma by sigma.sc;
-sub tau by tau.sc;
-sub upsilon by upsilon.sc;
-sub phi by phi.sc;
-sub chi by chi.sc;
-sub psi by psi.sc;
-sub omega by omega.sc;
-sub iotatonos by iotatonos.sc;
-sub iotadieresis by iotadieresis.sc;
-sub iotadieresistonos by iotadieresistonos.sc;
-sub upsilontonos by upsilontonos.sc;
-sub upsilondieresis by upsilondieresis.sc;
-sub upsilondieresistonos by upsilondieresistonos.sc;
-sub omicrontonos by omicrontonos.sc;
-sub omegatonos by omegatonos.sc;
-sub alphatonos by alphatonos.sc;
-sub epsilontonos by epsilontonos.sc;
-sub etatonos by etatonos.sc;
-sub kaiSymbol by kaiSymbol.sc;
-sub alphapsili by alphapsili.sc;
-sub alphadasia by alphadasia.sc;
-sub alphapsilivaria by alphapsilivaria.sc;
-sub alphadasiavaria by alphadasiavaria.sc;
-sub alphapsilioxia by alphapsilioxia.sc;
-sub alphadasiaoxia by alphadasiaoxia.sc;
-sub alphapsiliperispomeni by alphapsiliperispomeni.sc;
-sub alphadasiaperispomeni by alphadasiaperispomeni.sc;
-sub alphavaria by alphavaria.sc;
-sub alphaoxia by alphaoxia.sc;
-sub alphaperispomeni by alphaperispomeni.sc;
-sub alphavrachy by alphavrachy.sc;
-sub alphamacron by alphamacron.sc;
-sub alphaypogegrammeni by alphaypogegrammeni.sc;
-sub alphavariaypogegrammeni by alphavariaypogegrammeni.sc;
-sub alphaoxiaypogegrammeni by alphaoxiaypogegrammeni.sc;
-sub alphapsiliypogegrammeni by alphapsiliypogegrammeni.sc;
-sub alphadasiaypogegrammeni by alphadasiaypogegrammeni.sc;
-sub alphapsilivariaypogegrammeni by alphapsilivariaypogegrammeni.sc;
-sub alphadasiavariaypogegrammeni by alphadasiavariaypogegrammeni.sc;
-sub alphapsilioxiaypogegrammeni by alphapsilioxiaypogegrammeni.sc;
-sub alphadasiaoxiaypogegrammeni by alphadasiaoxiaypogegrammeni.sc;
-sub alphapsiliperispomeniypogegrammeni by alphapsiliperispomeniypogegrammeni.sc;
-sub alphadasiaperispomeniypogegrammeni by alphadasiaperispomeniypogegrammeni.sc;
-sub alphaperispomeniypogegrammeni by alphaperispomeniypogegrammeni.sc;
-sub epsilonpsili by epsilonpsili.sc;
-sub epsilondasia by epsilondasia.sc;
-sub epsilonpsilivaria by epsilonpsilivaria.sc;
-sub epsilondasiavaria by epsilondasiavaria.sc;
-sub epsilonpsilioxia by epsilonpsilioxia.sc;
-sub epsilondasiaoxia by epsilondasiaoxia.sc;
-sub epsilonvaria by epsilonvaria.sc;
-sub epsilonoxia by epsilonoxia.sc;
-sub etapsili by etapsili.sc;
-sub etadasia by etadasia.sc;
-sub etapsilivaria by etapsilivaria.sc;
-sub etadasiavaria by etadasiavaria.sc;
-sub etapsilioxia by etapsilioxia.sc;
-sub etadasiaoxia by etadasiaoxia.sc;
-sub etapsiliperispomeni by etapsiliperispomeni.sc;
-sub etadasiaperispomeni by etadasiaperispomeni.sc;
-sub etavaria by etavaria.sc;
-sub etaoxia by etaoxia.sc;
-sub etaperispomeni by etaperispomeni.sc;
-sub etaypogegrammeni by etaypogegrammeni.sc;
-sub etavariaypogegrammeni by etavariaypogegrammeni.sc;
-sub etaoxiaypogegrammeni by etaoxiaypogegrammeni.sc;
-sub etapsiliypogegrammeni by etapsiliypogegrammeni.sc;
-sub etadasiaypogegrammeni by etadasiaypogegrammeni.sc;
-sub etapsilivariaypogegrammeni by etapsilivariaypogegrammeni.sc;
-sub etadasiavariaypogegrammeni by etadasiavariaypogegrammeni.sc;
-sub etapsilioxiaypogegrammeni by etapsilioxiaypogegrammeni.sc;
-sub etadasiaoxiaypogegrammeni by etadasiaoxiaypogegrammeni.sc;
-sub etapsiliperispomeniypogegrammeni by etapsiliperispomeniypogegrammeni.sc;
-sub etadasiaperispomeniypogegrammeni by etadasiaperispomeniypogegrammeni.sc;
-sub etaperispomeniypogegrammeni by etaperispomeniypogegrammeni.sc;
-sub iotapsili by iotapsili.sc;
-sub iotadasia by iotadasia.sc;
-sub iotapsilivaria by iotapsilivaria.sc;
-sub iotadasiavaria by iotadasiavaria.sc;
-sub iotapsilioxia by iotapsilioxia.sc;
-sub iotadasiaoxia by iotadasiaoxia.sc;
-sub iotapsiliperispomeni by iotapsiliperispomeni.sc;
-sub iotadasiaperispomeni by iotadasiaperispomeni.sc;
-sub iotavaria by iotavaria.sc;
-sub iotaoxia by iotaoxia.sc;
-sub iotaperispomeni by iotaperispomeni.sc;
-sub iotavrachy by iotavrachy.sc;
-sub iotamacron by iotamacron.sc;
-sub iotadialytikavaria by iotadialytikavaria.sc;
-sub iotadialytikaoxia by iotadialytikaoxia.sc;
-sub iotadialytikaperispomeni by iotadialytikaperispomeni.sc;
-sub omicronpsili by omicronpsili.sc;
-sub omicrondasia by omicrondasia.sc;
-sub omicronpsilivaria by omicronpsilivaria.sc;
-sub omicrondasiavaria by omicrondasiavaria.sc;
-sub omicronpsilioxia by omicronpsilioxia.sc;
-sub omicrondasiaoxia by omicrondasiaoxia.sc;
-sub omicronvaria by omicronvaria.sc;
-sub omicronoxia by omicronoxia.sc;
-sub rhopsili by rhopsili.sc;
-sub rhodasia by rhodasia.sc;
-sub upsilonpsili by upsilonpsili.sc;
-sub upsilondasia by upsilondasia.sc;
-sub upsilonpsilivaria by upsilonpsilivaria.sc;
-sub upsilondasiavaria by upsilondasiavaria.sc;
-sub upsilonpsilioxia by upsilonpsilioxia.sc;
-sub upsilondasiaoxia by upsilondasiaoxia.sc;
-sub upsilonpsiliperispomeni by upsilonpsiliperispomeni.sc;
-sub upsilondasiaperispomeni by upsilondasiaperispomeni.sc;
-sub upsilonvaria by upsilonvaria.sc;
-sub upsilonoxia by upsilonoxia.sc;
-sub upsilonperispomeni by upsilonperispomeni.sc;
-sub upsilonvrachy by upsilonvrachy.sc;
-sub upsilonmacron by upsilonmacron.sc;
-sub upsilondialytikavaria by upsilondialytikavaria.sc;
-sub upsilondialytikaoxia by upsilondialytikaoxia.sc;
-sub upsilondialytikaperispomeni by upsilondialytikaperispomeni.sc;
-sub omegapsili by omegapsili.sc;
-sub omegadasia by omegadasia.sc;
-sub omegapsilivaria by omegapsilivaria.sc;
-sub omegadasiavaria by omegadasiavaria.sc;
-sub omegapsilioxia by omegapsilioxia.sc;
-sub omegadasiaoxia by omegadasiaoxia.sc;
-sub omegapsiliperispomeni by omegapsiliperispomeni.sc;
-sub omegadasiaperispomeni by omegadasiaperispomeni.sc;
-sub omegavaria by omegavaria.sc;
-sub omegaoxia by omegaoxia.sc;
-sub omegaperispomeni by omegaperispomeni.sc;
-sub omegaypogegrammeni by omegaypogegrammeni.sc;
-sub omegavariaypogegrammeni by omegavariaypogegrammeni.sc;
-sub omegaoxiaypogegrammeni by omegaoxiaypogegrammeni.sc;
-sub omegapsiliypogegrammeni by omegapsiliypogegrammeni.sc;
-sub omegadasiaypogegrammeni by omegadasiaypogegrammeni.sc;
-sub omegapsilivariaypogegrammeni by omegapsilivariaypogegrammeni.sc;
-sub omegadasiavariaypogegrammeni by omegadasiavariaypogegrammeni.sc;
-sub omegapsilioxiaypogegrammeni by omegapsilioxiaypogegrammeni.sc;
-sub omegadasiaoxiaypogegrammeni by omegadasiaoxiaypogegrammeni.sc;
-sub omegapsiliperispomeniypogegrammeni by omegapsiliperispomeniypogegrammeni.sc;
-sub omegadasiaperispomeniypogegrammeni by omegadasiaperispomeniypogegrammeni.sc;
-sub omegaperispomeniypogegrammeni by omegaperispomeniypogegrammeni.sc;
-sub zero by zero.sc;
-sub one by one.sc;
-sub two by two.sc;
-sub three by three.sc;
-sub four by four.sc;
-sub five by five.sc;
-sub six by six.sc;
-sub seven by seven.sc;
-sub eight by eight.sc;
-sub nine by nine.sc;
-sub anoteleia by anoteleia.sc;
-sub dieresiscomb by dieresiscomb.sc;
-sub dotaccentcomb by dotaccentcomb.sc;
-sub gravecomb by gravecomb.sc;
-sub acutecomb by acutecomb.sc;
-sub hungarumlautcomb by hungarumlautcomb.sc;
-sub circumflexcomb by circumflexcomb.sc;
-sub caroncomb by caroncomb.sc;
-sub brevecomb by brevecomb.sc;
-sub ringcomb by ringcomb.sc;
-sub tildecomb by tildecomb.sc;
-sub macroncomb by macroncomb.sc;
-sub hookabovecomb by hookabovecomb.sc;
-sub tonos by tonos.sc;
-sub dieresistonos by dieresistonos.sc;
-sub psili by psili.sc;
-sub koronis by koronis.sc;
-sub dasia by dasia.sc;
-sub psilivaria by psilivaria.sc;
-sub dasiavaria by dasiavaria.sc;
-sub psilioxia by psilioxia.sc;
-sub dasiaoxia by dasiaoxia.sc;
-sub psiliperispomeni by psiliperispomeni.sc;
-sub dasiaperispomeni by dasiaperispomeni.sc;
-sub dialytikavaria by dialytikavaria.sc;
-sub dialytikaoxia by dialytikaoxia.sc;
-sub dialytikaperispomeni by dialytikaperispomeni.sc;
-sub varia by varia.sc;
-sub oxia by oxia.sc;
-sub perispomeni by perispomeni.sc;
-sub brevecomb_acutecomb by brevecomb_acutecomb.sc;
-sub brevecomb_gravecomb by brevecomb_gravecomb.sc;
-sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;
-sub brevecomb_tildecomb by brevecomb_tildecomb.sc;
-sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;
-sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;
-sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;
-sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;
-sub brevecombcy by brevecombcy.sc;
-";
+code = "sub a by a.sc;\012sub aacute by aacute.sc;\012sub abreve by abreve.sc;\012sub abreveacute by abreveacute.sc;\012sub abrevedotbelow by abrevedotbelow.sc;\012sub abrevegrave by abrevegrave.sc;\012sub abrevehookabove by abrevehookabove.sc;\012sub abrevetilde by abrevetilde.sc;\012sub acircumflex by acircumflex.sc;\012sub acircumflexacute by acircumflexacute.sc;\012sub acircumflexdotbelow by acircumflexdotbelow.sc;\012sub acircumflexgrave by acircumflexgrave.sc;\012sub acircumflexhookabove by acircumflexhookabove.sc;\012sub acircumflextilde by acircumflextilde.sc;\012sub adieresis by adieresis.sc;\012sub adotbelow by adotbelow.sc;\012sub agrave by agrave.sc;\012sub ahookabove by ahookabove.sc;\012sub amacron by amacron.sc;\012sub aogonek by aogonek.sc;\012sub aring by aring.sc;\012sub aringacute by aringacute.sc;\012sub atilde by atilde.sc;\012sub ae by ae.sc;\012sub aeacute by aeacute.sc;\012sub b by b.sc;\012sub c by c.sc;\012sub cacute by cacute.sc;\012sub ccaron by ccaron.sc;\012sub ccedilla by ccedilla.sc;\012sub ccircumflex by ccircumflex.sc;\012sub cdotaccent by cdotaccent.sc;\012sub d by d.sc;\012sub eth by eth.sc;\012sub dcaron by dcaron.sc;\012sub dcroat by dcroat.sc;\012sub e by e.sc;\012sub eacute by eacute.sc;\012sub ebreve by ebreve.sc;\012sub ecaron by ecaron.sc;\012sub ecircumflex by ecircumflex.sc;\012sub ecircumflexacute by ecircumflexacute.sc;\012sub ecircumflexdotbelow by ecircumflexdotbelow.sc;\012sub ecircumflexgrave by ecircumflexgrave.sc;\012sub ecircumflexhookabove by ecircumflexhookabove.sc;\012sub ecircumflextilde by ecircumflextilde.sc;\012sub edieresis by edieresis.sc;\012sub edotaccent by edotaccent.sc;\012sub edotbelow by edotbelow.sc;\012sub egrave by egrave.sc;\012sub ehookabove by ehookabove.sc;\012sub emacron by emacron.sc;\012sub eogonek by eogonek.sc;\012sub etilde by etilde.sc;\012sub f by f.sc;\012sub g by g.sc;\012sub gbreve by gbreve.sc;\012sub gcircumflex by gcircumflex.sc;\012sub gcommaaccent by gcommaaccent.sc;\012sub gdotaccent by gdotaccent.sc;\012sub h by h.sc;\012sub hbar by hbar.sc;\012sub hcircumflex by hcircumflex.sc;\012sub i by i.sc;\012sub iacute by iacute.sc;\012sub ibreve by ibreve.sc;\012sub icircumflex by icircumflex.sc;\012sub idieresis by idieresis.sc;\012sub idotbelow by idotbelow.sc;\012sub igrave by igrave.sc;\012sub ihookabove by ihookabove.sc;\012sub imacron by imacron.sc;\012sub iogonek by iogonek.sc;\012sub itilde by itilde.sc;\012sub j by j.sc;\012sub jcircumflex by jcircumflex.sc;\012sub k by k.sc;\012sub kcommaaccent by kcommaaccent.sc;\012sub l by l.sc;\012sub lacute by lacute.sc;\012sub lcaron by lcaron.sc;\012sub lcommaaccent by lcommaaccent.sc;\012sub lslash by lslash.sc;\012sub m by m.sc;\012sub n by n.sc;\012sub nacute by nacute.sc;\012sub ncaron by ncaron.sc;\012sub ncommaaccent by ncommaaccent.sc;\012sub eng by eng.sc;\012sub ntilde by ntilde.sc;\012sub o by o.sc;\012sub oacute by oacute.sc;\012sub obreve by obreve.sc;\012sub ocircumflex by ocircumflex.sc;\012sub ocircumflexacute by ocircumflexacute.sc;\012sub ocircumflexdotbelow by ocircumflexdotbelow.sc;\012sub ocircumflexgrave by ocircumflexgrave.sc;\012sub ocircumflexhookabove by ocircumflexhookabove.sc;\012sub ocircumflextilde by ocircumflextilde.sc;\012sub odieresis by odieresis.sc;\012sub odotbelow by odotbelow.sc;\012sub ograve by ograve.sc;\012sub ohookabove by ohookabove.sc;\012sub ohorn by ohorn.sc;\012sub ohornacute by ohornacute.sc;\012sub ohorndotbelow by ohorndotbelow.sc;\012sub ohorngrave by ohorngrave.sc;\012sub ohornhookabove by ohornhookabove.sc;\012sub ohorntilde by ohorntilde.sc;\012sub ohungarumlaut by ohungarumlaut.sc;\012sub omacron by omacron.sc;\012sub oslash by oslash.sc;\012sub oslashacute by oslashacute.sc;\012sub otilde by otilde.sc;\012sub oe by oe.sc;\012sub p by p.sc;\012sub thorn by thorn.sc;\012sub q by q.sc;\012sub r by r.sc;\012sub racute by racute.sc;\012sub rcaron by rcaron.sc;\012sub rcommaaccent by rcommaaccent.sc;\012sub s by s.sc;\012sub sacute by sacute.sc;\012sub scaron by scaron.sc;\012sub scedilla by scedilla.sc;\012sub scircumflex by scircumflex.sc;\012sub scommaaccent by scommaaccent.sc;\012sub t by t.sc;\012sub tbar by tbar.sc;\012sub tcaron by tcaron.sc;\012sub tcedilla by tcedilla.sc;\012sub tcommaaccent by tcommaaccent.sc;\012sub u by u.sc;\012sub uacute by uacute.sc;\012sub ubreve by ubreve.sc;\012sub ucircumflex by ucircumflex.sc;\012sub udieresis by udieresis.sc;\012sub udotbelow by udotbelow.sc;\012sub ugrave by ugrave.sc;\012sub uhookabove by uhookabove.sc;\012sub uhorn by uhorn.sc;\012sub uhornacute by uhornacute.sc;\012sub uhorndotbelow by uhorndotbelow.sc;\012sub uhorngrave by uhorngrave.sc;\012sub uhornhookabove by uhornhookabove.sc;\012sub uhorntilde by uhorntilde.sc;\012sub uhungarumlaut by uhungarumlaut.sc;\012sub umacron by umacron.sc;\012sub uogonek by uogonek.sc;\012sub uring by uring.sc;\012sub utilde by utilde.sc;\012sub v by v.sc;\012sub w by w.sc;\012sub wacute by wacute.sc;\012sub wcircumflex by wcircumflex.sc;\012sub wdieresis by wdieresis.sc;\012sub wgrave by wgrave.sc;\012sub x by x.sc;\012sub y by y.sc;\012sub yacute by yacute.sc;\012sub ycircumflex by ycircumflex.sc;\012sub ydieresis by ydieresis.sc;\012sub ydotbelow by ydotbelow.sc;\012sub ygrave by ygrave.sc;\012sub yhookabove by yhookabove.sc;\012sub ytilde by ytilde.sc;\012sub z by z.sc;\012sub zacute by zacute.sc;\012sub zcaron by zcaron.sc;\012sub zdotaccent by zdotaccent.sc;\012sub a-cy by a-cy.sc;\012sub be-cy by be-cy.sc;\012sub ve-cy by ve-cy.sc;\012sub ge-cy by ge-cy.sc;\012sub gje-cy by gje-cy.sc;\012sub gheupturn-cy by gheupturn-cy.sc;\012sub de-cy by de-cy.sc;\012sub ie-cy by ie-cy.sc;\012sub iegrave-cy by iegrave-cy.sc;\012sub io-cy by io-cy.sc;\012sub zhe-cy by zhe-cy.sc;\012sub ze-cy by ze-cy.sc;\012sub ii-cy by ii-cy.sc;\012sub iishort-cy by iishort-cy.sc;\012sub iigrave-cy by iigrave-cy.sc;\012sub iishorttail-cy by iishorttail-cy.sc;\012sub ka-cy by ka-cy.sc;\012sub kje-cy by kje-cy.sc;\012sub el-cy by el-cy.sc;\012sub em-cy by em-cy.sc;\012sub en-cy by en-cy.sc;\012sub o-cy by o-cy.sc;\012sub pe-cy by pe-cy.sc;\012sub er-cy by er-cy.sc;\012sub es-cy by es-cy.sc;\012sub te-cy by te-cy.sc;\012sub u-cy by u-cy.sc;\012sub ushort-cy by ushort-cy.sc;\012sub ef-cy by ef-cy.sc;\012sub ha-cy by ha-cy.sc;\012sub che-cy by che-cy.sc;\012sub tse-cy by tse-cy.sc;\012sub sha-cy by sha-cy.sc;\012sub shcha-cy by shcha-cy.sc;\012sub dzhe-cy by dzhe-cy.sc;\012sub softsign-cy by softsign-cy.sc;\012sub hardsign-cy by hardsign-cy.sc;\012sub yeru-cy by yeru-cy.sc;\012sub lje-cy by lje-cy.sc;\012sub nje-cy by nje-cy.sc;\012sub dze-cy by dze-cy.sc;\012sub e-cy by e-cy.sc;\012sub ereversed-cy by ereversed-cy.sc;\012sub i-cy by i-cy.sc;\012sub yi-cy by yi-cy.sc;\012sub je-cy by je-cy.sc;\012sub tshe-cy by tshe-cy.sc;\012sub iu-cy by iu-cy.sc;\012sub ia-cy by ia-cy.sc;\012sub dje-cy by dje-cy.sc;\012sub yat-cy by yat-cy.sc;\012sub yusbig-cy by yusbig-cy.sc;\012sub fita-cy by fita-cy.sc;\012sub izhitsa-cy by izhitsa-cy.sc;\012sub ghestroke-cy by ghestroke-cy.sc;\012sub ghemiddlehook-cy by ghemiddlehook-cy.sc;\012sub zhedescender-cy by zhedescender-cy.sc;\012sub zedescender-cy by zedescender-cy.sc;\012sub kadescender-cy by kadescender-cy.sc;\012sub kaverticalstroke-cy by kaverticalstroke-cy.sc;\012sub kastroke-cy by kastroke-cy.sc;\012sub kabashkir-cy by kabashkir-cy.sc;\012sub endescender-cy by endescender-cy.sc;\012sub enghe-cy by enghe-cy.sc;\012sub pedescender-cy by pedescender-cy.sc;\012sub haabkhasian-cy by haabkhasian-cy.sc;\012sub esdescender-cy by esdescender-cy.sc;\012sub tedescender-cy by tedescender-cy.sc;\012sub ustraight-cy by ustraight-cy.sc;\012sub ustraightstroke-cy by ustraightstroke-cy.sc;\012sub hadescender-cy by hadescender-cy.sc;\012sub tetse-cy by tetse-cy.sc;\012sub chedescender-cy by chedescender-cy.sc;\012sub cheverticalstroke-cy by cheverticalstroke-cy.sc;\012sub shha-cy by shha-cy.sc;\012sub shhadescender-cy by shhadescender-cy.sc;\012sub cheabkhasian-cy by cheabkhasian-cy.sc;\012sub chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;\012sub palochka-cy by palochka-cy.sc;\012sub zhebreve-cy by zhebreve-cy.sc;\012sub kahook-cy by kahook-cy.sc;\012sub eltail-cy by eltail-cy.sc;\012sub enhook-cy by enhook-cy.sc;\012sub entail-cy by entail-cy.sc;\012sub chekhakassian-cy by chekhakassian-cy.sc;\012sub emtail-cy by emtail-cy.sc;\012sub abreve-cy by abreve-cy.sc;\012sub adieresis-cy by adieresis-cy.sc;\012sub aie-cy by aie-cy.sc;\012sub iebreve-cy by iebreve-cy.sc;\012sub schwa-cy by schwa-cy.sc;\012sub schwadieresis-cy by schwadieresis-cy.sc;\012sub zhedieresis-cy by zhedieresis-cy.sc;\012sub zedieresis-cy by zedieresis-cy.sc;\012sub dzeabkhasian-cy by dzeabkhasian-cy.sc;\012sub imacron-cy by imacron-cy.sc;\012sub idieresis-cy by idieresis-cy.sc;\012sub odieresis-cy by odieresis-cy.sc;\012sub obarred-cy by obarred-cy.sc;\012sub obarreddieresis-cy by obarreddieresis-cy.sc;\012sub edieresis-cy by edieresis-cy.sc;\012sub umacron-cy by umacron-cy.sc;\012sub udieresis-cy by udieresis-cy.sc;\012sub uhungarumlaut-cy by uhungarumlaut-cy.sc;\012sub chedieresis-cy by chedieresis-cy.sc;\012sub gedescender-cy by gedescender-cy.sc;\012sub yerudieresis-cy by yerudieresis-cy.sc;\012sub gestrokehook-cy by gestrokehook-cy.sc;\012sub hahook-cy by hahook-cy.sc;\012sub hastroke-cy by hastroke-cy.sc;\012sub reversedze-cy by reversedze-cy.sc;\012sub elhook-cy by elhook-cy.sc;\012sub qa-cy by qa-cy.sc;\012sub we-cy by we-cy.sc;\012sub semisoftsign-cy by semisoftsign-cy.sc;\012sub ertick-cy by ertick-cy.sc;\012sub enlefthook-cy by enlefthook-cy.sc;\012sub eldescender-cy by eldescender-cy.sc;\012sub ve-cy.loclBGR by ve-cy.sc;\012sub ge-cy.loclBGR by ge-cy.sc;\012sub de-cy.loclBGR by de-cy.loclBGR.sc;\012sub zhe-cy.loclBGR by zhe-cy.sc;\012sub ze-cy.loclBGR by ze-cy.sc;\012sub ii-cy.loclBGR by ii-cy.sc;\012sub iishort-cy.loclBGR by iishort-cy.sc;\012sub iigrave-cy.loclBGR by iigrave-cy.sc;\012sub ka-cy.loclBGR by ka-cy.sc;\012sub el-cy.loclBGR by el-cy.loclBGR.sc;\012sub pe-cy.loclBGR by pe-cy.sc;\012sub te-cy.loclBGR by te-cy.sc;\012sub ef-cy.loclBGR by ef-cy.loclBGR.sc;\012sub tse-cy.loclBGR by tse-cy.sc;\012sub sha-cy.loclBGR by sha-cy.sc;\012sub shcha-cy.loclBGR by shcha-cy.sc;\012sub softsign-cy.loclBGR by softsign-cy.sc;\012sub hardsign-cy.loclBGR by hardsign-cy.sc;\012sub yeru-cy.loclBGR by yeru-cy.sc;\012sub iu-cy.loclBGR by iu-cy.sc;\012sub ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;\012sub zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;\012sub esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;\012sub esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;\012sub ge-cy.loclMKD by ge-cy.sc;\012sub gje-cy.loclMKD by gje-cy.sc;\012sub be-cy.loclSRB by be-cy.sc;\012sub ge-cy.loclSRB by ge-cy.sc;\012sub de-cy.loclSRB by de-cy.sc;\012sub pe-cy.loclSRB by pe-cy.sc;\012sub te-cy.loclSRB by te-cy.sc;\012sub sha-cy.loclSRB by sha-cy.sc;\012sub alpha by alpha.sc;\012sub beta by beta.sc;\012sub gamma by gamma.sc;\012sub delta by delta.sc;\012sub epsilon by epsilon.sc;\012sub zeta by zeta.sc;\012sub eta by eta.sc;\012sub theta by theta.sc;\012sub iota by iota.sc;\012sub kappa by kappa.sc;\012sub lambda by lambda.sc;\012sub mu by mu.sc;\012sub nu by nu.sc;\012sub xi by xi.sc;\012sub omicron by omicron.sc;\012sub pi by pi.sc;\012sub rho by rho.sc;\012sub sigmafinal by sigmafinal.sc;\012sub sigma by sigma.sc;\012sub tau by tau.sc;\012sub upsilon by upsilon.sc;\012sub phi by phi.sc;\012sub chi by chi.sc;\012sub psi by psi.sc;\012sub omega by omega.sc;\012sub iotatonos by iotatonos.sc;\012sub iotadieresis by iotadieresis.sc;\012sub iotadieresistonos by iotadieresistonos.sc;\012sub upsilontonos by upsilontonos.sc;\012sub upsilondieresis by upsilondieresis.sc;\012sub upsilondieresistonos by upsilondieresistonos.sc;\012sub omicrontonos by omicrontonos.sc;\012sub omegatonos by omegatonos.sc;\012sub alphatonos by alphatonos.sc;\012sub epsilontonos by epsilontonos.sc;\012sub etatonos by etatonos.sc;\012sub kaiSymbol by kaiSymbol.sc;\012sub alphapsili by alphapsili.sc;\012sub alphadasia by alphadasia.sc;\012sub alphapsilivaria by alphapsilivaria.sc;\012sub alphadasiavaria by alphadasiavaria.sc;\012sub alphapsilioxia by alphapsilioxia.sc;\012sub alphadasiaoxia by alphadasiaoxia.sc;\012sub alphapsiliperispomeni by alphapsiliperispomeni.sc;\012sub alphadasiaperispomeni by alphadasiaperispomeni.sc;\012sub alphavaria by alphavaria.sc;\012sub alphaoxia by alphaoxia.sc;\012sub alphaperispomeni by alphaperispomeni.sc;\012sub alphavrachy by alphavrachy.sc;\012sub alphamacron by alphamacron.sc;\012sub alphaypogegrammeni by alphaypogegrammeni.sc;\012sub alphavariaypogegrammeni by alphavariaypogegrammeni.sc;\012sub alphaoxiaypogegrammeni by alphaoxiaypogegrammeni.sc;\012sub alphapsiliypogegrammeni by alphapsiliypogegrammeni.sc;\012sub alphadasiaypogegrammeni by alphadasiaypogegrammeni.sc;\012sub alphapsilivariaypogegrammeni by alphapsilivariaypogegrammeni.sc;\012sub alphadasiavariaypogegrammeni by alphadasiavariaypogegrammeni.sc;\012sub alphapsilioxiaypogegrammeni by alphapsilioxiaypogegrammeni.sc;\012sub alphadasiaoxiaypogegrammeni by alphadasiaoxiaypogegrammeni.sc;\012sub alphapsiliperispomeniypogegrammeni by alphapsiliperispomeniypogegrammeni.sc;\012sub alphadasiaperispomeniypogegrammeni by alphadasiaperispomeniypogegrammeni.sc;\012sub alphaperispomeniypogegrammeni by alphaperispomeniypogegrammeni.sc;\012sub epsilonpsili by epsilonpsili.sc;\012sub epsilondasia by epsilondasia.sc;\012sub epsilonpsilivaria by epsilonpsilivaria.sc;\012sub epsilondasiavaria by epsilondasiavaria.sc;\012sub epsilonpsilioxia by epsilonpsilioxia.sc;\012sub epsilondasiaoxia by epsilondasiaoxia.sc;\012sub epsilonvaria by epsilonvaria.sc;\012sub epsilonoxia by epsilonoxia.sc;\012sub etapsili by etapsili.sc;\012sub etadasia by etadasia.sc;\012sub etapsilivaria by etapsilivaria.sc;\012sub etadasiavaria by etadasiavaria.sc;\012sub etapsilioxia by etapsilioxia.sc;\012sub etadasiaoxia by etadasiaoxia.sc;\012sub etapsiliperispomeni by etapsiliperispomeni.sc;\012sub etadasiaperispomeni by etadasiaperispomeni.sc;\012sub etavaria by etavaria.sc;\012sub etaoxia by etaoxia.sc;\012sub etaperispomeni by etaperispomeni.sc;\012sub etaypogegrammeni by etaypogegrammeni.sc;\012sub etavariaypogegrammeni by etavariaypogegrammeni.sc;\012sub etaoxiaypogegrammeni by etaoxiaypogegrammeni.sc;\012sub etapsiliypogegrammeni by etapsiliypogegrammeni.sc;\012sub etadasiaypogegrammeni by etadasiaypogegrammeni.sc;\012sub etapsilivariaypogegrammeni by etapsilivariaypogegrammeni.sc;\012sub etadasiavariaypogegrammeni by etadasiavariaypogegrammeni.sc;\012sub etapsilioxiaypogegrammeni by etapsilioxiaypogegrammeni.sc;\012sub etadasiaoxiaypogegrammeni by etadasiaoxiaypogegrammeni.sc;\012sub etapsiliperispomeniypogegrammeni by etapsiliperispomeniypogegrammeni.sc;\012sub etadasiaperispomeniypogegrammeni by etadasiaperispomeniypogegrammeni.sc;\012sub etaperispomeniypogegrammeni by etaperispomeniypogegrammeni.sc;\012sub iotapsili by iotapsili.sc;\012sub iotadasia by iotadasia.sc;\012sub iotapsilivaria by iotapsilivaria.sc;\012sub iotadasiavaria by iotadasiavaria.sc;\012sub iotapsilioxia by iotapsilioxia.sc;\012sub iotadasiaoxia by iotadasiaoxia.sc;\012sub iotapsiliperispomeni by iotapsiliperispomeni.sc;\012sub iotadasiaperispomeni by iotadasiaperispomeni.sc;\012sub iotavaria by iotavaria.sc;\012sub iotaoxia by iotaoxia.sc;\012sub iotaperispomeni by iotaperispomeni.sc;\012sub iotavrachy by iotavrachy.sc;\012sub iotamacron by iotamacron.sc;\012sub iotadialytikavaria by iotadialytikavaria.sc;\012sub iotadialytikaoxia by iotadialytikaoxia.sc;\012sub iotadialytikaperispomeni by iotadialytikaperispomeni.sc;\012sub omicronpsili by omicronpsili.sc;\012sub omicrondasia by omicrondasia.sc;\012sub omicronpsilivaria by omicronpsilivaria.sc;\012sub omicrondasiavaria by omicrondasiavaria.sc;\012sub omicronpsilioxia by omicronpsilioxia.sc;\012sub omicrondasiaoxia by omicrondasiaoxia.sc;\012sub omicronvaria by omicronvaria.sc;\012sub omicronoxia by omicronoxia.sc;\012sub rhopsili by rhopsili.sc;\012sub rhodasia by rhodasia.sc;\012sub upsilonpsili by upsilonpsili.sc;\012sub upsilondasia by upsilondasia.sc;\012sub upsilonpsilivaria by upsilonpsilivaria.sc;\012sub upsilondasiavaria by upsilondasiavaria.sc;\012sub upsilonpsilioxia by upsilonpsilioxia.sc;\012sub upsilondasiaoxia by upsilondasiaoxia.sc;\012sub upsilonpsiliperispomeni by upsilonpsiliperispomeni.sc;\012sub upsilondasiaperispomeni by upsilondasiaperispomeni.sc;\012sub upsilonvaria by upsilonvaria.sc;\012sub upsilonoxia by upsilonoxia.sc;\012sub upsilonperispomeni by upsilonperispomeni.sc;\012sub upsilonvrachy by upsilonvrachy.sc;\012sub upsilonmacron by upsilonmacron.sc;\012sub upsilondialytikavaria by upsilondialytikavaria.sc;\012sub upsilondialytikaoxia by upsilondialytikaoxia.sc;\012sub upsilondialytikaperispomeni by upsilondialytikaperispomeni.sc;\012sub omegapsili by omegapsili.sc;\012sub omegadasia by omegadasia.sc;\012sub omegapsilivaria by omegapsilivaria.sc;\012sub omegadasiavaria by omegadasiavaria.sc;\012sub omegapsilioxia by omegapsilioxia.sc;\012sub omegadasiaoxia by omegadasiaoxia.sc;\012sub omegapsiliperispomeni by omegapsiliperispomeni.sc;\012sub omegadasiaperispomeni by omegadasiaperispomeni.sc;\012sub omegavaria by omegavaria.sc;\012sub omegaoxia by omegaoxia.sc;\012sub omegaperispomeni by omegaperispomeni.sc;\012sub omegaypogegrammeni by omegaypogegrammeni.sc;\012sub omegavariaypogegrammeni by omegavariaypogegrammeni.sc;\012sub omegaoxiaypogegrammeni by omegaoxiaypogegrammeni.sc;\012sub omegapsiliypogegrammeni by omegapsiliypogegrammeni.sc;\012sub omegadasiaypogegrammeni by omegadasiaypogegrammeni.sc;\012sub omegapsilivariaypogegrammeni by omegapsilivariaypogegrammeni.sc;\012sub omegadasiavariaypogegrammeni by omegadasiavariaypogegrammeni.sc;\012sub omegapsilioxiaypogegrammeni by omegapsilioxiaypogegrammeni.sc;\012sub omegadasiaoxiaypogegrammeni by omegadasiaoxiaypogegrammeni.sc;\012sub omegapsiliperispomeniypogegrammeni by omegapsiliperispomeniypogegrammeni.sc;\012sub omegadasiaperispomeniypogegrammeni by omegadasiaperispomeniypogegrammeni.sc;\012sub omegaperispomeniypogegrammeni by omegaperispomeniypogegrammeni.sc;\012sub zero by zero.sc;\012sub one by one.sc;\012sub two by two.sc;\012sub three by three.sc;\012sub four by four.sc;\012sub five by five.sc;\012sub six by six.sc;\012sub seven by seven.sc;\012sub eight by eight.sc;\012sub nine by nine.sc;\012sub anoteleia by anoteleia.sc;\012sub dieresiscomb by dieresiscomb.sc;\012sub dotaccentcomb by dotaccentcomb.sc;\012sub gravecomb by gravecomb.sc;\012sub acutecomb by acutecomb.sc;\012sub hungarumlautcomb by hungarumlautcomb.sc;\012sub circumflexcomb by circumflexcomb.sc;\012sub caroncomb by caroncomb.sc;\012sub brevecomb by brevecomb.sc;\012sub ringcomb by ringcomb.sc;\012sub tildecomb by tildecomb.sc;\012sub macroncomb by macroncomb.sc;\012sub hookabovecomb by hookabovecomb.sc;\012sub tonos by tonos.sc;\012sub dieresistonos by dieresistonos.sc;\012sub psili by psili.sc;\012sub koronis by koronis.sc;\012sub dasia by dasia.sc;\012sub psilivaria by psilivaria.sc;\012sub dasiavaria by dasiavaria.sc;\012sub psilioxia by psilioxia.sc;\012sub dasiaoxia by dasiaoxia.sc;\012sub psiliperispomeni by psiliperispomeni.sc;\012sub dasiaperispomeni by dasiaperispomeni.sc;\012sub dialytikavaria by dialytikavaria.sc;\012sub dialytikaoxia by dialytikaoxia.sc;\012sub dialytikaperispomeni by dialytikaperispomeni.sc;\012sub varia by varia.sc;\012sub oxia by oxia.sc;\012sub perispomeni by perispomeni.sc;\012sub brevecomb_acutecomb by brevecomb_acutecomb.sc;\012sub brevecomb_gravecomb by brevecomb_gravecomb.sc;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;\012sub brevecomb_tildecomb by brevecomb_tildecomb.sc;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;\012sub brevecombcy by brevecombcy.sc;\012";
 name = smcp;
 },
 {
-code = "# =============
-# BEGIN LATIN
-# =============
-
-sub f f b by f_f_b;
-sub f f h by f_f_h;
-sub f f j by f_f_j;
-sub f f k by f_f_k;
-sub f f t by f_f_t;
-sub r f f by r_f_f;
-sub f b by f_b;
-sub f h by f_h;
-sub f i by f_i;
-sub f j by f_j;
-sub f k by f_k;
-sub f l by f_l;
-sub f t by f_t;
-sub r f by r_f;
-sub r t by r_t;
-sub t f by t_f;
-sub t t by t_t;
-sub r.alt t.alt by r_t.alt;
-sub t.alt t.alt by t_t.alt;
-
-ignore substitute @grk_UPPERCASE kappa' alpha' iota', kappa' alpha' iota' @grk_UPPERCASE;
-ignore substitute @grk_lowercase kappa' alpha' iota', kappa' alpha' iota' @grk_lowercase;
-ignore substitute @grk_smallcaps kappa' alpha' iota', kappa' alpha' iota' @grk_smallcaps;
-
-sub [space hyphen softhyphen endash emdash underscore] kappa' alpha' iota' [space hyphen softhyphen endash emdash underscore] by kaiSymbol ;
-sub [space hyphen.cap endash.cap emdash.cap] Kappa' Alpha' Iota' [space hyphen.cap endash.cap emdash.cap] by KaiSymbol ;
-
-sub [space hyphen softhyphen endash emdash underscore] kappa.sc' alpha.sc' iota.sc' [space hyphen softhyphen endash emdash underscore] by kaiSymbol.sc ;
-
-# =============
-# END LATIN
-# =============
-
-# =============
-# BEGIN HEBREW
-# =============
-
-lookup yiddish {
-	lookupflag IgnoreMarks;
-	sub alef-hb lamed-hb by aleflamed-hb;
-	sub vav-hb vav-hb by vavvav-hb;
-	sub yod-hb vav-hb by vavyod-hb;
-	sub yod-hb yod-hb by yodyod-hb;
-} yiddish;
-
-
-# =============
-# END HEBREW
-# =============";
+code = "# =============\012# BEGIN LATIN\012# =============\012\012sub f f b by f_f_b;\012sub f f h by f_f_h;\012sub f f j by f_f_j;\012sub f f k by f_f_k;\012sub f f t by f_f_t;\012sub r f f by r_f_f;\012sub f b by f_b;\012sub f h by f_h;\012sub f i by f_i;\012sub f j by f_j;\012sub f k by f_k;\012sub f l by f_l;\012sub f t by f_t;\012sub r f by r_f;\012sub r t by r_t;\012sub t f by t_f;\012sub t t by t_t;\012sub r.alt t.alt by r_t.alt;\012sub t.alt t.alt by t_t.alt;\012\012ignore substitute @grk_UPPERCASE kappa' alpha' iota', kappa' alpha' iota' @grk_UPPERCASE;\012ignore substitute @grk_lowercase kappa' alpha' iota', kappa' alpha' iota' @grk_lowercase;\012ignore substitute @grk_smallcaps kappa' alpha' iota', kappa' alpha' iota' @grk_smallcaps;\012\012sub [space hyphen softhyphen endash emdash underscore] kappa' alpha' iota' [space hyphen softhyphen endash emdash underscore] by kaiSymbol ;\012sub [space hyphen.cap endash.cap emdash.cap] Kappa' Alpha' Iota' [space hyphen.cap endash.cap emdash.cap] by KaiSymbol ;\012\012sub [space hyphen softhyphen endash emdash underscore] kappa.sc' alpha.sc' iota.sc' [space hyphen softhyphen endash emdash underscore] by kaiSymbol.sc ;\012\012# =============\012# END LATIN\012# =============\012\012# =============\012# BEGIN HEBREW\012# =============\012\012lookup yiddish {\012	lookupflag IgnoreMarks;\012	sub alef-hb lamed-hb by aleflamed-hb;\012	sub vav-hb vav-hb by vavvav-hb;\012	sub yod-hb vav-hb by vavyod-hb;\012	sub yod-hb yod-hb by yodyod-hb;\012} yiddish;\012\012\012# =============\012# END HEBREW\012# =============";
 name = dlig;
 },
 {
-code = "sub [G g] o o g l e underscore l o g o by Google.logo;
-sub g o o g l e underscore [G g] by G.logo;
-sub s u p e r underscore [G g] underscore l o g o by G.super;
-sub G underscore l o g o by G.logo;
-sub e underscore l o g o by e.logo;
-sub g underscore l o g o by g.logo;
-sub l underscore l o g o by l.logo;
-sub o underscore l o g o by o.logo;
-
-sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;
-
-sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
-sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
-sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;";
+code = "sub [G g] o o g l e underscore l o g o by Google.logo;\012sub g o o g l e underscore [G g] by G.logo;\012sub s u p e r underscore [G g] underscore l o g o by G.super;\012sub G underscore l o g o by G.logo;\012sub e underscore l o g o by e.logo;\012sub g underscore l o g o by g.logo;\012sub l underscore l o g o by l.logo;\012sub o underscore l o g o by o.logo;\012\012sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;\012\012sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;\012sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;\012sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;";
 name = calt;
 },
 {
-code = "featureNames {
-    name \"Number pad asterisk\";
-    name 1 \"Number pad asterisk\";
-};
-sub asterisk by asterisk.num;";
+code = "featureNames {\012    name \"Number pad asterisk\";\012    name 1 \"Number pad asterisk\";\012};\012sub asterisk by asterisk.num;";
 name = ss01;
 },
 {
-code = "featureNames {
-    name \"Colon time\";
-    name 1 \"Colon time\";
-};
-sub colon by colon.time;";
+code = "featureNames {\012    name \"Colon time\";\012    name 1 \"Colon time\";\012};\012sub colon by colon.time;";
 name = ss02;
 },
 {
-code = "featureNames {
-    name \"Alternate Arrows\";
-    name 1 \"Alternate Arrows\";
-};
-
-sub upArrow by upArrow.ss05;
-sub northEastArrow by northEastArrow.ss05;
-sub rightArrow by rightArrow.ss05;
-sub southEastArrow by southEastArrow.ss05;
-sub downArrow by downArrow.ss05;
-sub southWestArrow by southWestArrow.ss05;
-sub leftArrow by leftArrow.ss05;
-sub northWestArrow by northWestArrow.ss05;
-";
+code = "featureNames {\012    name \"Alternate Arrows\";\012    name 1 \"Alternate Arrows\";\012};\012\012sub upArrow by upArrow.ss05;\012sub northEastArrow by northEastArrow.ss05;\012sub rightArrow by rightArrow.ss05;\012sub southEastArrow by southEastArrow.ss05;\012sub downArrow by downArrow.ss05;\012sub southWestArrow by southWestArrow.ss05;\012sub leftArrow by leftArrow.ss05;\012sub northWestArrow by northWestArrow.ss05;\012";
 name = ss05;
 },
 {
-code = "featureNames {
-    name \"Accented Greek SC\";
-    name 1 \"Accented Greek SC\";
-};
-
-sub alphaypogegrammeni.sc.ad by alphaypogegrammeni.sc.ad.ss06;
-sub alphavariaypogegrammeni.sc.ad by alphavariaypogegrammeni.sc.ad.ss06;
-sub alphaoxiaypogegrammeni.sc.ad by alphaoxiaypogegrammeni.sc.ad.ss06;
-sub alphapsiliypogegrammeni.sc.ad by alphapsiliypogegrammeni.sc.ad.ss06;
-sub alphadasiaypogegrammeni.sc.ad by alphadasiaypogegrammeni.sc.ad.ss06;
-sub alphapsilivariaypogegrammeni.sc.ad by alphapsilivariaypogegrammeni.sc.ad.ss06;
-sub alphadasiavariaypogegrammeni.sc.ad by alphadasiavariaypogegrammeni.sc.ad.ss06;
-sub alphapsilioxiaypogegrammeni.sc.ad by alphapsilioxiaypogegrammeni.sc.ad.ss06;
-sub alphadasiaoxiaypogegrammeni.sc.ad by alphadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub alphapsiliperispomeniypogegrammeni.sc.ad by alphapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub alphadasiaperispomeniypogegrammeni.sc.ad by alphadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub alphaperispomeniypogegrammeni.sc.ad by alphaperispomeniypogegrammeni.sc.ad.ss06;
-sub etaypogegrammeni.sc.ad by etaypogegrammeni.sc.ad.ss06;
-sub etavariaypogegrammeni.sc.ad by etavariaypogegrammeni.sc.ad.ss06;
-sub etaoxiaypogegrammeni.sc.ad by etaoxiaypogegrammeni.sc.ad.ss06;
-sub etapsiliypogegrammeni.sc.ad by etapsiliypogegrammeni.sc.ad.ss06;
-sub etadasiaypogegrammeni.sc.ad by etadasiaypogegrammeni.sc.ad.ss06;
-sub etapsilivariaypogegrammeni.sc.ad by etapsilivariaypogegrammeni.sc.ad.ss06;
-sub etadasiavariaypogegrammeni.sc.ad by etadasiavariaypogegrammeni.sc.ad.ss06;
-sub etapsilioxiaypogegrammeni.sc.ad by etapsilioxiaypogegrammeni.sc.ad.ss06;
-sub etadasiaoxiaypogegrammeni.sc.ad by etadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub etapsiliperispomeniypogegrammeni.sc.ad by etapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub etadasiaperispomeniypogegrammeni.sc.ad by etadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub etaperispomeniypogegrammeni.sc.ad by etaperispomeniypogegrammeni.sc.ad.ss06;
-sub omegaypogegrammeni.sc.ad by omegaypogegrammeni.sc.ad.ss06;
-sub omegavariaypogegrammeni.sc.ad by omegavariaypogegrammeni.sc.ad.ss06;
-sub omegaoxiaypogegrammeni.sc.ad by omegaoxiaypogegrammeni.sc.ad.ss06;
-sub omegapsiliypogegrammeni.sc.ad by omegapsiliypogegrammeni.sc.ad.ss06;
-sub omegadasiaypogegrammeni.sc.ad by omegadasiaypogegrammeni.sc.ad.ss06;
-sub omegapsilivariaypogegrammeni.sc.ad by omegapsilivariaypogegrammeni.sc.ad.ss06;
-sub omegadasiavariaypogegrammeni.sc.ad by omegadasiavariaypogegrammeni.sc.ad.ss06;
-sub omegapsilioxiaypogegrammeni.sc.ad by omegapsilioxiaypogegrammeni.sc.ad.ss06;
-sub omegadasiaoxiaypogegrammeni.sc.ad by omegadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub omegapsiliperispomeniypogegrammeni.sc.ad by omegapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub omegadasiaperispomeniypogegrammeni.sc.ad by omegadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub omegaperispomeniypogegrammeni.sc.ad by omegaperispomeniypogegrammeni.sc.ad.ss06;
-sub iotatonos.sc by iotatonos.sc.ss06;
-sub iotadieresis.sc by iotadieresis.sc.ss06;
-sub iotadieresistonos.sc by iotadieresistonos.sc.ss06;
-sub upsilontonos.sc by upsilontonos.sc.ss06;
-sub upsilondieresis.sc by upsilondieresis.sc.ss06;
-sub upsilondieresistonos.sc by upsilondieresistonos.sc.ss06;
-sub omicrontonos.sc by omicrontonos.sc.ss06;
-sub omegatonos.sc by omegatonos.sc.ss06;
-sub alphatonos.sc by alphatonos.sc.ss06;
-sub epsilontonos.sc by epsilontonos.sc.ss06;
-sub etatonos.sc by etatonos.sc.ss06;
-sub alphapsili.sc by alphapsili.sc.ss06;
-sub alphadasia.sc by alphadasia.sc.ss06;
-sub alphapsilivaria.sc by alphapsilivaria.sc.ss06;
-sub alphadasiavaria.sc by alphadasiavaria.sc.ss06;
-sub alphapsilioxia.sc by alphapsilioxia.sc.ss06;
-sub alphadasiaoxia.sc by alphadasiaoxia.sc.ss06;
-sub alphapsiliperispomeni.sc by alphapsiliperispomeni.sc.ss06;
-sub alphadasiaperispomeni.sc by alphadasiaperispomeni.sc.ss06;
-sub alphavaria.sc by alphavaria.sc.ss06;
-sub alphaoxia.sc by alphaoxia.sc.ss06;
-sub alphaperispomeni.sc by alphaperispomeni.sc.ss06;
-sub alphavrachy.sc by alphavrachy.sc.ss06;
-sub alphamacron.sc by alphamacron.sc.ss06;
-sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ss06;
-sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ss06;
-sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ss06;
-sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ss06;
-sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ss06;
-sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ss06;
-sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ss06;
-sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ss06;
-sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ss06;
-sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ss06;
-sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ss06;
-sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ss06;
-sub epsilonpsili.sc by epsilonpsili.sc.ss06;
-sub epsilondasia.sc by epsilondasia.sc.ss06;
-sub epsilonpsilivaria.sc by epsilonpsilivaria.sc.ss06;
-sub epsilondasiavaria.sc by epsilondasiavaria.sc.ss06;
-sub epsilonpsilioxia.sc by epsilonpsilioxia.sc.ss06;
-sub epsilondasiaoxia.sc by epsilondasiaoxia.sc.ss06;
-sub epsilonvaria.sc by epsilonvaria.sc.ss06;
-sub epsilonoxia.sc by epsilonoxia.sc.ss06;
-sub etapsili.sc by etapsili.sc.ss06;
-sub etadasia.sc by etadasia.sc.ss06;
-sub etapsilivaria.sc by etapsilivaria.sc.ss06;
-sub etadasiavaria.sc by etadasiavaria.sc.ss06;
-sub etapsilioxia.sc by etapsilioxia.sc.ss06;
-sub etadasiaoxia.sc by etadasiaoxia.sc.ss06;
-sub etapsiliperispomeni.sc by etapsiliperispomeni.sc.ss06;
-sub etadasiaperispomeni.sc by etadasiaperispomeni.sc.ss06;
-sub etavaria.sc by etavaria.sc.ss06;
-sub etaoxia.sc by etaoxia.sc.ss06;
-sub etaperispomeni.sc by etaperispomeni.sc.ss06;
-sub etaypogegrammeni.sc by etaypogegrammeni.sc.ss06;
-sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ss06;
-sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ss06;
-sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ss06;
-sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ss06;
-sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ss06;
-sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ss06;
-sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ss06;
-sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ss06;
-sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ss06;
-sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ss06;
-sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ss06;
-sub iotapsili.sc by iotapsili.sc.ss06;
-sub iotadasia.sc by iotadasia.sc.ss06;
-sub iotapsilivaria.sc by iotapsilivaria.sc.ss06;
-sub iotadasiavaria.sc by iotadasiavaria.sc.ss06;
-sub iotapsilioxia.sc by iotapsilioxia.sc.ss06;
-sub iotadasiaoxia.sc by iotadasiaoxia.sc.ss06;
-sub iotapsiliperispomeni.sc by iotapsiliperispomeni.sc.ss06;
-sub iotadasiaperispomeni.sc by iotadasiaperispomeni.sc.ss06;
-sub iotavaria.sc by iotavaria.sc.ss06;
-sub iotaoxia.sc by iotaoxia.sc.ss06;
-sub iotaperispomeni.sc by iotaperispomeni.sc.ss06;
-sub iotavrachy.sc by iotavrachy.sc.ss06;
-sub iotamacron.sc by iotamacron.sc.ss06;
-sub iotadialytikavaria.sc by iotadialytikavaria.sc.ss06;
-sub iotadialytikaoxia.sc by iotadialytikaoxia.sc.ss06;
-sub iotadialytikaperispomeni.sc by iotadialytikaperispomeni.sc.ss06;
-sub omicronpsili.sc by omicronpsili.sc.ss06;
-sub omicrondasia.sc by omicrondasia.sc.ss06;
-sub omicronpsilivaria.sc by omicronpsilivaria.sc.ss06;
-sub omicrondasiavaria.sc by omicrondasiavaria.sc.ss06;
-sub omicronpsilioxia.sc by omicronpsilioxia.sc.ss06;
-sub omicrondasiaoxia.sc by omicrondasiaoxia.sc.ss06;
-sub omicronvaria.sc by omicronvaria.sc.ss06;
-sub omicronoxia.sc by omicronoxia.sc.ss06;
-sub rhopsili.sc by rhopsili.sc.ss06;
-sub rhodasia.sc by rhodasia.sc.ss06;
-sub upsilonpsili.sc by upsilonpsili.sc.ss06;
-sub upsilondasia.sc by upsilondasia.sc.ss06;
-sub upsilonpsilivaria.sc by upsilonpsilivaria.sc.ss06;
-sub upsilondasiavaria.sc by upsilondasiavaria.sc.ss06;
-sub upsilonpsilioxia.sc by upsilonpsilioxia.sc.ss06;
-sub upsilondasiaoxia.sc by upsilondasiaoxia.sc.ss06;
-sub upsilonpsiliperispomeni.sc by upsilonpsiliperispomeni.sc.ss06;
-sub upsilondasiaperispomeni.sc by upsilondasiaperispomeni.sc.ss06;
-sub upsilonvaria.sc by upsilonvaria.sc.ss06;
-sub upsilonoxia.sc by upsilonoxia.sc.ss06;
-sub upsilonperispomeni.sc by upsilonperispomeni.sc.ss06;
-sub upsilonvrachy.sc by upsilonvrachy.sc.ss06;
-sub upsilonmacron.sc by upsilonmacron.sc.ss06;
-sub upsilondialytikavaria.sc by upsilondialytikavaria.sc.ss06;
-sub upsilondialytikaoxia.sc by upsilondialytikaoxia.sc.ss06;
-sub upsilondialytikaperispomeni.sc by upsilondialytikaperispomeni.sc.ss06;
-sub omegapsili.sc by omegapsili.sc.ss06;
-sub omegadasia.sc by omegadasia.sc.ss06;
-sub omegapsilivaria.sc by omegapsilivaria.sc.ss06;
-sub omegadasiavaria.sc by omegadasiavaria.sc.ss06;
-sub omegapsilioxia.sc by omegapsilioxia.sc.ss06;
-sub omegadasiaoxia.sc by omegadasiaoxia.sc.ss06;
-sub omegapsiliperispomeni.sc by omegapsiliperispomeni.sc.ss06;
-sub omegadasiaperispomeni.sc by omegadasiaperispomeni.sc.ss06;
-sub omegavaria.sc by omegavaria.sc.ss06;
-sub omegaoxia.sc by omegaoxia.sc.ss06;
-sub omegaperispomeni.sc by omegaperispomeni.sc.ss06;
-sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ss06;
-sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ss06;
-sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ss06;
-sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ss06;
-sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ss06;
-sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ss06;
-sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ss06;
-sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ss06;
-sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ss06;
-sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ss06;
-sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ss06;
-sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ss06;
-";
+code = "featureNames {\012    name \"Accented Greek SC\";\012    name 1 \"Accented Greek SC\";\012};\012\012sub alphaypogegrammeni.sc.ad by alphaypogegrammeni.sc.ad.ss06;\012sub alphavariaypogegrammeni.sc.ad by alphavariaypogegrammeni.sc.ad.ss06;\012sub alphaoxiaypogegrammeni.sc.ad by alphaoxiaypogegrammeni.sc.ad.ss06;\012sub alphapsiliypogegrammeni.sc.ad by alphapsiliypogegrammeni.sc.ad.ss06;\012sub alphadasiaypogegrammeni.sc.ad by alphadasiaypogegrammeni.sc.ad.ss06;\012sub alphapsilivariaypogegrammeni.sc.ad by alphapsilivariaypogegrammeni.sc.ad.ss06;\012sub alphadasiavariaypogegrammeni.sc.ad by alphadasiavariaypogegrammeni.sc.ad.ss06;\012sub alphapsilioxiaypogegrammeni.sc.ad by alphapsilioxiaypogegrammeni.sc.ad.ss06;\012sub alphadasiaoxiaypogegrammeni.sc.ad by alphadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub alphapsiliperispomeniypogegrammeni.sc.ad by alphapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub alphadasiaperispomeniypogegrammeni.sc.ad by alphadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub alphaperispomeniypogegrammeni.sc.ad by alphaperispomeniypogegrammeni.sc.ad.ss06;\012sub etaypogegrammeni.sc.ad by etaypogegrammeni.sc.ad.ss06;\012sub etavariaypogegrammeni.sc.ad by etavariaypogegrammeni.sc.ad.ss06;\012sub etaoxiaypogegrammeni.sc.ad by etaoxiaypogegrammeni.sc.ad.ss06;\012sub etapsiliypogegrammeni.sc.ad by etapsiliypogegrammeni.sc.ad.ss06;\012sub etadasiaypogegrammeni.sc.ad by etadasiaypogegrammeni.sc.ad.ss06;\012sub etapsilivariaypogegrammeni.sc.ad by etapsilivariaypogegrammeni.sc.ad.ss06;\012sub etadasiavariaypogegrammeni.sc.ad by etadasiavariaypogegrammeni.sc.ad.ss06;\012sub etapsilioxiaypogegrammeni.sc.ad by etapsilioxiaypogegrammeni.sc.ad.ss06;\012sub etadasiaoxiaypogegrammeni.sc.ad by etadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub etapsiliperispomeniypogegrammeni.sc.ad by etapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub etadasiaperispomeniypogegrammeni.sc.ad by etadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub etaperispomeniypogegrammeni.sc.ad by etaperispomeniypogegrammeni.sc.ad.ss06;\012sub omegaypogegrammeni.sc.ad by omegaypogegrammeni.sc.ad.ss06;\012sub omegavariaypogegrammeni.sc.ad by omegavariaypogegrammeni.sc.ad.ss06;\012sub omegaoxiaypogegrammeni.sc.ad by omegaoxiaypogegrammeni.sc.ad.ss06;\012sub omegapsiliypogegrammeni.sc.ad by omegapsiliypogegrammeni.sc.ad.ss06;\012sub omegadasiaypogegrammeni.sc.ad by omegadasiaypogegrammeni.sc.ad.ss06;\012sub omegapsilivariaypogegrammeni.sc.ad by omegapsilivariaypogegrammeni.sc.ad.ss06;\012sub omegadasiavariaypogegrammeni.sc.ad by omegadasiavariaypogegrammeni.sc.ad.ss06;\012sub omegapsilioxiaypogegrammeni.sc.ad by omegapsilioxiaypogegrammeni.sc.ad.ss06;\012sub omegadasiaoxiaypogegrammeni.sc.ad by omegadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub omegapsiliperispomeniypogegrammeni.sc.ad by omegapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub omegadasiaperispomeniypogegrammeni.sc.ad by omegadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub omegaperispomeniypogegrammeni.sc.ad by omegaperispomeniypogegrammeni.sc.ad.ss06;\012sub iotatonos.sc by iotatonos.sc.ss06;\012sub iotadieresis.sc by iotadieresis.sc.ss06;\012sub iotadieresistonos.sc by iotadieresistonos.sc.ss06;\012sub upsilontonos.sc by upsilontonos.sc.ss06;\012sub upsilondieresis.sc by upsilondieresis.sc.ss06;\012sub upsilondieresistonos.sc by upsilondieresistonos.sc.ss06;\012sub omicrontonos.sc by omicrontonos.sc.ss06;\012sub omegatonos.sc by omegatonos.sc.ss06;\012sub alphatonos.sc by alphatonos.sc.ss06;\012sub epsilontonos.sc by epsilontonos.sc.ss06;\012sub etatonos.sc by etatonos.sc.ss06;\012sub alphapsili.sc by alphapsili.sc.ss06;\012sub alphadasia.sc by alphadasia.sc.ss06;\012sub alphapsilivaria.sc by alphapsilivaria.sc.ss06;\012sub alphadasiavaria.sc by alphadasiavaria.sc.ss06;\012sub alphapsilioxia.sc by alphapsilioxia.sc.ss06;\012sub alphadasiaoxia.sc by alphadasiaoxia.sc.ss06;\012sub alphapsiliperispomeni.sc by alphapsiliperispomeni.sc.ss06;\012sub alphadasiaperispomeni.sc by alphadasiaperispomeni.sc.ss06;\012sub alphavaria.sc by alphavaria.sc.ss06;\012sub alphaoxia.sc by alphaoxia.sc.ss06;\012sub alphaperispomeni.sc by alphaperispomeni.sc.ss06;\012sub alphavrachy.sc by alphavrachy.sc.ss06;\012sub alphamacron.sc by alphamacron.sc.ss06;\012sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ss06;\012sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ss06;\012sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ss06;\012sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ss06;\012sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ss06;\012sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ss06;\012sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ss06;\012sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ss06;\012sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ss06;\012sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ss06;\012sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ss06;\012sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ss06;\012sub epsilonpsili.sc by epsilonpsili.sc.ss06;\012sub epsilondasia.sc by epsilondasia.sc.ss06;\012sub epsilonpsilivaria.sc by epsilonpsilivaria.sc.ss06;\012sub epsilondasiavaria.sc by epsilondasiavaria.sc.ss06;\012sub epsilonpsilioxia.sc by epsilonpsilioxia.sc.ss06;\012sub epsilondasiaoxia.sc by epsilondasiaoxia.sc.ss06;\012sub epsilonvaria.sc by epsilonvaria.sc.ss06;\012sub epsilonoxia.sc by epsilonoxia.sc.ss06;\012sub etapsili.sc by etapsili.sc.ss06;\012sub etadasia.sc by etadasia.sc.ss06;\012sub etapsilivaria.sc by etapsilivaria.sc.ss06;\012sub etadasiavaria.sc by etadasiavaria.sc.ss06;\012sub etapsilioxia.sc by etapsilioxia.sc.ss06;\012sub etadasiaoxia.sc by etadasiaoxia.sc.ss06;\012sub etapsiliperispomeni.sc by etapsiliperispomeni.sc.ss06;\012sub etadasiaperispomeni.sc by etadasiaperispomeni.sc.ss06;\012sub etavaria.sc by etavaria.sc.ss06;\012sub etaoxia.sc by etaoxia.sc.ss06;\012sub etaperispomeni.sc by etaperispomeni.sc.ss06;\012sub etaypogegrammeni.sc by etaypogegrammeni.sc.ss06;\012sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ss06;\012sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ss06;\012sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ss06;\012sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ss06;\012sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ss06;\012sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ss06;\012sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ss06;\012sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ss06;\012sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ss06;\012sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ss06;\012sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ss06;\012sub iotapsili.sc by iotapsili.sc.ss06;\012sub iotadasia.sc by iotadasia.sc.ss06;\012sub iotapsilivaria.sc by iotapsilivaria.sc.ss06;\012sub iotadasiavaria.sc by iotadasiavaria.sc.ss06;\012sub iotapsilioxia.sc by iotapsilioxia.sc.ss06;\012sub iotadasiaoxia.sc by iotadasiaoxia.sc.ss06;\012sub iotapsiliperispomeni.sc by iotapsiliperispomeni.sc.ss06;\012sub iotadasiaperispomeni.sc by iotadasiaperispomeni.sc.ss06;\012sub iotavaria.sc by iotavaria.sc.ss06;\012sub iotaoxia.sc by iotaoxia.sc.ss06;\012sub iotaperispomeni.sc by iotaperispomeni.sc.ss06;\012sub iotavrachy.sc by iotavrachy.sc.ss06;\012sub iotamacron.sc by iotamacron.sc.ss06;\012sub iotadialytikavaria.sc by iotadialytikavaria.sc.ss06;\012sub iotadialytikaoxia.sc by iotadialytikaoxia.sc.ss06;\012sub iotadialytikaperispomeni.sc by iotadialytikaperispomeni.sc.ss06;\012sub omicronpsili.sc by omicronpsili.sc.ss06;\012sub omicrondasia.sc by omicrondasia.sc.ss06;\012sub omicronpsilivaria.sc by omicronpsilivaria.sc.ss06;\012sub omicrondasiavaria.sc by omicrondasiavaria.sc.ss06;\012sub omicronpsilioxia.sc by omicronpsilioxia.sc.ss06;\012sub omicrondasiaoxia.sc by omicrondasiaoxia.sc.ss06;\012sub omicronvaria.sc by omicronvaria.sc.ss06;\012sub omicronoxia.sc by omicronoxia.sc.ss06;\012sub rhopsili.sc by rhopsili.sc.ss06;\012sub rhodasia.sc by rhodasia.sc.ss06;\012sub upsilonpsili.sc by upsilonpsili.sc.ss06;\012sub upsilondasia.sc by upsilondasia.sc.ss06;\012sub upsilonpsilivaria.sc by upsilonpsilivaria.sc.ss06;\012sub upsilondasiavaria.sc by upsilondasiavaria.sc.ss06;\012sub upsilonpsilioxia.sc by upsilonpsilioxia.sc.ss06;\012sub upsilondasiaoxia.sc by upsilondasiaoxia.sc.ss06;\012sub upsilonpsiliperispomeni.sc by upsilonpsiliperispomeni.sc.ss06;\012sub upsilondasiaperispomeni.sc by upsilondasiaperispomeni.sc.ss06;\012sub upsilonvaria.sc by upsilonvaria.sc.ss06;\012sub upsilonoxia.sc by upsilonoxia.sc.ss06;\012sub upsilonperispomeni.sc by upsilonperispomeni.sc.ss06;\012sub upsilonvrachy.sc by upsilonvrachy.sc.ss06;\012sub upsilonmacron.sc by upsilonmacron.sc.ss06;\012sub upsilondialytikavaria.sc by upsilondialytikavaria.sc.ss06;\012sub upsilondialytikaoxia.sc by upsilondialytikaoxia.sc.ss06;\012sub upsilondialytikaperispomeni.sc by upsilondialytikaperispomeni.sc.ss06;\012sub omegapsili.sc by omegapsili.sc.ss06;\012sub omegadasia.sc by omegadasia.sc.ss06;\012sub omegapsilivaria.sc by omegapsilivaria.sc.ss06;\012sub omegadasiavaria.sc by omegadasiavaria.sc.ss06;\012sub omegapsilioxia.sc by omegapsilioxia.sc.ss06;\012sub omegadasiaoxia.sc by omegadasiaoxia.sc.ss06;\012sub omegapsiliperispomeni.sc by omegapsiliperispomeni.sc.ss06;\012sub omegadasiaperispomeni.sc by omegadasiaperispomeni.sc.ss06;\012sub omegavaria.sc by omegavaria.sc.ss06;\012sub omegaoxia.sc by omegaoxia.sc.ss06;\012sub omegaperispomeni.sc by omegaperispomeni.sc.ss06;\012sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ss06;\012sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ss06;\012sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ss06;\012sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ss06;\012sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ss06;\012sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ss06;\012sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ss06;\012sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ss06;\012sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ss06;\012sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ss06;\012sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ss06;\012sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ss06;\012";
 name = ss06;
 },
 {
-code = "featureNames {
-    name \"iota adscript\";
-    name 1 \"iota adscript\";
-};
-
-sub Alphaprosgegrammeni by Alphaprosgegrammeni.ad;
-sub Alphapsiliprosgegrammeni by Alphapsiliprosgegrammeni.ad;
-sub Alphadasiaprosgegrammeni by Alphadasiaprosgegrammeni.ad;
-sub Alphapsilivariaprosgegrammeni by Alphapsilivariaprosgegrammeni.ad;
-sub Alphadasiavariaprosgegrammeni by Alphadasiavariaprosgegrammeni.ad;
-sub Alphapsilioxiaprosgegrammeni by Alphapsilioxiaprosgegrammeni.ad;
-sub Alphadasiaoxiaprosgegrammeni by Alphadasiaoxiaprosgegrammeni.ad;
-sub Alphapsiliperispomeniprosgegrammeni by Alphapsiliperispomeniprosgegrammeni.ad;
-sub Alphadasiaperispomeniprosgegrammeni by Alphadasiaperispomeniprosgegrammeni.ad;
-sub Etaprosgegrammeni by Etaprosgegrammeni.ad;
-sub Etapsiliprosgegrammeni by Etapsiliprosgegrammeni.ad;
-sub Etadasiaprosgegrammeni by Etadasiaprosgegrammeni.ad;
-sub Etapsilivariaprosgegrammeni by Etapsilivariaprosgegrammeni.ad;
-sub Etadasiavariaprosgegrammeni by Etadasiavariaprosgegrammeni.ad;
-sub Etapsilioxiaprosgegrammeni by Etapsilioxiaprosgegrammeni.ad;
-sub Etadasiaoxiaprosgegrammeni by Etadasiaoxiaprosgegrammeni.ad;
-sub Etapsiliperispomeniprosgegrammeni by Etapsiliperispomeniprosgegrammeni.ad;
-sub Etadasiaperispomeniprosgegrammeni by Etadasiaperispomeniprosgegrammeni.ad;
-sub Omegaprosgegrammeni by Omegaprosgegrammeni.ad;
-sub Omegapsiliprosgegrammeni by Omegapsiliprosgegrammeni.ad;
-sub Omegadasiaprosgegrammeni by Omegadasiaprosgegrammeni.ad;
-sub Omegapsilivariaprosgegrammeni by Omegapsilivariaprosgegrammeni.ad;
-sub Omegadasiavariaprosgegrammeni by Omegadasiavariaprosgegrammeni.ad;
-sub Omegapsilioxiaprosgegrammeni by Omegapsilioxiaprosgegrammeni.ad;
-sub Omegadasiaoxiaprosgegrammeni by Omegadasiaoxiaprosgegrammeni.ad;
-sub Omegapsiliperispomeniprosgegrammeni by Omegapsiliperispomeniprosgegrammeni.ad;
-sub Omegadasiaperispomeniprosgegrammeni by Omegadasiaperispomeniprosgegrammeni.ad;
-sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ad;
-sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ad;
-sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ad;
-sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ad;
-sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ad;
-sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ad;
-sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ad;
-sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ad;
-sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ad;
-sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ad;
-sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ad;
-sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ad;
-sub etaypogegrammeni.sc by etaypogegrammeni.sc.ad;
-sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ad;
-sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ad;
-sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ad;
-sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ad;
-sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ad;
-sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ad;
-sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ad;
-sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ad;
-sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ad;
-sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ad;
-sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ad;
-sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ad;
-sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ad;
-sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ad;
-sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ad;
-sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ad;
-sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ad;
-sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ad;
-sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ad;
-sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ad;
-sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ad;
-sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ad;
-sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ad;
-sub alphaypogegrammeni.sc.ss06 by alphaypogegrammeni.sc.ad.ss06 ;
-sub alphavariaypogegrammeni.sc.ss06 by alphavariaypogegrammeni.sc.ad.ss06 ;
-sub alphaoxiaypogegrammeni.sc.ss06 by alphaoxiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsiliypogegrammeni.sc.ss06 by alphapsiliypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaypogegrammeni.sc.ss06 by alphadasiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsilivariaypogegrammeni.sc.ss06 by alphapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub alphadasiavariaypogegrammeni.sc.ss06 by alphadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub alphapsilioxiaypogegrammeni.sc.ss06 by alphapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaoxiaypogegrammeni.sc.ss06 by alphadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsiliperispomeniypogegrammeni.sc.ss06 by alphapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaperispomeniypogegrammeni.sc.ss06 by alphadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub alphaperispomeniypogegrammeni.sc.ss06 by alphaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etaypogegrammeni.sc.ss06 by etaypogegrammeni.sc.ad.ss06 ;
-sub etavariaypogegrammeni.sc.ss06 by etavariaypogegrammeni.sc.ad.ss06 ;
-sub etaoxiaypogegrammeni.sc.ss06 by etaoxiaypogegrammeni.sc.ad.ss06 ;
-sub etapsiliypogegrammeni.sc.ss06 by etapsiliypogegrammeni.sc.ad.ss06 ;
-sub etadasiaypogegrammeni.sc.ss06 by etadasiaypogegrammeni.sc.ad.ss06 ;
-sub etapsilivariaypogegrammeni.sc.ss06 by etapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub etadasiavariaypogegrammeni.sc.ss06 by etadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub etapsilioxiaypogegrammeni.sc.ss06 by etapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub etadasiaoxiaypogegrammeni.sc.ss06 by etadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub etapsiliperispomeniypogegrammeni.sc.ss06 by etapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etadasiaperispomeniypogegrammeni.sc.ss06 by etadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etaperispomeniypogegrammeni.sc.ss06 by etaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegaypogegrammeni.sc.ss06 by omegaypogegrammeni.sc.ad.ss06 ;
-sub omegavariaypogegrammeni.sc.ss06 by omegavariaypogegrammeni.sc.ad.ss06 ;
-sub omegaoxiaypogegrammeni.sc.ss06 by omegaoxiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsiliypogegrammeni.sc.ss06 by omegapsiliypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaypogegrammeni.sc.ss06 by omegadasiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsilivariaypogegrammeni.sc.ss06 by omegapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub omegadasiavariaypogegrammeni.sc.ss06 by omegadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub omegapsilioxiaypogegrammeni.sc.ss06 by omegapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaoxiaypogegrammeni.sc.ss06 by omegadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsiliperispomeniypogegrammeni.sc.ss06 by omegapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaperispomeniypogegrammeni.sc.ss06 by omegadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegaperispomeniypogegrammeni.sc.ss06 by omegaperispomeniypogegrammeni.sc.ad.ss06 ;";
+code = "featureNames {\012    name \"iota adscript\";\012    name 1 \"iota adscript\";\012};\012\012sub Alphaprosgegrammeni by Alphaprosgegrammeni.ad;\012sub Alphapsiliprosgegrammeni by Alphapsiliprosgegrammeni.ad;\012sub Alphadasiaprosgegrammeni by Alphadasiaprosgegrammeni.ad;\012sub Alphapsilivariaprosgegrammeni by Alphapsilivariaprosgegrammeni.ad;\012sub Alphadasiavariaprosgegrammeni by Alphadasiavariaprosgegrammeni.ad;\012sub Alphapsilioxiaprosgegrammeni by Alphapsilioxiaprosgegrammeni.ad;\012sub Alphadasiaoxiaprosgegrammeni by Alphadasiaoxiaprosgegrammeni.ad;\012sub Alphapsiliperispomeniprosgegrammeni by Alphapsiliperispomeniprosgegrammeni.ad;\012sub Alphadasiaperispomeniprosgegrammeni by Alphadasiaperispomeniprosgegrammeni.ad;\012sub Etaprosgegrammeni by Etaprosgegrammeni.ad;\012sub Etapsiliprosgegrammeni by Etapsiliprosgegrammeni.ad;\012sub Etadasiaprosgegrammeni by Etadasiaprosgegrammeni.ad;\012sub Etapsilivariaprosgegrammeni by Etapsilivariaprosgegrammeni.ad;\012sub Etadasiavariaprosgegrammeni by Etadasiavariaprosgegrammeni.ad;\012sub Etapsilioxiaprosgegrammeni by Etapsilioxiaprosgegrammeni.ad;\012sub Etadasiaoxiaprosgegrammeni by Etadasiaoxiaprosgegrammeni.ad;\012sub Etapsiliperispomeniprosgegrammeni by Etapsiliperispomeniprosgegrammeni.ad;\012sub Etadasiaperispomeniprosgegrammeni by Etadasiaperispomeniprosgegrammeni.ad;\012sub Omegaprosgegrammeni by Omegaprosgegrammeni.ad;\012sub Omegapsiliprosgegrammeni by Omegapsiliprosgegrammeni.ad;\012sub Omegadasiaprosgegrammeni by Omegadasiaprosgegrammeni.ad;\012sub Omegapsilivariaprosgegrammeni by Omegapsilivariaprosgegrammeni.ad;\012sub Omegadasiavariaprosgegrammeni by Omegadasiavariaprosgegrammeni.ad;\012sub Omegapsilioxiaprosgegrammeni by Omegapsilioxiaprosgegrammeni.ad;\012sub Omegadasiaoxiaprosgegrammeni by Omegadasiaoxiaprosgegrammeni.ad;\012sub Omegapsiliperispomeniprosgegrammeni by Omegapsiliperispomeniprosgegrammeni.ad;\012sub Omegadasiaperispomeniprosgegrammeni by Omegadasiaperispomeniprosgegrammeni.ad;\012sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ad;\012sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ad;\012sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ad;\012sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ad;\012sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ad;\012sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ad;\012sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ad;\012sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ad;\012sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ad;\012sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ad;\012sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ad;\012sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ad;\012sub etaypogegrammeni.sc by etaypogegrammeni.sc.ad;\012sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ad;\012sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ad;\012sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ad;\012sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ad;\012sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ad;\012sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ad;\012sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ad;\012sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ad;\012sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ad;\012sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ad;\012sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ad;\012sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ad;\012sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ad;\012sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ad;\012sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ad;\012sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ad;\012sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ad;\012sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ad;\012sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ad;\012sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ad;\012sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ad;\012sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ad;\012sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ad;\012sub alphaypogegrammeni.sc.ss06 by alphaypogegrammeni.sc.ad.ss06 ;\012sub alphavariaypogegrammeni.sc.ss06 by alphavariaypogegrammeni.sc.ad.ss06 ;\012sub alphaoxiaypogegrammeni.sc.ss06 by alphaoxiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsiliypogegrammeni.sc.ss06 by alphapsiliypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaypogegrammeni.sc.ss06 by alphadasiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsilivariaypogegrammeni.sc.ss06 by alphapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub alphadasiavariaypogegrammeni.sc.ss06 by alphadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub alphapsilioxiaypogegrammeni.sc.ss06 by alphapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaoxiaypogegrammeni.sc.ss06 by alphadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsiliperispomeniypogegrammeni.sc.ss06 by alphapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaperispomeniypogegrammeni.sc.ss06 by alphadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub alphaperispomeniypogegrammeni.sc.ss06 by alphaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etaypogegrammeni.sc.ss06 by etaypogegrammeni.sc.ad.ss06 ;\012sub etavariaypogegrammeni.sc.ss06 by etavariaypogegrammeni.sc.ad.ss06 ;\012sub etaoxiaypogegrammeni.sc.ss06 by etaoxiaypogegrammeni.sc.ad.ss06 ;\012sub etapsiliypogegrammeni.sc.ss06 by etapsiliypogegrammeni.sc.ad.ss06 ;\012sub etadasiaypogegrammeni.sc.ss06 by etadasiaypogegrammeni.sc.ad.ss06 ;\012sub etapsilivariaypogegrammeni.sc.ss06 by etapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub etadasiavariaypogegrammeni.sc.ss06 by etadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub etapsilioxiaypogegrammeni.sc.ss06 by etapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub etadasiaoxiaypogegrammeni.sc.ss06 by etadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub etapsiliperispomeniypogegrammeni.sc.ss06 by etapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etadasiaperispomeniypogegrammeni.sc.ss06 by etadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etaperispomeniypogegrammeni.sc.ss06 by etaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegaypogegrammeni.sc.ss06 by omegaypogegrammeni.sc.ad.ss06 ;\012sub omegavariaypogegrammeni.sc.ss06 by omegavariaypogegrammeni.sc.ad.ss06 ;\012sub omegaoxiaypogegrammeni.sc.ss06 by omegaoxiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsiliypogegrammeni.sc.ss06 by omegapsiliypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaypogegrammeni.sc.ss06 by omegadasiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsilivariaypogegrammeni.sc.ss06 by omegapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub omegadasiavariaypogegrammeni.sc.ss06 by omegadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub omegapsilioxiaypogegrammeni.sc.ss06 by omegapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaoxiaypogegrammeni.sc.ss06 by omegadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsiliperispomeniypogegrammeni.sc.ss06 by omegapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaperispomeniypogegrammeni.sc.ss06 by omegadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegaperispomeniypogegrammeni.sc.ss06 by omegaperispomeniypogegrammeni.sc.ad.ss06 ;";
 name = ss07;
 },
 {
-code = "featureNames {
-    name \"Bulgarian Locale\";
-    name 1 \"Bulgarian Locale\";
-};
-
-script cyrl;
-sub De-cy by De-cy.loclBGR;
-sub El-cy by El-cy.loclBGR;
-sub Ef-cy by Ef-cy.loclBGR;
-sub ve-cy by ve-cy.loclBGR;
-sub ge-cy by ge-cy.loclBGR;
-sub de-cy by de-cy.loclBGR;
-sub zhe-cy by zhe-cy.loclBGR;
-sub ze-cy by ze-cy.loclBGR;
-sub ii-cy by ii-cy.loclBGR;
-sub iishort-cy by iishort-cy.loclBGR;
-sub iigrave-cy by iigrave-cy.loclBGR;
-sub ka-cy by ka-cy.loclBGR;
-sub el-cy by el-cy.loclBGR;
-sub ef-cy by ef-cy.loclBGR;
-sub pe-cy by pe-cy.loclBGR;
-sub te-cy by te-cy.loclBGR;
-sub tse-cy by tse-cy.loclBGR;
-sub sha-cy by sha-cy.loclBGR;
-sub shcha-cy by shcha-cy.loclBGR;
-sub softsign-cy by softsign-cy.loclBGR;
-sub hardsign-cy by hardsign-cy.loclBGR;
-sub iu-cy by iu-cy.loclBGR;
-sub yeru-cy by yeru-cy.loclBGR;
-sub de-cy.sc by de-cy.loclBGR.sc;
-sub el-cy.sc by el-cy.loclBGR.sc;
-sub ef-cy.sc by ef-cy.loclBGR.sc;
-";
+code = "featureNames {\012    name \"Bulgarian Locale\";\012    name 1 \"Bulgarian Locale\";\012};\012\012script cyrl;\012sub De-cy by De-cy.loclBGR;\012sub El-cy by El-cy.loclBGR;\012sub Ef-cy by Ef-cy.loclBGR;\012sub ve-cy by ve-cy.loclBGR;\012sub ge-cy by ge-cy.loclBGR;\012sub de-cy by de-cy.loclBGR;\012sub zhe-cy by zhe-cy.loclBGR;\012sub ze-cy by ze-cy.loclBGR;\012sub ii-cy by ii-cy.loclBGR;\012sub iishort-cy by iishort-cy.loclBGR;\012sub iigrave-cy by iigrave-cy.loclBGR;\012sub ka-cy by ka-cy.loclBGR;\012sub el-cy by el-cy.loclBGR;\012sub ef-cy by ef-cy.loclBGR;\012sub pe-cy by pe-cy.loclBGR;\012sub te-cy by te-cy.loclBGR;\012sub tse-cy by tse-cy.loclBGR;\012sub sha-cy by sha-cy.loclBGR;\012sub shcha-cy by shcha-cy.loclBGR;\012sub softsign-cy by softsign-cy.loclBGR;\012sub hardsign-cy by hardsign-cy.loclBGR;\012sub iu-cy by iu-cy.loclBGR;\012sub yeru-cy by yeru-cy.loclBGR;\012sub de-cy.sc by de-cy.loclBGR.sc;\012sub el-cy.sc by el-cy.loclBGR.sc;\012sub ef-cy.sc by ef-cy.loclBGR.sc;\012";
 name = ss08;
 },
 {
-code = "# =============
-# BEGIN HEBREW
-# =============
-
-sub alef-hb by widealef-hb;
-sub he-hb by widehe-hb;
-sub lamed-hb by widelamed-hb;
-sub dalet-hb by widedalet-hb;
-sub kaf-hb by widekaf-hb;
-sub finalmem-hb by finalwidemem-hb;
-sub resh-hb by wideresh-hb;
-sub tav-hb by widetav-hb;
-
-# =============
-# END HEBREW
-# =============";
+code = "# =============\012# BEGIN HEBREW\012# =============\012\012sub alef-hb by widealef-hb;\012sub he-hb by widehe-hb;\012sub lamed-hb by widelamed-hb;\012sub dalet-hb by widedalet-hb;\012sub kaf-hb by widekaf-hb;\012sub finalmem-hb by finalwidemem-hb;\012sub resh-hb by wideresh-hb;\012sub tav-hb by widetav-hb;\012\012# =============\012# END HEBREW\012# =============";
 name = jalt;
 },
 {
-code = "# =============
-# BEGIN HEBREW
-# =============
-	lookupflag 0;
-	lookupflag RightToLeft;	
-	
-	# Kerning between narrow letters with wide marks			
-	pos [vav-hb yod-hb] @hb_wideMarks resh-hb' 60 @hb_wideMarks;
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_narrowHebrewLetters' 60 @hb_wideMarks;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks resh-hb' 30 @hb_wideMarks;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_narrowHebrewLetters' 30 @hb_wideMarks;
-	
-	#	Make it work with cantillation marks (changed the second group to include all bottom diacritics)
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation resh-hb' 60 @hb_bottomDiacritics;
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 60 @hb_bottomDiacritics;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation resh-hb' 30 @hb_bottomDiacritics;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 30 @hb_bottomDiacritics;
-			
-
-	# ---------- KERNING BETWEEN LAMED HOLAM AND SHINDOT
-	
-	pos [lamed_holam-hb lamed_dagesh_holam-hb] [shinshindot-hb shindageshshindot-hb ]' 60;
-	pos [lamed_holam-hb lamed_dagesh_holam-hb] @hb_allCantillation [shinshindot-hb shindageshshindot-hb ]' 60;
-	
-	
-	# ---------- KERNING BACK HOLAM IN BUSY PLACES
-	pos @hb_AllHebrewLetters holam-hb' < 50 0 0 0 > [shinshindot-hb shindageshshindot-hb vavholam-hb];
-	
-	
-	# ---------- NARROW LETTER WITH HOLAM
-	
-	# Add kerning for holam after a wide cantillation sits on top of a narrow letter
-	pos @hb_narrowHebrewLetters holam-hb' < -30 0 0 0 > @hb_wideTopCantillation; 
-	
-	
-	# ---------- CANTILLATION GOES DOWN WHEN...		
-	
-	#1 between two wide diacritic marks
-	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] @hb_goesDown' < 50 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];	
-	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] siluqleft-hb' < 20 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];
-		
-	#2 between a wide mark and any letter with a very wide mark
-	pos @hb_goesDownBefore @hb_wideMarks @hb_goesDown' < 120 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;	
-	pos @hb_goesDownBefore @hb_wideMarks siluqleft-hb' < 80 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;		
-			
-	#3 under the letter Qof
-	pos [qof-hb qofdagesh-hb] @hb_bottomDiacritics [@hb_goesDown siluqleft-hb]' < 50 -170 0 0 >;
-		
-	#4 before finalNun, finalKaf, finalPe
-	pos @hb_goesDown' < 0 -100 0 0 > [finalnun-hb finalpe-hb finalkaf-hb];
-
-# =============
-# END HEBREW
-# =============";
+code = "# =============\012# BEGIN HEBREW\012# =============\012	lookupflag 0;\012	lookupflag RightToLeft;	\012	\012	# Kerning between narrow letters with wide marks			\012	pos [vav-hb yod-hb] @hb_wideMarks resh-hb' 60 @hb_wideMarks;\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_narrowHebrewLetters' 60 @hb_wideMarks;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks resh-hb' 30 @hb_wideMarks;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_narrowHebrewLetters' 30 @hb_wideMarks;\012	\012	#	Make it work with cantillation marks (changed the second group to include all bottom diacritics)\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation resh-hb' 60 @hb_bottomDiacritics;\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 60 @hb_bottomDiacritics;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation resh-hb' 30 @hb_bottomDiacritics;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 30 @hb_bottomDiacritics;\012			\012\012	# ---------- KERNING BETWEEN LAMED HOLAM AND SHINDOT\012	\012	pos [lamed_holam-hb lamed_dagesh_holam-hb] [shinshindot-hb shindageshshindot-hb ]' 60;\012	pos [lamed_holam-hb lamed_dagesh_holam-hb] @hb_allCantillation [shinshindot-hb shindageshshindot-hb ]' 60;\012	\012	\012	# ---------- KERNING BACK HOLAM IN BUSY PLACES\012	pos @hb_AllHebrewLetters holam-hb' < 50 0 0 0 > [shinshindot-hb shindageshshindot-hb vavholam-hb];\012	\012	\012	# ---------- NARROW LETTER WITH HOLAM\012	\012	# Add kerning for holam after a wide cantillation sits on top of a narrow letter\012	pos @hb_narrowHebrewLetters holam-hb' < -30 0 0 0 > @hb_wideTopCantillation; \012	\012	\012	# ---------- CANTILLATION GOES DOWN WHEN...		\012	\012	#1 between two wide diacritic marks\012	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] @hb_goesDown' < 50 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];	\012	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] siluqleft-hb' < 20 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];\012		\012	#2 between a wide mark and any letter with a very wide mark\012	pos @hb_goesDownBefore @hb_wideMarks @hb_goesDown' < 120 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;	\012	pos @hb_goesDownBefore @hb_wideMarks siluqleft-hb' < 80 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;		\012			\012	#3 under the letter Qof\012	pos [qof-hb qofdagesh-hb] @hb_bottomDiacritics [@hb_goesDown siluqleft-hb]' < 50 -170 0 0 >;\012		\012	#4 before finalNun, finalKaf, finalPe\012	pos @hb_goesDown' < 0 -100 0 0 > [finalnun-hb finalpe-hb finalkaf-hb];\012\012# =============\012# END HEBREW\012# =============";
 name = kern;
 }
 );
@@ -67592,11 +64499,6 @@ width = 598;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = a.sc;
-userData = {
-RMXScaler = {
-source = A;
-};
-};
 },
 {
 glyphname = aacute.sc;
@@ -69391,11 +66293,6 @@ leftKerningGroup = a.sc;
 leftMetricsKey = a.sc;
 rightKerningGroup = e.sc;
 rightMetricsKey = e.sc;
-userData = {
-RMXScaler = {
-source = AE;
-};
-};
 },
 {
 glyphname = aeacute.sc;
@@ -83445,11 +80342,6 @@ nodes = (
 width = 367;
 }
 );
-userData = {
-RMXScaler = {
-source = a;
-};
-};
 },
 {
 glyphname = b.sc.lc.ss04;
@@ -83641,11 +80533,6 @@ width = 393;
 }
 );
 rightKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = b;
-};
-};
 },
 {
 glyphname = c.sc.lc.ss04;
@@ -83801,11 +80688,6 @@ width = 359;
 }
 );
 leftKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = c;
-};
-};
 },
 {
 glyphname = d.sc.lc.ss04;
@@ -83998,11 +80880,6 @@ width = 392;
 );
 leftKerningGroup = o.sc.lc.ss04;
 rightKerningGroup = l.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = d;
-};
-};
 },
 {
 glyphname = e.sc.lc.ss04;
@@ -84278,11 +81155,6 @@ width = 362;
 }
 );
 leftKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = e;
-};
-};
 },
 {
 glyphname = f.sc.lc.ss04;
@@ -84429,11 +81301,6 @@ nodes = (
 width = 252;
 }
 );
-userData = {
-RMXScaler = {
-source = f;
-};
-};
 },
 {
 glyphname = g.sc.lc.ss04;
@@ -84668,11 +81535,6 @@ nodes = (
 width = 376;
 }
 );
-userData = {
-RMXScaler = {
-source = g;
-};
-};
 },
 {
 glyphname = h.sc.lc.ss04;
@@ -84832,11 +81694,6 @@ width = 385;
 }
 );
 rightKerningGroup = h.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = h;
-};
-};
 },
 {
 glyphname = i.sc.lc.ss04;
@@ -84971,11 +81828,6 @@ nodes = (
 width = 175;
 }
 );
-userData = {
-RMXScaler = {
-source = i;
-};
-};
 },
 {
 glyphname = j.sc.lc.ss04;
@@ -85158,11 +82010,6 @@ nodes = (
 width = 172;
 }
 );
-userData = {
-RMXScaler = {
-source = j;
-};
-};
 },
 {
 glyphname = k.sc.lc.ss04;
@@ -85289,11 +82136,6 @@ nodes = (
 width = 357;
 }
 );
-userData = {
-RMXScaler = {
-source = k;
-};
-};
 },
 {
 glyphname = l.sc.lc.ss04;
@@ -85361,11 +82203,6 @@ width = 175;
 }
 );
 rightKerningGroup = l.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = l;
-};
-};
 },
 {
 glyphname = m.sc.lc.ss04;
@@ -85593,11 +82430,6 @@ width = 550;
 }
 );
 rightKerningGroup = h.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = m;
-};
-};
 },
 {
 glyphname = n.sc.lc.ss04;
@@ -85753,11 +82585,6 @@ width = 379;
 }
 );
 rightKerningGroup = h.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = n;
-};
-};
 },
 {
 glyphname = o.sc.lc.ss04;
@@ -85926,11 +82753,6 @@ width = 378;
 );
 leftKerningGroup = o.sc.lc.ss04;
 rightKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = o;
-};
-};
 },
 {
 glyphname = p.sc.lc.ss04;
@@ -86122,11 +82944,6 @@ width = 389;
 }
 );
 rightKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = p;
-};
-};
 },
 {
 glyphname = q.sc.lc.ss04;
@@ -86318,11 +83135,6 @@ width = 390;
 }
 );
 leftKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = q;
-};
-};
 },
 {
 glyphname = r.sc.lc.ss04;
@@ -86445,11 +83257,6 @@ nodes = (
 width = 267;
 }
 );
-userData = {
-RMXScaler = {
-source = r;
-};
-};
 },
 {
 glyphname = s.sc.lc.ss04;
@@ -86660,11 +83467,6 @@ nodes = (
 width = 324;
 }
 );
-userData = {
-RMXScaler = {
-source = s;
-};
-};
 },
 {
 glyphname = t.sc.lc.ss04;
@@ -86874,11 +83676,6 @@ nodes = (
 width = 260;
 }
 );
-userData = {
-RMXScaler = {
-source = t;
-};
-};
 },
 {
 glyphname = u.sc.lc.ss04;
@@ -87033,11 +83830,6 @@ nodes = (
 width = 379;
 }
 );
-userData = {
-RMXScaler = {
-source = u;
-};
-};
 },
 {
 glyphname = v.sc.lc.ss04;
@@ -87116,11 +83908,6 @@ nodes = (
 width = 374;
 }
 );
-userData = {
-RMXScaler = {
-source = v;
-};
-};
 },
 {
 glyphname = w.sc.lc.ss04;
@@ -87246,11 +84033,6 @@ nodes = (
 width = 498;
 }
 );
-userData = {
-RMXScaler = {
-source = w;
-};
-};
 },
 {
 glyphname = x.sc.lc.ss04;
@@ -87416,11 +84198,6 @@ nodes = (
 width = 342;
 }
 );
-userData = {
-RMXScaler = {
-source = x;
-};
-};
 },
 {
 glyphname = y.sc.lc.ss04;
@@ -87719,11 +84496,6 @@ nodes = (
 width = 355;
 }
 );
-userData = {
-RMXScaler = {
-source = y;
-};
-};
 },
 {
 glyphname = z.sc.lc.ss04;
@@ -87814,11 +84586,6 @@ nodes = (
 width = 323;
 }
 );
-userData = {
-RMXScaler = {
-source = z;
-};
-};
 },
 {
 glyphname = a.sc.ss04;
@@ -88273,11 +85040,6 @@ nodes = (
 width = 438;
 }
 );
-userData = {
-RMXScaler = {
-source = B;
-};
-};
 },
 {
 glyphname = c.sc.ss04;
@@ -88473,11 +85235,6 @@ width = 486;
 }
 );
 leftKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = C;
-};
-};
 },
 {
 glyphname = d.sc.ss04;
@@ -88621,11 +85378,6 @@ width = 480;
 }
 );
 rightKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = D;
-};
-};
 },
 {
 glyphname = e.sc.ss04;
@@ -88796,11 +85548,6 @@ nodes = (
 width = 403;
 }
 );
-userData = {
-RMXScaler = {
-source = E;
-};
-};
 },
 {
 glyphname = f.sc.ss04;
@@ -88931,11 +85678,6 @@ nodes = (
 width = 371;
 }
 );
-userData = {
-RMXScaler = {
-source = F;
-};
-};
 },
 {
 glyphname = g.sc.ss04;
@@ -89287,11 +86029,6 @@ width = 512;
 }
 );
 leftKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = G;
-};
-};
 },
 {
 glyphname = h.sc.ss04;
@@ -89462,11 +86199,6 @@ nodes = (
 width = 464;
 }
 );
-userData = {
-RMXScaler = {
-source = H;
-};
-};
 },
 {
 glyphname = i.sc.ss04;
@@ -89589,11 +86321,6 @@ nodes = (
 width = 193;
 }
 );
-userData = {
-RMXScaler = {
-source = I;
-};
-};
 },
 {
 glyphname = j.sc.ss04;
@@ -89748,11 +86475,6 @@ nodes = (
 width = 377;
 }
 );
-userData = {
-RMXScaler = {
-source = J;
-};
-};
 },
 {
 glyphname = k.sc.ss04;
@@ -89961,11 +86683,6 @@ nodes = (
 width = 443;
 }
 );
-userData = {
-RMXScaler = {
-source = K;
-};
-};
 },
 {
 glyphname = l.sc.ss04;
@@ -90112,11 +86829,6 @@ nodes = (
 width = 389;
 }
 );
-userData = {
-RMXScaler = {
-source = L;
-};
-};
 },
 {
 glyphname = m.sc.ss04;
@@ -90345,11 +87057,6 @@ nodes = (
 width = 578;
 }
 );
-userData = {
-RMXScaler = {
-source = M;
-};
-};
 },
 {
 glyphname = n.sc.ss04;
@@ -90488,11 +87195,6 @@ nodes = (
 width = 486;
 }
 );
-userData = {
-RMXScaler = {
-source = N;
-};
-};
 },
 {
 glyphname = o.sc.ss04;
@@ -90765,11 +87467,6 @@ width = 521;
 );
 leftKerningGroup = o.sc.ss04;
 rightKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = O;
-};
-};
 },
 {
 glyphname = p.sc.ss04;
@@ -90920,11 +87617,6 @@ nodes = (
 width = 425;
 }
 );
-userData = {
-RMXScaler = {
-source = P;
-};
-};
 },
 {
 glyphname = q.sc.ss04;
@@ -91235,11 +87927,6 @@ width = 527;
 );
 leftKerningGroup = o.sc.ss04;
 rightKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = Q;
-};
-};
 },
 {
 glyphname = r.sc.ss04;
@@ -91450,11 +88137,6 @@ nodes = (
 width = 437;
 }
 );
-userData = {
-RMXScaler = {
-source = R;
-};
-};
 },
 {
 glyphname = s.sc.ss04;
@@ -91705,11 +88387,6 @@ nodes = (
 width = 400;
 }
 );
-userData = {
-RMXScaler = {
-source = S;
-};
-};
 },
 {
 glyphname = t.sc.ss04;
@@ -91848,11 +88525,6 @@ nodes = (
 width = 414;
 }
 );
-userData = {
-RMXScaler = {
-source = T;
-};
-};
 },
 {
 glyphname = u.sc.ss04;
@@ -92071,11 +88743,6 @@ nodes = (
 width = 459;
 }
 );
-userData = {
-RMXScaler = {
-source = U;
-};
-};
 },
 {
 glyphname = v.sc.ss04;
@@ -92162,11 +88829,6 @@ nodes = (
 width = 437;
 }
 );
-userData = {
-RMXScaler = {
-source = V;
-};
-};
 },
 {
 glyphname = w.sc.ss04;
@@ -92333,11 +88995,6 @@ nodes = (
 width = 620;
 }
 );
-userData = {
-RMXScaler = {
-source = W;
-};
-};
 },
 {
 glyphname = x.sc.ss04;
@@ -92457,11 +89114,6 @@ nodes = (
 width = 468;
 }
 );
-userData = {
-RMXScaler = {
-source = X;
-};
-};
 },
 {
 glyphname = y.sc.ss04;
@@ -92640,11 +89292,6 @@ nodes = (
 width = 422;
 }
 );
-userData = {
-RMXScaler = {
-source = Y;
-};
-};
 },
 {
 glyphname = z.sc.ss04;
@@ -92791,11 +89438,6 @@ nodes = (
 width = 410;
 }
 );
-userData = {
-RMXScaler = {
-source = Z;
-};
-};
 },
 {
 glyphname = ordfeminine;
@@ -124530,14 +121172,6 @@ leftKerningGroup = o;
 leftMetricsKey = "=o";
 rightKerningGroup = o;
 rightMetricsKey = "=|";
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "tse-cy.loclBGR";
@@ -127443,11 +124077,6 @@ width = 558;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_b.sc;
-userData = {
-RMXScaler = {
-source = "Be-cy";
-};
-};
 },
 {
 glyphname = "ve-cy.sc";
@@ -127624,11 +124253,6 @@ width = 492;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
-userData = {
-RMXScaler = {
-source = "Ge-cy";
-};
-};
 },
 {
 glyphname = "gje-cy.sc";
@@ -127704,11 +124328,6 @@ width = 492;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_g.sc;
-userData = {
-RMXScaler = {
-source = "Gje-cy";
-};
-};
 },
 {
 glyphname = "gheupturn-cy.sc";
@@ -127810,11 +124429,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gheupturn-cy";
-};
-};
 },
 {
 glyphname = "de-cy.sc";
@@ -128011,11 +124625,6 @@ width = 685;
 leftKerningGroup = cyr_d.sc;
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "tse-cy.sc";
-userData = {
-RMXScaler = {
-source = "De-cy";
-};
-};
 },
 {
 glyphname = "ie-cy.sc";
@@ -128159,11 +124768,6 @@ width = 537;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = e.sc;
-userData = {
-RMXScaler = {
-source = "Iegrave-cy";
-};
-};
 },
 {
 glyphname = "io-cy.sc";
@@ -128241,11 +124845,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = e.sc;
 rightMetricsKey = "e-cy.sc";
-userData = {
-RMXScaler = {
-source = "Io-cy";
-};
-};
 },
 {
 glyphname = "zhe-cy.sc";
@@ -128442,11 +125041,6 @@ width = 862;
 leftKerningGroup = cyr_zhe.sc;
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Zhe-cy";
-};
-};
 },
 {
 glyphname = "ze-cy.sc";
@@ -128725,11 +125319,6 @@ width = 555;
 );
 leftKerningGroup = "cyr-ze.sc";
 rightKerningGroup = "cyr-ze.sc";
-userData = {
-RMXScaler = {
-source = "Ze-cy";
-};
-};
 },
 {
 glyphname = "ii-cy.sc";
@@ -128891,11 +125480,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ii-cy";
-};
-};
 },
 {
 glyphname = "iishort-cy.sc";
@@ -128971,11 +125555,6 @@ width = 667;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Iishort-cy";
-};
-};
 },
 {
 glyphname = "iigrave-cy.sc";
@@ -129305,11 +125884,6 @@ width = 698;
 leftKerningGroup = h.sc;
 leftMetricsKey = h.sc;
 rightKerningGroup = "tse-cy.sc";
-userData = {
-RMXScaler = {
-source = "iishorttail-cy";
-};
-};
 },
 {
 glyphname = "ka-cy.sc";
@@ -129462,11 +126036,6 @@ width = 601;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Ka-cy";
-};
-};
 },
 {
 glyphname = "kje-cy.sc";
@@ -129675,11 +126244,6 @@ width = 622;
 leftKerningGroup = cyr_l.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "El-cy";
-};
-};
 },
 {
 glyphname = "em-cy.sc";
@@ -129937,11 +126501,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Pe-cy";
-};
-};
 },
 {
 glyphname = "er-cy.sc";
@@ -130286,11 +126845,6 @@ width = 582;
 );
 leftKerningGroup = "u-cy.sc";
 rightKerningGroup = "u-cy.sc";
-userData = {
-RMXScaler = {
-source = "U-cy";
-};
-};
 },
 {
 glyphname = "ushort-cy.sc";
@@ -130631,11 +127185,6 @@ leftKerningGroup = cyr_f.sc;
 leftMetricsKey = "o-cy.sc";
 rightKerningGroup = cyr_f.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ef-cy";
-};
-};
 },
 {
 glyphname = "ha-cy.sc";
@@ -130908,11 +127457,6 @@ width = 598;
 leftKerningGroup = cyr_che.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Che-cy";
-};
-};
 },
 {
 glyphname = "tse-cy.sc";
@@ -131029,11 +127573,6 @@ width = 665;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Tse-cy";
-};
-};
 },
 {
 glyphname = "sha-cy.sc";
@@ -131150,11 +127689,6 @@ width = 840;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Sha-cy";
-};
-};
 },
 {
 color = 4;
@@ -131305,11 +127839,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "tse-cy.sc";
-userData = {
-RMXScaler = {
-source = "Shcha-cy";
-};
-};
 },
 {
 color = 4;
@@ -131444,11 +127973,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Dzhe-cy";
-};
-};
 },
 {
 glyphname = "softsign-cy.sc";
@@ -131634,11 +128158,6 @@ width = 558;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_soft.sc;
-userData = {
-RMXScaler = {
-source = "Softsign-cy";
-};
-};
 },
 {
 glyphname = "hardsign-cy.sc";
@@ -131832,11 +128351,6 @@ width = 666;
 leftKerningGroup = t.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Hardsign-cy";
-};
-};
 },
 {
 glyphname = "yeru-cy.sc";
@@ -132083,11 +128597,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Yeru-cy";
-};
-};
 },
 {
 color = 4;
@@ -132339,11 +128848,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Lje-cy";
-};
-};
 },
 {
 glyphname = "nje-cy.sc";
@@ -132562,11 +129066,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Nje-cy";
-};
-};
 },
 {
 glyphname = "dze-cy.sc";
@@ -132823,11 +129322,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = c.sc;
 rightKerningGroup = c.sc;
 rightMetricsKey = c.sc;
-userData = {
-RMXScaler = {
-source = "E-cy";
-};
-};
 },
 {
 glyphname = "ereversed-cy.sc";
@@ -133040,11 +129534,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = "=|c.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "o-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ereversed-cy";
-};
-};
 },
 {
 glyphname = "i-cy.sc";
@@ -133567,11 +130056,6 @@ width = 696;
 leftKerningGroup = t.sc;
 leftMetricsKey = t.sc;
 rightKerningGroup = cyr_dje.sc;
-userData = {
-RMXScaler = {
-source = "Tshe-cy";
-};
-};
 },
 {
 glyphname = "iu-cy.sc";
@@ -133809,11 +130293,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "o-cy.sc";
-userData = {
-RMXScaler = {
-source = "Iu-cy";
-};
-};
 },
 {
 glyphname = "ia-cy.sc";
@@ -134026,11 +130505,6 @@ width = 588;
 leftKerningGroup = cyr_ia.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ia-cy";
-};
-};
 },
 {
 color = 4;
@@ -134261,11 +130735,6 @@ width = 670;
 leftKerningGroup = t.sc;
 leftMetricsKey = t.sc;
 rightKerningGroup = cyr_dje.sc;
-userData = {
-RMXScaler = {
-source = "Dje-cy";
-};
-};
 },
 {
 glyphname = "yat-cy.sc";
@@ -134508,11 +130977,6 @@ leftKerningGroup = cyr_h.sc;
 leftMetricsKey = hbar.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Yat-cy";
-};
-};
 },
 {
 glyphname = "yusbig-cy.sc";
@@ -134736,11 +131200,6 @@ width = 685;
 );
 leftMetricsKey = "zhe-cy.sc";
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Yusbig-cy";
-};
-};
 },
 {
 glyphname = "fita-cy.sc";
@@ -134981,11 +131440,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Fita-cy";
-};
-};
 },
 {
 glyphname = "izhitsa-cy.sc";
@@ -135142,11 +131596,6 @@ width = 599;
 leftKerningGroup = v.sc;
 leftMetricsKey = v.sc;
 rightKerningGroup = cyr_v.sc;
-userData = {
-RMXScaler = {
-source = "Izhitsa-cy";
-};
-};
 },
 {
 glyphname = "ghestroke-cy.sc";
@@ -135271,11 +131720,6 @@ width = 500;
 leftKerningGroup = cyr_h.sc;
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ghestroke-cy";
-};
-};
 },
 {
 color = 4;
@@ -135474,11 +131918,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_dje.sc;
 rightMetricsKey = "dje-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ghemiddlehook-cy";
-};
-};
 },
 {
 glyphname = "zhedescender-cy.sc";
@@ -135676,11 +132115,6 @@ leftKerningGroup = cyr_zhe.sc;
 leftMetricsKey = "zhe-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "hadescender-cy.sc";
-userData = {
-RMXScaler = {
-source = "Zhedescender-cy";
-};
-};
 },
 {
 glyphname = "zedescender-cy.sc";
@@ -135960,11 +132394,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "hadescender-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kadescender-cy";
-};
-};
 },
 {
 glyphname = "kaverticalstroke-cy.sc";
@@ -136134,11 +132563,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kaverticalstroke-cy";
-};
-};
 },
 {
 glyphname = "kastroke-cy.sc";
@@ -136315,11 +132739,6 @@ width = 623;
 leftKerningGroup = cyr_h.sc;
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kastroke-cy";
-};
-};
 },
 {
 glyphname = "kabashkir-cy.sc";
@@ -136474,11 +132893,6 @@ leftKerningGroup = t.sc;
 leftMetricsKey = "hardsign-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kabashkir-cy";
-};
-};
 },
 {
 glyphname = "endescender-cy.sc";
@@ -136616,11 +133030,6 @@ width = 682;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Endescender-cy";
-};
-};
 },
 {
 color = 4;
@@ -136748,11 +133157,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Enghe-cy";
-};
-};
 },
 {
 glyphname = "pedescender-cy.sc";
@@ -137193,11 +133597,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Haabkhasian-cy";
-};
-};
 },
 {
 glyphname = "esdescender-cy.sc";
@@ -137455,11 +133854,6 @@ leftKerningGroup = t.sc;
 leftMetricsKey = "te-cy.sc";
 rightKerningGroup = t.sc;
 rightMetricsKey = "te-cy.sc";
-userData = {
-RMXScaler = {
-source = "Tedescender-cy";
-};
-};
 },
 {
 glyphname = "ustraight-cy.sc";
@@ -137659,11 +134053,6 @@ width = 578;
 );
 leftKerningGroup = y.sc;
 rightKerningGroup = y.sc;
-userData = {
-RMXScaler = {
-source = "Ustraitstroke-cy";
-};
-};
 },
 {
 glyphname = "hadescender-cy.sc";
@@ -137844,11 +134233,6 @@ width = 610;
 leftKerningGroup = x.sc;
 leftMetricsKey = x.sc;
 rightKerningGroup = x.sc;
-userData = {
-RMXScaler = {
-source = "Hadescender-cy";
-};
-};
 },
 {
 color = 4;
@@ -138087,11 +134471,6 @@ leftKerningGroup = cyr_che.sc;
 leftMetricsKey = "che-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "tse-cy.sc";
-userData = {
-RMXScaler = {
-source = "Chedescender-cy";
-};
-};
 },
 {
 glyphname = "cheverticalstroke-cy.sc";
@@ -138301,11 +134680,6 @@ leftKerningGroup = cyr_che.sc;
 leftMetricsKey = "che-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Cheverticalstroke-cy";
-};
-};
 },
 {
 glyphname = "shha-cy.sc";
@@ -138477,11 +134851,6 @@ width = 598;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_shha.sc;
-userData = {
-RMXScaler = {
-source = "Shha-cy";
-};
-};
 },
 {
 glyphname = "shhadescender-cy.sc";
@@ -138686,11 +135055,6 @@ width = 623;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_shha.sc;
-userData = {
-RMXScaler = {
-source = "Shhadescender-cy";
-};
-};
 },
 {
 glyphname = "enlefthook-cy.sc";
@@ -138871,11 +135235,6 @@ width = 632;
 leftKerningGroup = "enlefthook-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = h.sc;
-userData = {
-RMXScaler = {
-source = "EnLeftHook-cy";
-};
-};
 },
 {
 color = 4;
@@ -139056,11 +135415,6 @@ width = 662;
 );
 leftKerningGroup = cyr_l.sc;
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Eldescender-cy";
-};
-};
 },
 {
 glyphname = "cheabkhasian-cy.sc";
@@ -139342,11 +135696,6 @@ width = 764;
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
 rightMetricsKey = "=|schwa-cy.sc";
-userData = {
-RMXScaler = {
-source = "Cheabkhasian-cy";
-};
-};
 },
 {
 glyphname = "chedescenderabkhasian-cy.sc";
@@ -139749,11 +136098,6 @@ width = 595;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Kahook-cy";
-};
-};
 },
 {
 glyphname = "eltail-cy.sc";
@@ -139935,11 +136279,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "entail-cy.sc";
-userData = {
-RMXScaler = {
-source = "Eltail-cy";
-};
-};
 },
 {
 glyphname = "enhook-cy.sc";
@@ -140121,11 +136460,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Enhook-cy";
-};
-};
 },
 {
 glyphname = "entail-cy.sc";
@@ -140274,11 +136608,6 @@ width = 659;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Entail-cy";
-};
-};
 },
 {
 glyphname = "chekhakassian-cy.sc";
@@ -140488,11 +136817,6 @@ leftKerningGroup = cyr_che.sc;
 leftMetricsKey = "che-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Chekhakassian-cy";
-};
-};
 },
 {
 glyphname = "emtail-cy.sc";
@@ -140666,11 +136990,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "em-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "entail-cy.sc";
-userData = {
-RMXScaler = {
-source = "Emtail-cy";
-};
-};
 },
 {
 glyphname = "abreve-cy.sc";
@@ -141130,11 +137449,6 @@ width = 676;
 leftKerningGroup = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Schwa-cy";
-};
-};
 },
 {
 glyphname = "schwadieresis-cy.sc";
@@ -141513,11 +137827,6 @@ leftKerningGroup = "cyr-ze.sc";
 leftMetricsKey = "ze-cy.sc";
 rightKerningGroup = "cyr-ze.sc";
 rightMetricsKey = "ze-cy.sc";
-userData = {
-RMXScaler = {
-source = "Dzeabkhasian-cy";
-};
-};
 },
 {
 glyphname = "imacron-cy.sc";
@@ -141593,11 +137902,6 @@ width = 667;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Imacron-cy";
-};
-};
 },
 {
 glyphname = "idieresis-cy.sc";
@@ -142077,11 +138381,6 @@ width = 582;
 );
 leftKerningGroup = "u-cy.sc";
 rightKerningGroup = "u-cy.sc";
-userData = {
-RMXScaler = {
-source = "Uhungarumlaut-cy";
-};
-};
 },
 {
 glyphname = "chedieresis-cy.sc";
@@ -142261,11 +138560,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gedescender-cy";
-};
-};
 },
 {
 glyphname = "yerudieresis-cy.sc";
@@ -142482,11 +138776,6 @@ width = 492;
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gestrokehook-cy";
-};
-};
 },
 {
 glyphname = "hahook-cy.sc";
@@ -142700,11 +138989,6 @@ leftKerningGroup = x.sc;
 leftMetricsKey = x.sc;
 widthMetricsKey = x.sc;
 rightKerningGroup = x.sc;
-userData = {
-RMXScaler = {
-source = "Hahook-cy";
-};
-};
 },
 {
 color = 4;
@@ -142923,11 +139207,6 @@ leftKerningGroup = x.sc;
 leftMetricsKey = "ha-cy.sc";
 rightKerningGroup = x.sc;
 rightMetricsKey = "ha-cy.sc";
-userData = {
-RMXScaler = {
-source = "Hastroke-cy";
-};
-};
 },
 {
 glyphname = "reversedze-cy.sc";
@@ -143184,11 +139463,6 @@ width = 587;
 );
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
-userData = {
-RMXScaler = {
-source = "Reversedze-cy";
-};
-};
 },
 {
 glyphname = "elhook-cy.sc";
@@ -143402,11 +139676,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Elhook-cy";
-};
-};
 },
 {
 glyphname = "qa-cy.sc";
@@ -143712,11 +139981,6 @@ leftKerningGroup = cyr_h.sc;
 leftMetricsKey = hbar.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Semisoftsign-cy";
-};
-};
 },
 {
 glyphname = "ertick-cy.sc";
@@ -143938,11 +140202,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = p.sc;
 rightMetricsKey = "er-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ertick-cy";
-};
-};
 },
 {
 glyphname = "de-cy.loclBGR.sc";
@@ -144102,11 +140361,6 @@ width = 654;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = a.sc;
-userData = {
-RMXScaler = {
-source = "De-cy.loclBGR";
-};
-};
 },
 {
 glyphname = "el-cy.loclBGR.sc";
@@ -144441,11 +140695,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = "ef-cy.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ef-cy.loclBGR";
-};
-};
 },
 {
 glyphname = "ghestroke-cy.loclBSH.sc";
@@ -156324,14 +152573,6 @@ leftMetricsKey = "=p";
 rightKerningGroup = GRK_beta;
 rightMetricsKey = "=p";
 unicode = 03B2;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = gamma;
@@ -156427,14 +152668,6 @@ leftMetricsKey = "=v";
 rightKerningGroup = GRK_gamma;
 rightMetricsKey = "=v";
 unicode = 03B3;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = delta;
@@ -157068,14 +153301,6 @@ leftMetricsKey = "=o";
 rightKerningGroup = GRK_zeta;
 rightMetricsKey = "=c-20";
 unicode = 03B6;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = eta;
@@ -157874,14 +154099,6 @@ leftMetricsKey = "=k";
 rightKerningGroup = GRK_kappa;
 rightMetricsKey = "=k";
 unicode = 03BA;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = lambda;
@@ -159925,14 +156142,6 @@ leftMetricsKey = "=o";
 rightKerningGroup = GRK_omicron;
 rightMetricsKey = "=o";
 unicode = 03C6;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = chi;
@@ -160546,14 +156755,6 @@ leftMetricsKey = "=o+10";
 rightKerningGroup = GRK_omicron;
 rightMetricsKey = "=o+10";
 unicode = 03C9;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = iotatonos;
@@ -160928,17 +157129,6 @@ width = 606;
 leftKerningGroup = GRK_upsilon;
 rightKerningGroup = GRK_upsilon;
 unicode = 03B0;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 1018;
-}
-);
-};
 },
 {
 glyphname = omicrontonos;
@@ -161187,14 +157377,6 @@ width = 541;
 leftKerningGroup = GRK_epsilon;
 rightKerningGroup = GRK_epsilon;
 unicode = 03AD;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = etatonos;
@@ -267017,7 +263199,7 @@ width = 535;
 unicode = 005E;
 },
 {
-glyphname = infinity;
+glyphname = "infinity";
 lastChange = "2020-01-22 16:45:12 +0000";
 layers = (
 {
@@ -319899,45 +316081,6 @@ width = 3284;
 }
 );
 unicode = E006;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 861;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 1439;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2017;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2583;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2770;
-y = 0;
-}
-);
-};
 },
 {
 glyphname = uniE007;

--- a/source/GoogleSans/GoogleSans.glyphs
+++ b/source/GoogleSans/GoogleSans.glyphs
@@ -43,689 +43,15 @@ code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove A
 name = Uppercase;
 },
 {
-code = "Alpha
-Beta
-Gamma
-Delta
-Epsilon
-Zeta
-Eta
-Theta
-Iota
-Kappa
-Lambda
-Mu
-Nu
-Xi
-Omicron
-Pi
-Rho
-Sigma
-Tau
-Upsilon
-Phi
-Chi
-Psi
-Omega
-Alphatonos
-Epsilontonos
-Etatonos
-Iotatonos
-Omicrontonos
-Upsilontonos
-Omegatonos
-Iotadieresis
-Upsilondieresis
-KaiSymbol
-Alphapsili
-Alphadasia
-Alphapsilivaria
-Alphadasiavaria
-Alphapsilioxia
-Alphadasiaoxia
-Alphapsiliperispomeni
-Alphadasiaperispomeni
-Alphavaria
-Alphaoxia
-Alphavrachy
-Alphamacron
-Alphaprosgegrammeni
-Alphapsiliprosgegrammeni
-Alphadasiaprosgegrammeni
-Alphapsilivariaprosgegrammeni
-Alphadasiavariaprosgegrammeni
-Alphapsilioxiaprosgegrammeni
-Alphadasiaoxiaprosgegrammeni
-Alphapsiliperispomeniprosgegrammeni
-Alphadasiaperispomeniprosgegrammeni
-Epsilonpsili
-Epsilondasia
-Epsilonpsilivaria
-Epsilondasiavaria
-Epsilonpsilioxia
-Epsilondasiaoxia
-Epsilonvaria
-Epsilonoxia
-Etapsili
-Etadasia
-Etapsilivaria
-Etadasiavaria
-Etapsilioxia
-Etadasiaoxia
-Etapsiliperispomeni
-Etadasiaperispomeni
-Etavaria
-Etaoxia
-Etaprosgegrammeni
-Etapsiliprosgegrammeni
-Etadasiaprosgegrammeni
-Etapsilivariaprosgegrammeni
-Etadasiavariaprosgegrammeni
-Etapsilioxiaprosgegrammeni
-Etadasiaoxiaprosgegrammeni
-Etapsiliperispomeniprosgegrammeni
-Etadasiaperispomeniprosgegrammeni
-Iotapsili
-Iotadasia
-Iotapsilivaria
-Iotadasiavaria
-Iotapsilioxia
-Iotadasiaoxia
-Iotapsiliperispomeni
-Iotadasiaperispomeni
-Iotavaria
-Iotaoxia
-Iotavrachy
-Iotamacron
-Omicronpsili
-Omicrondasia
-Omicronpsilivaria
-Omicrondasiavaria
-Omicronpsilioxia
-Omicrondasiaoxia
-Omicronvaria
-Omicronoxia
-Rhodasia
-Upsilondasia
-Upsilondasiavaria
-Upsilondasiaoxia
-Upsilondasiaperispomeni
-Upsilonvaria
-Upsilonoxia
-Upsilonvrachy
-Upsilonmacron
-Omegapsili
-Omegadasia
-Omegapsilivaria
-Omegadasiavaria
-Omegapsilioxia
-Omegadasiaoxia
-Omegapsiliperispomeni
-Omegadasiaperispomeni
-Omegavaria
-Omegaoxia
-Omegaprosgegrammeni
-Omegapsiliprosgegrammeni
-Omegadasiaprosgegrammeni
-Omegapsilivariaprosgegrammeni
-Omegadasiavariaprosgegrammeni
-Omegapsilioxiaprosgegrammeni
-Omegadasiaoxiaprosgegrammeni
-Omegapsiliperispomeniprosgegrammeni
-Omegadasiaperispomeniprosgegrammeni
-Alphaprosgegrammeni.ad
-Alphapsiliprosgegrammeni.ad
-Alphadasiaprosgegrammeni.ad
-Alphapsilivariaprosgegrammeni.ad
-Alphadasiavariaprosgegrammeni.ad
-Alphapsilioxiaprosgegrammeni.ad
-Alphadasiaoxiaprosgegrammeni.ad
-Alphapsiliperispomeniprosgegrammeni.ad
-Alphadasiaperispomeniprosgegrammeni.ad
-Etaprosgegrammeni.ad
-Etapsiliprosgegrammeni.ad
-Etadasiaprosgegrammeni.ad
-Etapsilivariaprosgegrammeni.ad
-Etadasiavariaprosgegrammeni.ad
-Etapsilioxiaprosgegrammeni.ad
-Etadasiaoxiaprosgegrammeni.ad
-Etapsiliperispomeniprosgegrammeni.ad
-Etadasiaperispomeniprosgegrammeni.ad
-Omegaprosgegrammeni.ad
-Omegapsiliprosgegrammeni.ad
-Omegadasiaprosgegrammeni.ad
-Omegapsilivariaprosgegrammeni.ad
-Omegadasiavariaprosgegrammeni.ad
-Omegapsilioxiaprosgegrammeni.ad
-Omegadasiaoxiaprosgegrammeni.ad
-Omegapsiliperispomeniprosgegrammeni.ad
-Omegadasiaperispomeniprosgegrammeni.ad";
+code = "Alpha\012Beta\012Gamma\012Delta\012Epsilon\012Zeta\012Eta\012Theta\012Iota\012Kappa\012Lambda\012Mu\012Nu\012Xi\012Omicron\012Pi\012Rho\012Sigma\012Tau\012Upsilon\012Phi\012Chi\012Psi\012Omega\012Alphatonos\012Epsilontonos\012Etatonos\012Iotatonos\012Omicrontonos\012Upsilontonos\012Omegatonos\012Iotadieresis\012Upsilondieresis\012KaiSymbol\012Alphapsili\012Alphadasia\012Alphapsilivaria\012Alphadasiavaria\012Alphapsilioxia\012Alphadasiaoxia\012Alphapsiliperispomeni\012Alphadasiaperispomeni\012Alphavaria\012Alphaoxia\012Alphavrachy\012Alphamacron\012Alphaprosgegrammeni\012Alphapsiliprosgegrammeni\012Alphadasiaprosgegrammeni\012Alphapsilivariaprosgegrammeni\012Alphadasiavariaprosgegrammeni\012Alphapsilioxiaprosgegrammeni\012Alphadasiaoxiaprosgegrammeni\012Alphapsiliperispomeniprosgegrammeni\012Alphadasiaperispomeniprosgegrammeni\012Epsilonpsili\012Epsilondasia\012Epsilonpsilivaria\012Epsilondasiavaria\012Epsilonpsilioxia\012Epsilondasiaoxia\012Epsilonvaria\012Epsilonoxia\012Etapsili\012Etadasia\012Etapsilivaria\012Etadasiavaria\012Etapsilioxia\012Etadasiaoxia\012Etapsiliperispomeni\012Etadasiaperispomeni\012Etavaria\012Etaoxia\012Etaprosgegrammeni\012Etapsiliprosgegrammeni\012Etadasiaprosgegrammeni\012Etapsilivariaprosgegrammeni\012Etadasiavariaprosgegrammeni\012Etapsilioxiaprosgegrammeni\012Etadasiaoxiaprosgegrammeni\012Etapsiliperispomeniprosgegrammeni\012Etadasiaperispomeniprosgegrammeni\012Iotapsili\012Iotadasia\012Iotapsilivaria\012Iotadasiavaria\012Iotapsilioxia\012Iotadasiaoxia\012Iotapsiliperispomeni\012Iotadasiaperispomeni\012Iotavaria\012Iotaoxia\012Iotavrachy\012Iotamacron\012Omicronpsili\012Omicrondasia\012Omicronpsilivaria\012Omicrondasiavaria\012Omicronpsilioxia\012Omicrondasiaoxia\012Omicronvaria\012Omicronoxia\012Rhodasia\012Upsilondasia\012Upsilondasiavaria\012Upsilondasiaoxia\012Upsilondasiaperispomeni\012Upsilonvaria\012Upsilonoxia\012Upsilonvrachy\012Upsilonmacron\012Omegapsili\012Omegadasia\012Omegapsilivaria\012Omegadasiavaria\012Omegapsilioxia\012Omegadasiaoxia\012Omegapsiliperispomeni\012Omegadasiaperispomeni\012Omegavaria\012Omegaoxia\012Omegaprosgegrammeni\012Omegapsiliprosgegrammeni\012Omegadasiaprosgegrammeni\012Omegapsilivariaprosgegrammeni\012Omegadasiavariaprosgegrammeni\012Omegapsilioxiaprosgegrammeni\012Omegadasiaoxiaprosgegrammeni\012Omegapsiliperispomeniprosgegrammeni\012Omegadasiaperispomeniprosgegrammeni\012Alphaprosgegrammeni.ad\012Alphapsiliprosgegrammeni.ad\012Alphadasiaprosgegrammeni.ad\012Alphapsilivariaprosgegrammeni.ad\012Alphadasiavariaprosgegrammeni.ad\012Alphapsilioxiaprosgegrammeni.ad\012Alphadasiaoxiaprosgegrammeni.ad\012Alphapsiliperispomeniprosgegrammeni.ad\012Alphadasiaperispomeniprosgegrammeni.ad\012Etaprosgegrammeni.ad\012Etapsiliprosgegrammeni.ad\012Etadasiaprosgegrammeni.ad\012Etapsilivariaprosgegrammeni.ad\012Etadasiavariaprosgegrammeni.ad\012Etapsilioxiaprosgegrammeni.ad\012Etadasiaoxiaprosgegrammeni.ad\012Etapsiliperispomeniprosgegrammeni.ad\012Etadasiaperispomeniprosgegrammeni.ad\012Omegaprosgegrammeni.ad\012Omegapsiliprosgegrammeni.ad\012Omegadasiaprosgegrammeni.ad\012Omegapsilivariaprosgegrammeni.ad\012Omegadasiavariaprosgegrammeni.ad\012Omegapsilioxiaprosgegrammeni.ad\012Omegadasiaoxiaprosgegrammeni.ad\012Omegapsiliperispomeniprosgegrammeni.ad\012Omegadasiaperispomeniprosgegrammeni.ad";
 name = grk_UPPERCASE;
 },
 {
-code = "alpha
-beta
-gamma
-delta
-epsilon
-zeta
-eta
-theta
-iota
-kappa
-lambda
-mu
-nu
-xi
-omicron
-pi
-rho
-sigmafinal
-sigma
-tau
-upsilon
-phi
-chi
-psi
-omega
-iotatonos
-iotadieresis
-iotadieresistonos
-upsilontonos
-upsilondieresis
-upsilondieresistonos
-omicrontonos
-omegatonos
-alphatonos
-epsilontonos
-etatonos
-kaiSymbol
-alphapsili
-alphadasia
-alphapsilivaria
-alphadasiavaria
-alphapsilioxia
-alphadasiaoxia
-alphapsiliperispomeni
-alphadasiaperispomeni
-alphavaria
-alphaoxia
-alphaperispomeni
-alphavrachy
-alphamacron
-alphaypogegrammeni
-alphavariaypogegrammeni
-alphaoxiaypogegrammeni
-alphapsiliypogegrammeni
-alphadasiaypogegrammeni
-alphapsilivariaypogegrammeni
-alphadasiavariaypogegrammeni
-alphapsilioxiaypogegrammeni
-alphadasiaoxiaypogegrammeni
-alphapsiliperispomeniypogegrammeni
-alphadasiaperispomeniypogegrammeni
-alphaperispomeniypogegrammeni
-epsilonpsili
-epsilondasia
-epsilonpsilivaria
-epsilondasiavaria
-epsilonpsilioxia
-epsilondasiaoxia
-epsilonvaria
-epsilonoxia
-etapsili
-etadasia
-etapsilivaria
-etadasiavaria
-etapsilioxia
-etadasiaoxia
-etapsiliperispomeni
-etadasiaperispomeni
-etavaria
-etaoxia
-etaperispomeni
-etaypogegrammeni
-etavariaypogegrammeni
-etaoxiaypogegrammeni
-etapsiliypogegrammeni
-etadasiaypogegrammeni
-etapsilivariaypogegrammeni
-etadasiavariaypogegrammeni
-etapsilioxiaypogegrammeni
-etadasiaoxiaypogegrammeni
-etapsiliperispomeniypogegrammeni
-etadasiaperispomeniypogegrammeni
-etaperispomeniypogegrammeni
-iotapsili
-iotadasia
-iotapsilivaria
-iotadasiavaria
-iotapsilioxia
-iotadasiaoxia
-iotapsiliperispomeni
-iotadasiaperispomeni
-iotavaria
-iotaoxia
-iotaperispomeni
-iotavrachy
-iotamacron
-iotadialytikavaria
-iotadialytikaoxia
-iotadialytikaperispomeni
-omicronpsili
-omicrondasia
-omicronpsilivaria
-omicrondasiavaria
-omicronpsilioxia
-omicrondasiaoxia
-omicronvaria
-omicronoxia
-rhopsili
-rhodasia
-upsilonpsili
-upsilondasia
-upsilonpsilivaria
-upsilondasiavaria
-upsilonpsilioxia
-upsilondasiaoxia
-upsilonpsiliperispomeni
-upsilondasiaperispomeni
-upsilonvaria
-upsilonoxia
-upsilonperispomeni
-upsilonvrachy
-upsilonmacron
-upsilondialytikavaria
-upsilondialytikaoxia
-upsilondialytikaperispomeni
-omegapsili
-omegadasia
-omegapsilivaria
-omegadasiavaria
-omegapsilioxia
-omegadasiaoxia
-omegapsiliperispomeni
-omegadasiaperispomeni
-omegavaria
-omegaoxia
-omegaperispomeni
-omegaypogegrammeni
-omegavariaypogegrammeni
-omegaoxiaypogegrammeni
-omegapsiliypogegrammeni
-omegadasiaypogegrammeni
-omegapsilivariaypogegrammeni
-omegadasiavariaypogegrammeni
-omegapsilioxiaypogegrammeni
-omegadasiaoxiaypogegrammeni
-omegapsiliperispomeniypogegrammeni
-omegadasiaperispomeniypogegrammeni
-omegaperispomeniypogegrammeni";
+code = "alpha\012beta\012gamma\012delta\012epsilon\012zeta\012eta\012theta\012iota\012kappa\012lambda\012mu\012nu\012xi\012omicron\012pi\012rho\012sigmafinal\012sigma\012tau\012upsilon\012phi\012chi\012psi\012omega\012iotatonos\012iotadieresis\012iotadieresistonos\012upsilontonos\012upsilondieresis\012upsilondieresistonos\012omicrontonos\012omegatonos\012alphatonos\012epsilontonos\012etatonos\012kaiSymbol\012alphapsili\012alphadasia\012alphapsilivaria\012alphadasiavaria\012alphapsilioxia\012alphadasiaoxia\012alphapsiliperispomeni\012alphadasiaperispomeni\012alphavaria\012alphaoxia\012alphaperispomeni\012alphavrachy\012alphamacron\012alphaypogegrammeni\012alphavariaypogegrammeni\012alphaoxiaypogegrammeni\012alphapsiliypogegrammeni\012alphadasiaypogegrammeni\012alphapsilivariaypogegrammeni\012alphadasiavariaypogegrammeni\012alphapsilioxiaypogegrammeni\012alphadasiaoxiaypogegrammeni\012alphapsiliperispomeniypogegrammeni\012alphadasiaperispomeniypogegrammeni\012alphaperispomeniypogegrammeni\012epsilonpsili\012epsilondasia\012epsilonpsilivaria\012epsilondasiavaria\012epsilonpsilioxia\012epsilondasiaoxia\012epsilonvaria\012epsilonoxia\012etapsili\012etadasia\012etapsilivaria\012etadasiavaria\012etapsilioxia\012etadasiaoxia\012etapsiliperispomeni\012etadasiaperispomeni\012etavaria\012etaoxia\012etaperispomeni\012etaypogegrammeni\012etavariaypogegrammeni\012etaoxiaypogegrammeni\012etapsiliypogegrammeni\012etadasiaypogegrammeni\012etapsilivariaypogegrammeni\012etadasiavariaypogegrammeni\012etapsilioxiaypogegrammeni\012etadasiaoxiaypogegrammeni\012etapsiliperispomeniypogegrammeni\012etadasiaperispomeniypogegrammeni\012etaperispomeniypogegrammeni\012iotapsili\012iotadasia\012iotapsilivaria\012iotadasiavaria\012iotapsilioxia\012iotadasiaoxia\012iotapsiliperispomeni\012iotadasiaperispomeni\012iotavaria\012iotaoxia\012iotaperispomeni\012iotavrachy\012iotamacron\012iotadialytikavaria\012iotadialytikaoxia\012iotadialytikaperispomeni\012omicronpsili\012omicrondasia\012omicronpsilivaria\012omicrondasiavaria\012omicronpsilioxia\012omicrondasiaoxia\012omicronvaria\012omicronoxia\012rhopsili\012rhodasia\012upsilonpsili\012upsilondasia\012upsilonpsilivaria\012upsilondasiavaria\012upsilonpsilioxia\012upsilondasiaoxia\012upsilonpsiliperispomeni\012upsilondasiaperispomeni\012upsilonvaria\012upsilonoxia\012upsilonperispomeni\012upsilonvrachy\012upsilonmacron\012upsilondialytikavaria\012upsilondialytikaoxia\012upsilondialytikaperispomeni\012omegapsili\012omegadasia\012omegapsilivaria\012omegadasiavaria\012omegapsilioxia\012omegadasiaoxia\012omegapsiliperispomeni\012omegadasiaperispomeni\012omegavaria\012omegaoxia\012omegaperispomeni\012omegaypogegrammeni\012omegavariaypogegrammeni\012omegaoxiaypogegrammeni\012omegapsiliypogegrammeni\012omegadasiaypogegrammeni\012omegapsilivariaypogegrammeni\012omegadasiavariaypogegrammeni\012omegapsilioxiaypogegrammeni\012omegadasiaoxiaypogegrammeni\012omegapsiliperispomeniypogegrammeni\012omegadasiaperispomeniypogegrammeni\012omegaperispomeniypogegrammeni";
 name = grk_lowercase;
 },
 {
-code = "alphaypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-alphaperispomeniypogegrammeni.sc.ad
-etaypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-etaperispomeniypogegrammeni.sc.ad
-omegaypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-omegaperispomeniypogegrammeni.sc.ad
-alpha.sc
-beta.sc
-gamma.sc
-delta.sc
-epsilon.sc
-zeta.sc
-eta.sc
-theta.sc
-iota.sc
-kappa.sc
-lambda.sc
-mu.sc
-nu.sc
-xi.sc
-omicron.sc
-pi.sc
-rho.sc
-sigmafinal.sc
-sigma.sc
-tau.sc
-upsilon.sc
-phi.sc
-chi.sc
-psi.sc
-omega.sc
-iotatonos.sc
-iotadieresis.sc
-iotadieresistonos.sc
-upsilontonos.sc
-upsilondieresis.sc
-upsilondieresistonos.sc
-omicrontonos.sc
-omegatonos.sc
-alphatonos.sc
-epsilontonos.sc
-etatonos.sc
-kaiSymbol.sc
-alphapsili.sc
-alphadasia.sc
-alphapsilivaria.sc
-alphadasiavaria.sc
-alphapsilioxia.sc
-alphadasiaoxia.sc
-alphapsiliperispomeni.sc
-alphadasiaperispomeni.sc
-alphavaria.sc
-alphaoxia.sc
-alphaperispomeni.sc
-alphavrachy.sc
-alphamacron.sc
-alphaypogegrammeni.sc
-alphavariaypogegrammeni.sc
-alphaoxiaypogegrammeni.sc
-alphapsiliypogegrammeni.sc
-alphadasiaypogegrammeni.sc
-alphapsilivariaypogegrammeni.sc
-alphadasiavariaypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-alphaperispomeniypogegrammeni.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-epsilonoxia.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaperispomeni.sc
-etaypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-etaperispomeniypogegrammeni.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotamacron.sc
-iotadialytikaperispomeni.sc
-iotadialytikaperispomeni.sc
-iotadialytikaperispomeni.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-omicronoxia.sc
-rhodasia.sc
-rhodasia.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilonmacron.sc
-upsilondialytikaperispomeni.sc
-upsilondialytikaperispomeni.sc
-upsilondialytikaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaperispomeni.sc
-omegaypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-omegaperispomeniypogegrammeni.sc
-alphaypogegrammeni.sc.ad.ss06
-alphavariaypogegrammeni.sc.ad.ss06
-alphaoxiaypogegrammeni.sc.ad.ss06
-alphapsiliypogegrammeni.sc.ad.ss06
-alphadasiaypogegrammeni.sc.ad.ss06
-alphapsilivariaypogegrammeni.sc.ad.ss06
-alphadasiavariaypogegrammeni.sc.ad.ss06
-alphapsilioxiaypogegrammeni.sc.ad.ss06
-alphadasiaoxiaypogegrammeni.sc.ad.ss06
-alphapsiliperispomeniypogegrammeni.sc.ad.ss06
-alphadasiaperispomeniypogegrammeni.sc.ad.ss06
-alphaperispomeniypogegrammeni.sc.ad.ss06
-etaypogegrammeni.sc.ad.ss06
-etavariaypogegrammeni.sc.ad.ss06
-etaoxiaypogegrammeni.sc.ad.ss06
-etapsiliypogegrammeni.sc.ad.ss06
-etadasiaypogegrammeni.sc.ad.ss06
-etapsilivariaypogegrammeni.sc.ad.ss06
-etadasiavariaypogegrammeni.sc.ad.ss06
-etapsilioxiaypogegrammeni.sc.ad.ss06
-etadasiaoxiaypogegrammeni.sc.ad.ss06
-etapsiliperispomeniypogegrammeni.sc.ad.ss06
-etadasiaperispomeniypogegrammeni.sc.ad.ss06
-etaperispomeniypogegrammeni.sc.ad.ss06
-omegaypogegrammeni.sc.ad.ss06
-omegavariaypogegrammeni.sc.ad.ss06
-omegaoxiaypogegrammeni.sc.ad.ss06
-omegapsiliypogegrammeni.sc.ad.ss06
-omegadasiaypogegrammeni.sc.ad.ss06
-omegapsilivariaypogegrammeni.sc.ad.ss06
-omegadasiavariaypogegrammeni.sc.ad.ss06
-omegapsilioxiaypogegrammeni.sc.ad.ss06
-omegadasiaoxiaypogegrammeni.sc.ad.ss06
-omegapsiliperispomeniypogegrammeni.sc.ad.ss06
-omegadasiaperispomeniypogegrammeni.sc.ad.ss06
-omegaperispomeniypogegrammeni.sc.ad.ss06
-iotatonos.sc.ss06
-iotadieresis.sc.ss06
-iotadieresistonos.sc.ss06
-upsilontonos.sc.ss06
-upsilondieresis.sc.ss06
-upsilondieresistonos.sc.ss06
-omicrontonos.sc.ss06
-omegatonos.sc.ss06
-alphatonos.sc.ss06
-epsilontonos.sc.ss06
-etatonos.sc.ss06
-alphapsili.sc.ss06
-alphadasia.sc.ss06
-alphapsilivaria.sc.ss06
-alphadasiavaria.sc.ss06
-alphapsilioxia.sc.ss06
-alphadasiaoxia.sc.ss06
-alphapsiliperispomeni.sc.ss06
-alphadasiaperispomeni.sc.ss06
-alphavaria.sc.ss06
-alphaoxia.sc.ss06
-alphaperispomeni.sc.ss06
-alphavrachy.sc.ss06
-alphamacron.sc.ss06
-alphaypogegrammeni.sc.ss06
-alphavariaypogegrammeni.sc.ss06
-alphaoxiaypogegrammeni.sc.ss06
-alphapsiliypogegrammeni.sc.ss06
-alphadasiaypogegrammeni.sc.ss06
-alphapsilivariaypogegrammeni.sc.ss06
-alphadasiavariaypogegrammeni.sc.ss06
-alphapsilioxiaypogegrammeni.sc.ss06
-alphadasiaoxiaypogegrammeni.sc.ss06
-alphapsiliperispomeniypogegrammeni.sc.ss06
-alphadasiaperispomeniypogegrammeni.sc.ss06
-alphaperispomeniypogegrammeni.sc.ss06
-epsilonpsili.sc.ss06
-epsilondasia.sc.ss06
-epsilonpsilivaria.sc.ss06
-epsilondasiavaria.sc.ss06
-epsilonpsilioxia.sc.ss06
-epsilondasiaoxia.sc.ss06
-epsilonvaria.sc.ss06
-epsilonoxia.sc.ss06
-etapsili.sc.ss06
-etadasia.sc.ss06
-etapsilivaria.sc.ss06
-etadasiavaria.sc.ss06
-etapsilioxia.sc.ss06
-etadasiaoxia.sc.ss06
-etapsiliperispomeni.sc.ss06
-etadasiaperispomeni.sc.ss06
-etavaria.sc.ss06
-etaoxia.sc.ss06
-etaperispomeni.sc.ss06
-etaypogegrammeni.sc.ss06
-etavariaypogegrammeni.sc.ss06
-etaoxiaypogegrammeni.sc.ss06
-etapsiliypogegrammeni.sc.ss06
-etadasiaypogegrammeni.sc.ss06
-etapsilivariaypogegrammeni.sc.ss06
-etadasiavariaypogegrammeni.sc.ss06
-etapsilioxiaypogegrammeni.sc.ss06
-etadasiaoxiaypogegrammeni.sc.ss06
-etapsiliperispomeniypogegrammeni.sc.ss06
-etadasiaperispomeniypogegrammeni.sc.ss06
-etaperispomeniypogegrammeni.sc.ss06
-iotapsili.sc.ss06
-iotadasia.sc.ss06
-iotapsilivaria.sc.ss06
-iotadasiavaria.sc.ss06
-iotapsilioxia.sc.ss06
-iotadasiaoxia.sc.ss06
-iotapsiliperispomeni.sc.ss06
-iotadasiaperispomeni.sc.ss06
-iotavaria.sc.ss06
-iotaoxia.sc.ss06
-iotaperispomeni.sc.ss06
-iotavrachy.sc.ss06
-iotamacron.sc.ss06
-iotadialytikavaria.sc.ss06
-iotadialytikaoxia.sc.ss06
-iotadialytikaperispomeni.sc.ss06
-omicronpsili.sc.ss06
-omicrondasia.sc.ss06
-omicronpsilivaria.sc.ss06
-omicrondasiavaria.sc.ss06
-omicronpsilioxia.sc.ss06
-omicrondasiaoxia.sc.ss06
-omicronvaria.sc.ss06
-omicronoxia.sc.ss06
-rhopsili.sc.ss06
-rhodasia.sc.ss06
-upsilonpsili.sc.ss06
-upsilondasia.sc.ss06
-upsilonpsilivaria.sc.ss06
-upsilondasiavaria.sc.ss06
-upsilonpsilioxia.sc.ss06
-upsilondasiaoxia.sc.ss06
-upsilonpsiliperispomeni.sc.ss06
-upsilondasiaperispomeni.sc.ss06
-upsilonvaria.sc.ss06
-upsilonoxia.sc.ss06
-upsilonperispomeni.sc.ss06
-upsilonvrachy.sc.ss06
-upsilonmacron.sc.ss06
-upsilondialytikavaria.sc.ss06
-upsilondialytikaoxia.sc.ss06
-upsilondialytikaperispomeni.sc.ss06
-omegapsili.sc.ss06
-omegadasia.sc.ss06
-omegapsilivaria.sc.ss06
-omegadasiavaria.sc.ss06
-omegapsilioxia.sc.ss06
-omegadasiaoxia.sc.ss06
-omegapsiliperispomeni.sc.ss06
-omegadasiaperispomeni.sc.ss06
-omegavaria.sc.ss06
-omegaoxia.sc.ss06
-omegaperispomeni.sc.ss06
-omegaypogegrammeni.sc.ss06
-omegavariaypogegrammeni.sc.ss06
-omegaoxiaypogegrammeni.sc.ss06
-omegapsiliypogegrammeni.sc.ss06
-omegadasiaypogegrammeni.sc.ss06
-omegapsilivariaypogegrammeni.sc.ss06
-omegadasiavariaypogegrammeni.sc.ss06
-omegapsilioxiaypogegrammeni.sc.ss06
-omegadasiaoxiaypogegrammeni.sc.ss06
-omegapsiliperispomeniypogegrammeni.sc.ss06
-omegadasiaperispomeniypogegrammeni.sc.ss06
-omegaperispomeniypogegrammeni.sc.ss06";
+code = "alphaypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012alphaperispomeniypogegrammeni.sc.ad\012etaypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012etaperispomeniypogegrammeni.sc.ad\012omegaypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012omegaperispomeniypogegrammeni.sc.ad\012alpha.sc\012beta.sc\012gamma.sc\012delta.sc\012epsilon.sc\012zeta.sc\012eta.sc\012theta.sc\012iota.sc\012kappa.sc\012lambda.sc\012mu.sc\012nu.sc\012xi.sc\012omicron.sc\012pi.sc\012rho.sc\012sigmafinal.sc\012sigma.sc\012tau.sc\012upsilon.sc\012phi.sc\012chi.sc\012psi.sc\012omega.sc\012iotatonos.sc\012iotadieresis.sc\012iotadieresistonos.sc\012upsilontonos.sc\012upsilondieresis.sc\012upsilondieresistonos.sc\012omicrontonos.sc\012omegatonos.sc\012alphatonos.sc\012epsilontonos.sc\012etatonos.sc\012kaiSymbol.sc\012alphapsili.sc\012alphadasia.sc\012alphapsilivaria.sc\012alphadasiavaria.sc\012alphapsilioxia.sc\012alphadasiaoxia.sc\012alphapsiliperispomeni.sc\012alphadasiaperispomeni.sc\012alphavaria.sc\012alphaoxia.sc\012alphaperispomeni.sc\012alphavrachy.sc\012alphamacron.sc\012alphaypogegrammeni.sc\012alphavariaypogegrammeni.sc\012alphaoxiaypogegrammeni.sc\012alphapsiliypogegrammeni.sc\012alphadasiaypogegrammeni.sc\012alphapsilivariaypogegrammeni.sc\012alphadasiavariaypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012alphaperispomeniypogegrammeni.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012epsilonoxia.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaperispomeni.sc\012etaypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012etaperispomeniypogegrammeni.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotamacron.sc\012iotadialytikaperispomeni.sc\012iotadialytikaperispomeni.sc\012iotadialytikaperispomeni.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012omicronoxia.sc\012rhodasia.sc\012rhodasia.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilonmacron.sc\012upsilondialytikaperispomeni.sc\012upsilondialytikaperispomeni.sc\012upsilondialytikaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaperispomeni.sc\012omegaypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012omegaperispomeniypogegrammeni.sc\012alphaypogegrammeni.sc.ad.ss06\012alphavariaypogegrammeni.sc.ad.ss06\012alphaoxiaypogegrammeni.sc.ad.ss06\012alphapsiliypogegrammeni.sc.ad.ss06\012alphadasiaypogegrammeni.sc.ad.ss06\012alphapsilivariaypogegrammeni.sc.ad.ss06\012alphadasiavariaypogegrammeni.sc.ad.ss06\012alphapsilioxiaypogegrammeni.sc.ad.ss06\012alphadasiaoxiaypogegrammeni.sc.ad.ss06\012alphapsiliperispomeniypogegrammeni.sc.ad.ss06\012alphadasiaperispomeniypogegrammeni.sc.ad.ss06\012alphaperispomeniypogegrammeni.sc.ad.ss06\012etaypogegrammeni.sc.ad.ss06\012etavariaypogegrammeni.sc.ad.ss06\012etaoxiaypogegrammeni.sc.ad.ss06\012etapsiliypogegrammeni.sc.ad.ss06\012etadasiaypogegrammeni.sc.ad.ss06\012etapsilivariaypogegrammeni.sc.ad.ss06\012etadasiavariaypogegrammeni.sc.ad.ss06\012etapsilioxiaypogegrammeni.sc.ad.ss06\012etadasiaoxiaypogegrammeni.sc.ad.ss06\012etapsiliperispomeniypogegrammeni.sc.ad.ss06\012etadasiaperispomeniypogegrammeni.sc.ad.ss06\012etaperispomeniypogegrammeni.sc.ad.ss06\012omegaypogegrammeni.sc.ad.ss06\012omegavariaypogegrammeni.sc.ad.ss06\012omegaoxiaypogegrammeni.sc.ad.ss06\012omegapsiliypogegrammeni.sc.ad.ss06\012omegadasiaypogegrammeni.sc.ad.ss06\012omegapsilivariaypogegrammeni.sc.ad.ss06\012omegadasiavariaypogegrammeni.sc.ad.ss06\012omegapsilioxiaypogegrammeni.sc.ad.ss06\012omegadasiaoxiaypogegrammeni.sc.ad.ss06\012omegapsiliperispomeniypogegrammeni.sc.ad.ss06\012omegadasiaperispomeniypogegrammeni.sc.ad.ss06\012omegaperispomeniypogegrammeni.sc.ad.ss06\012iotatonos.sc.ss06\012iotadieresis.sc.ss06\012iotadieresistonos.sc.ss06\012upsilontonos.sc.ss06\012upsilondieresis.sc.ss06\012upsilondieresistonos.sc.ss06\012omicrontonos.sc.ss06\012omegatonos.sc.ss06\012alphatonos.sc.ss06\012epsilontonos.sc.ss06\012etatonos.sc.ss06\012alphapsili.sc.ss06\012alphadasia.sc.ss06\012alphapsilivaria.sc.ss06\012alphadasiavaria.sc.ss06\012alphapsilioxia.sc.ss06\012alphadasiaoxia.sc.ss06\012alphapsiliperispomeni.sc.ss06\012alphadasiaperispomeni.sc.ss06\012alphavaria.sc.ss06\012alphaoxia.sc.ss06\012alphaperispomeni.sc.ss06\012alphavrachy.sc.ss06\012alphamacron.sc.ss06\012alphaypogegrammeni.sc.ss06\012alphavariaypogegrammeni.sc.ss06\012alphaoxiaypogegrammeni.sc.ss06\012alphapsiliypogegrammeni.sc.ss06\012alphadasiaypogegrammeni.sc.ss06\012alphapsilivariaypogegrammeni.sc.ss06\012alphadasiavariaypogegrammeni.sc.ss06\012alphapsilioxiaypogegrammeni.sc.ss06\012alphadasiaoxiaypogegrammeni.sc.ss06\012alphapsiliperispomeniypogegrammeni.sc.ss06\012alphadasiaperispomeniypogegrammeni.sc.ss06\012alphaperispomeniypogegrammeni.sc.ss06\012epsilonpsili.sc.ss06\012epsilondasia.sc.ss06\012epsilonpsilivaria.sc.ss06\012epsilondasiavaria.sc.ss06\012epsilonpsilioxia.sc.ss06\012epsilondasiaoxia.sc.ss06\012epsilonvaria.sc.ss06\012epsilonoxia.sc.ss06\012etapsili.sc.ss06\012etadasia.sc.ss06\012etapsilivaria.sc.ss06\012etadasiavaria.sc.ss06\012etapsilioxia.sc.ss06\012etadasiaoxia.sc.ss06\012etapsiliperispomeni.sc.ss06\012etadasiaperispomeni.sc.ss06\012etavaria.sc.ss06\012etaoxia.sc.ss06\012etaperispomeni.sc.ss06\012etaypogegrammeni.sc.ss06\012etavariaypogegrammeni.sc.ss06\012etaoxiaypogegrammeni.sc.ss06\012etapsiliypogegrammeni.sc.ss06\012etadasiaypogegrammeni.sc.ss06\012etapsilivariaypogegrammeni.sc.ss06\012etadasiavariaypogegrammeni.sc.ss06\012etapsilioxiaypogegrammeni.sc.ss06\012etadasiaoxiaypogegrammeni.sc.ss06\012etapsiliperispomeniypogegrammeni.sc.ss06\012etadasiaperispomeniypogegrammeni.sc.ss06\012etaperispomeniypogegrammeni.sc.ss06\012iotapsili.sc.ss06\012iotadasia.sc.ss06\012iotapsilivaria.sc.ss06\012iotadasiavaria.sc.ss06\012iotapsilioxia.sc.ss06\012iotadasiaoxia.sc.ss06\012iotapsiliperispomeni.sc.ss06\012iotadasiaperispomeni.sc.ss06\012iotavaria.sc.ss06\012iotaoxia.sc.ss06\012iotaperispomeni.sc.ss06\012iotavrachy.sc.ss06\012iotamacron.sc.ss06\012iotadialytikavaria.sc.ss06\012iotadialytikaoxia.sc.ss06\012iotadialytikaperispomeni.sc.ss06\012omicronpsili.sc.ss06\012omicrondasia.sc.ss06\012omicronpsilivaria.sc.ss06\012omicrondasiavaria.sc.ss06\012omicronpsilioxia.sc.ss06\012omicrondasiaoxia.sc.ss06\012omicronvaria.sc.ss06\012omicronoxia.sc.ss06\012rhopsili.sc.ss06\012rhodasia.sc.ss06\012upsilonpsili.sc.ss06\012upsilondasia.sc.ss06\012upsilonpsilivaria.sc.ss06\012upsilondasiavaria.sc.ss06\012upsilonpsilioxia.sc.ss06\012upsilondasiaoxia.sc.ss06\012upsilonpsiliperispomeni.sc.ss06\012upsilondasiaperispomeni.sc.ss06\012upsilonvaria.sc.ss06\012upsilonoxia.sc.ss06\012upsilonperispomeni.sc.ss06\012upsilonvrachy.sc.ss06\012upsilonmacron.sc.ss06\012upsilondialytikavaria.sc.ss06\012upsilondialytikaoxia.sc.ss06\012upsilondialytikaperispomeni.sc.ss06\012omegapsili.sc.ss06\012omegadasia.sc.ss06\012omegapsilivaria.sc.ss06\012omegadasiavaria.sc.ss06\012omegapsilioxia.sc.ss06\012omegadasiaoxia.sc.ss06\012omegapsiliperispomeni.sc.ss06\012omegadasiaperispomeni.sc.ss06\012omegavaria.sc.ss06\012omegaoxia.sc.ss06\012omegaperispomeni.sc.ss06\012omegaypogegrammeni.sc.ss06\012omegavariaypogegrammeni.sc.ss06\012omegaoxiaypogegrammeni.sc.ss06\012omegapsiliypogegrammeni.sc.ss06\012omegadasiaypogegrammeni.sc.ss06\012omegapsilivariaypogegrammeni.sc.ss06\012omegadasiavariaypogegrammeni.sc.ss06\012omegapsilioxiaypogegrammeni.sc.ss06\012omegadasiaoxiaypogegrammeni.sc.ss06\012omegapsiliperispomeniypogegrammeni.sc.ss06\012omegadasiaperispomeniypogegrammeni.sc.ss06\012omegaperispomeniypogegrammeni.sc.ss06";
 name = grk_smallcaps;
 },
 {
@@ -878,785 +204,25 @@ designer = "Google Sans Authors";
 familyName = "Google Sans";
 featurePrefixes = (
 {
-code = "languagesystem DFLT dflt;
-languagesystem latn dflt;
-languagesystem cyrl dflt;
-languagesystem hebr dflt;
-
-languagesystem latn ROM;
-languagesystem latn MOL;
-languagesystem latn CAT;
-languagesystem latn SRB;
-languagesystem cyrl BGR;
-languagesystem hebr IWR;
-
-@grk_UPPERCASE = [ Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega Alphatonos Epsilontonos Etatonos Iotatonos Omicrontonos Upsilontonos Omegatonos Iotadieresis Upsilondieresis ] ;
-
-@grk_lowercase = [ alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alphatonos epsilontonos etatonos iotatonos omicrontonos upsilontonos omegatonos iotadieresis upsilondieresis iotadieresistonos upsilondieresistonos sigmafinal ] ;
-
-@grk_smallcaps = [ alpha.sc beta.sc gamma.sc delta.sc epsilon.sc zeta.sc eta.sc theta.sc iota.sc kappa.sc lambda.sc mu.sc nu.sc xi.sc omicron.sc pi.sc rho.sc sigma.sc tau.sc upsilon.sc phi.sc chi.sc psi.sc omega.sc alphatonos.sc epsilontonos.sc etatonos.sc iotatonos.sc omicrontonos.sc upsilontonos.sc omegatonos.sc iotadieresis.sc upsilondieresis.sc iotadieresistonos.sc upsilondieresistonos.sc sigmafinal.sc ] ;
-
-";
+code = "languagesystem DFLT dflt;\012languagesystem latn dflt;\012languagesystem cyrl dflt;\012languagesystem hebr dflt;\012\012languagesystem latn ROM;\012languagesystem latn MOL;\012languagesystem latn CAT;\012languagesystem latn SRB;\012languagesystem cyrl BGR;\012languagesystem hebr IWR;\012\012@grk_UPPERCASE = [ Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega Alphatonos Epsilontonos Etatonos Iotatonos Omicrontonos Upsilontonos Omegatonos Iotadieresis Upsilondieresis ] ;\012\012@grk_lowercase = [ alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alphatonos epsilontonos etatonos iotatonos omicrontonos upsilontonos omegatonos iotadieresis upsilondieresis iotadieresistonos upsilondieresistonos sigmafinal ] ;\012\012@grk_smallcaps = [ alpha.sc beta.sc gamma.sc delta.sc epsilon.sc zeta.sc eta.sc theta.sc iota.sc kappa.sc lambda.sc mu.sc nu.sc xi.sc omicron.sc pi.sc rho.sc sigma.sc tau.sc upsilon.sc phi.sc chi.sc psi.sc omega.sc alphatonos.sc epsilontonos.sc etatonos.sc iotatonos.sc omicrontonos.sc upsilontonos.sc omegatonos.sc iotadieresis.sc upsilondieresis.sc iotadieresistonos.sc upsilondieresistonos.sc sigmafinal.sc ] ;\012\012";
 name = Languagesystems;
 }
 );
 features = (
 {
-code = "    # ==============
-    # BEGIN LATIN
-    # ==============
-    
-    sub Ccedilla from [Ccedilla Ccedilla.alt];
-    sub Ccedilla.alt from [Ccedilla.alt Ccedilla];
-    sub euro from [euro euro.cap euro.tf];
-    sub euro.tf from [euro.tf euro euro.cap];
-    sub euro.cap from [euro.cap euro.tf euro];
-    sub G from [G G.alt G.logo];
-    sub G.logo from [G.logo G G.alt];
-    sub G.alt from [G.alt G.logo G];
-    sub Gbreve from [Gbreve Gbreve.alt];
-    sub Gbreve.alt from [Gbreve.alt Gbreve];
-    sub Gcircumflex from [Gcircumflex Gcircumflex.alt];
-    sub Gcircumflex.alt from [Gcircumflex.alt Gcircumflex];
-    sub Gdotaccent from [Gdotaccent Gdotaccent.alt];
-    sub Gdotaccent.alt from [Gdotaccent.alt Gdotaccent];
-    sub Gcommaaccent from [Gcommaaccent Gcommaaccent.alt];
-    sub Gcommaaccent.alt from [Gcommaaccent.alt Gcommaaccent];
-    sub I from [I I.alt];
-    sub I.alt from [I.alt I];
-    sub Iacute from [Iacute Iacute.alt];
-    sub Iacute.alt from [Iacute.alt Iacute];
-    sub Ibreve from [Ibreve Ibreve.alt];
-    sub Ibreve.alt from [Ibreve.alt Ibreve];
-    sub Icircumflex from [Icircumflex Icircumflex.alt];
-    sub Icircumflex.alt from [Icircumflex.alt Icircumflex];
-    sub Idieresis from [Idieresis Idieresis.alt];
-    sub Idieresis.alt from [Idieresis.alt Idieresis];
-    sub Idotaccent from [Idotaccent Idotaccent.alt];
-    sub Idotaccent.alt from [Idotaccent.alt Idotaccent];
-    sub Igrave from [Igrave Igrave.alt];
-    sub Igrave.alt from [Igrave.alt Igrave];
-    sub Imacron from [Imacron Imacron.alt];
-    sub Imacron.alt from [Imacron.alt Imacron];
-    sub Iogonek from [Iogonek Iogonek.alt];
-    sub Iogonek.alt from [Iogonek.alt Iogonek];
-    sub Itilde from [Itilde Itilde.alt];
-    sub Itilde.alt from [Itilde.alt Itilde];
-    sub J from [J J.alt];
-    sub J.alt from [J.alt J];
-    sub Jcircumflex from [Jcircumflex Jcircumflex.alt];
-    sub Jcircumflex.alt from [Jcircumflex.alt Jcircumflex];
-    sub K from [K K.alt];
-    sub K.alt from [K.alt K];
-    sub Kcommaaccent from [Kcommaaccent Kcommaaccent.alt];
-    sub Kcommaaccent.alt from [Kcommaaccent.alt Kcommaaccent];
-    sub M from [M M.alt];
-    sub M.alt from [M.alt M];
-    sub Q from [Q Q.alt];
-    sub Q.alt from [Q.alt Q];
-    sub R from [R R.alt];
-    sub R.alt from [R.alt R];
-    sub Racute from [Racute Racute.alt];
-    sub Racute.alt from [Racute.alt Racute];
-    sub Rcaron from [Rcaron Rcaron.alt];
-    sub Rcaron.alt from [Rcaron.alt Rcaron];
-    sub Rcommaaccent from [Rcommaaccent Rcommaaccent.alt];
-    sub Rcommaaccent.alt from [Rcommaaccent.alt Rcommaaccent];    
-    sub Scedilla from [Scedilla Scedilla.alt];
-    sub Scedilla.alt from [Scedilla.alt Scedilla];
-    sub W from [W W.alt];
-    sub W.alt from [W.alt W];
-    sub Wacute from [Wacute Wacute.alt];
-    sub Wacute.alt from [Wacute.alt Wacute];
-    sub Wcircumflex from [Wcircumflex Wcircumflex.alt];
-    sub Wcircumflex.alt from [Wcircumflex.alt Wcircumflex];
-    sub Wdieresis from [Wdieresis Wdieresis.alt];
-    sub Wdieresis.alt from [Wdieresis.alt Wdieresis];
-    sub Wgrave from [Wgrave Wgrave.alt];
-    sub Wgrave.alt from [Wgrave.alt Wgrave];
-    sub a from [a a.alt];
-    sub a.alt from [a.alt a];
-    sub aacute from [aacute aacute.alt];
-    sub aacute.alt from [aacute.alt aacute];
-    sub abreve from [abreve abreve.alt];
-    sub abreve.alt from [abreve.alt abreve];
-    sub acircumflex from [acircumflex acircumflex.alt];
-    sub acircumflex.alt from [acircumflex.alt acircumflex];
-    sub acutecomb from [acutecomb acutecomb.cap];
-    sub acutecomb.cap from [acutecomb.cap acute];
-    sub adieresis from [adieresis adieresis.alt];
-    sub adieresis.alt from [adieresis.alt adieresis];
-    sub ae from [ae ae.alt];
-    sub ae.alt from [ae.alt ae];
-    sub aeacute from [aeacute aeacute.alt];
-    sub aeacute.alt from [aeacute.alt aeacute];
-    sub agrave from [agrave agrave.alt];
-    sub agrave.alt from [agrave.alt agrave];
-    sub amacron from [amacron amacron.alt];
-    sub amacron.alt from [amacron.alt amacron];
-    sub ampersand from [ampersand ampersand.alt];
-    sub ampersand.alt from [ampersand.alt ampersand];
-    sub aogonek from [aogonek aogonek.alt];
-    sub aogonek.alt from [aogonek.alt aogonek];
-    sub adotbelow from [adotbelow adotbelow.alt];
-    sub adotbelow.alt from [adotbelow.alt adotbelow];
-    sub ahookabove from [ahookabove ahookabove.alt];
-    sub ahookabove.alt from [ahookabove.alt ahookabove];
-    sub acircumflexacute from [acircumflexacute acircumflexacute.alt];
-    sub acircumflexacute.alt from [acircumflexacute.alt acircumflexacute];
-    sub acircumflexgrave from [acircumflexgrave acircumflexgrave.alt];
-    sub acircumflexgrave.alt from [acircumflexgrave.alt acircumflexgrave];
-	sub acircumflexhookabove from [acircumflexhookabove acircumflexhookabove.alt];
-    sub acircumflexhookabove.alt from [acircumflexhookabove.alt acircumflexhookabove];
-    sub acircumflextilde from [acircumflextilde acircumflextilde.alt];
-    sub acircumflextilde.alt from [acircumflextilde.alt acircumflextilde];    
-    sub acircumflexdotbelow from [acircumflexdotbelow acircumflexdotbelow.alt];
-    sub acircumflexdotbelow.alt from [acircumflexdotbelow.alt acircumflexdotbelow];
-    sub abreveacute from [abreveacute abreveacute.alt];
-    sub abreveacute.alt from [abreveacute.alt abreveacute];
-    sub abrevegrave from [abrevegrave abrevegrave.alt];
-    sub abrevegrave.alt from [abrevegrave.alt abrevegrave];
-    sub abrevehookabove from [abrevehookabove abrevehookabove.alt];
-    sub abrevehookabove.alt from [abrevehookabove.alt abrevehookabove];
-    sub abrevetilde from [abrevetilde abrevetilde.alt];
-    sub abrevetilde.alt from [abrevetilde.alt abrevetilde];
-    sub abrevedotbelow from [abrevedotbelow abrevedotbelow.alt];
-    sub abrevedotbelow.alt from [abrevedotbelow.alt abrevedotbelow];
-    sub quoteright from [quoteright quoteright.alt];
-    sub quoteright.alt from [quoteright.alt quoteright];
-    sub approxequal from [approxequal approxequal.tf];
-    sub approxequal.tf from [approxequal.tf approxequal];
-    sub aring from [aring aring.alt];
-    sub aring.alt from [aring.alt aring];
-    sub aringacute from [aringacute aringacute.alt];
-    sub aringacute.alt from [aringacute.alt aringacute];
-    sub at from [at at.cap];
-    sub at.cap from [at.cap at];
-    sub atilde from [atilde atilde.alt];
-    sub atilde.alt from [atilde.alt atilde];
-    sub braceleft from [braceleft braceleft.cap];
-    sub braceleft.cap from [braceleft.cap braceleft];
-    sub braceright from [braceright braceright.cap];
-    sub braceright.cap from [braceright.cap braceright];
-    sub bracketleft from [bracketleft bracketleft.cap];
-    sub bracketleft.cap from [bracketleft.cap bracketleft];
-    sub bracketright from [bracketright bracketright.cap];
-    sub bracketright.cap from [bracketright.cap bracketright];
-    sub brevecomb from [brevecomb brevecomb.cap];
-    sub brevecomb.cap from [brevecomb.cap brevecomb];
-    sub brevecombcy from [brevecombcy brevecombcy.cap brevecombcy.sc];
-    sub brevecombcy.cap from [brevecombcy.cap brevecombcy brevecombcy.sc];
-    sub brevecombcy.sc from [brevecombcy.sc brevecombcy brevecombcy.cap]; 
-    sub brevecomb_hookabovecomb from [brevecomb_hookabovecomb brevecomb_hookabovecomb.cap];
-    sub brevecomb_hookabovecomb.cap from [brevecomb_hookabovecomb.cap brevecomb_hookabovecomb];
-    sub bullet from [bullet bullet.cap];
-    sub bullet.cap from [bullet.cap bullet];
-    sub caroncomb from [caroncomb caron.alt caroncomb.cap];
-    sub caroncomb.cap from [caroncomb.cap caron caroncomb.alt];
-    sub caroncomb.alt from [caroncomb.alt caroncomb.alt.cap];    
-    sub caroncomb.alt.cap from [caroncomb.alt.cap caroncomb.alt];
-    sub caron.alt from [caron.alt caroncomb.cap caron];
-    sub ccedilla from [ccedilla ccedilla.alt];
-    sub ccedilla.alt from [ccedilla.alt ccedilla];
-    sub cedilla from [cedilla cedilla.alt];
-    sub cedilla.alt from [cedilla.alt cedilla];
-    sub cedillacomb from [cedillacomb cedillacomb.alt];
-    sub cedillacomb.alt from [cedillacomb.alt cedillacomb];
-    sub cent from [cent cent.tf cent.cap];
-    sub cent.cap from [cent.cap cent cent.tf];
-    sub cent.tf from [cent.tf cent.cap cent];
-    sub circumflex from [circumflex circumflexcomb.cap];
-    sub circumflexcomb.cap from [circumflexcomb.cap circumflex];
-    sub circumflexcomb_hookabovecomb from [circumflexcomb_hookabovecomb circumflexcomb_hookabovecomb.cap];
-    sub circumflexcomb_hookabovecomb.cap from [circumflexcomb_hookabovecomb.cap circumflexcomb_hookabovecomb];
-    sub colon from [colon colon.tf];
-    sub colon.tf from [colon.tf colon];
-    sub comma from [comma comma.tf comma.alt];
-    sub comma.alt from [comma.alt comma comma.tf];
-    sub comma.tf from [comma.tf comma.alt comma];
-    sub copyright from [copyright copyright.alt];
-    sub copyright.alt from [copyright.alt copyright];
-    sub currency from [currency currency.cap currency.tf];
-    sub currency.tf from [currency.tf currency currency.cap];
-    sub currency.cap from [currency.cap currency.tf currency];
-    sub degree from [degree degree.cap];
-    sub degree.cap from [degree.cap degree];
-    sub dieresis from [dieresis dieresiscomb.cap];
-    sub dieresiscomb.cap from [dieresiscomb.cap dieresis];
-    sub dieresistonos from [dieresistonos];
-    sub divide from [divide divide.tf];
-    sub divide.tf from [divide.tf divide];
-    sub dollar from [dollar dollar.tf dollar.cap];
-    sub dollar.cap from [dollar.cap dollar dollar.tf];
-    sub dollar.tf from [dollar.tf dollar.cap dollar];
-    sub dotaccent from [dotaccent dotaccentcomb dotaccentcomb.cap];
-    sub dotaccentcomb.cap from [dotaccentcomb.cap dotaccentcomb dotaccent];
-    sub e from [e e.logo];
-    sub e.logo from [e.logo e];
-    sub eight from [eight eight.tf eight.cap eight.numerator eight.denominator];
-    sub eight.denominator from [eight.denominator eight eight.tf eight.cap eight.numerator];
-    sub eight.numerator from [eight.numerator eight.denominator eight eight.tf eight.cap];
-    sub eight.cap from [eight.cap eight.numerator eight.denominator eight eight.tf];
-    sub eight.tf from [eight.tf eight.cap eight.numerator eight.denominator eight];
-    sub emdash from [emdash emdash.cap];
-    sub emdash.cap from [emdash.cap emdash];
-    sub endash from [endash endash.cap];
-    sub endash.cap from [endash.cap endash];
-    sub equal from [equal equal.tf];
-    sub equal.tf from [equal.tf equal];
-    sub exclamdown from [exclamdown exclamdown.cap];
-    sub exclamdown.cap from [exclamdown.cap exclamdown];
-    sub f_f_j from [f_f_j f_f_j.alt];
-    sub f_f_j.alt from [f_f_j.alt f_f_j];
-    sub f_f_k from [f_f_k f_f_k.alt];
-    sub f_f_k.alt from [f_f_k.alt f_f_k];
-    sub f_f_t from [f_f_t f_f_t.alt];
-    sub f_f_t.alt from [f_f_t.alt f_f_t];
-    sub f_j from [f_j f_j.alt];
-    sub f_j.alt from [f_j.alt f_j];
-    sub f_k from [f_k f_k.alt];
-    sub f_k.alt from [f_k.alt f_k];
-    sub f_t from [f_t f_t.alt];
-    sub f_t.alt from [f_t.alt f_t];
-    sub five from [five five.cap five.tf five.numerator five.denominator];
-    sub five.denominator from [five.denominator five five.cap five.tf five.numerator];
-    sub five.numerator from [five.numerator five.denominator five five.cap five.tf];
-    sub five.tf from [five.tf five.numerator five.denominator five five.cap];
-    sub five.cap from [five.cap five.tf five.numerator five.denominator five];
-    sub florin from [florin florin.tf];
-    sub florin.tf from [florin.tf florin];
-    sub four from [four four.cap four.tf four.denominator four.numerator];
-    sub four.numerator from [four.numerator four four.cap four.tf four.denominator];
-    sub four.denominator from [four.denominator four.numerator four four.cap four.tf];
-    sub four.tf from [four.tf four.denominator four.numerator four four.cap];
-    sub four.cap from [four.cap four.tf four.denominator four.numerator four];
-    sub g from [g g.logo];
-    sub g.logo from [g.logo g];
-    sub grave from [grave gravecomb gravecomb.cap];
-    sub gravecomb.cap from [gravecomb.cap grave];
-    sub greater from [greater greater.tf];
-    sub greater.tf from [greater.tf greater];
-    sub greaterequal from [greaterequal greaterequal.tf];
-    sub greaterequal.tf from [greaterequal.tf greaterequal];
-    sub guillemetleft from [guillemetleft guillemetleft.cap];
-    sub guillemetleft.cap from [guillemetleft.cap guillemetleft];
-    sub guillemetright from [guillemetright guillemetright.cap];
-    sub guillemetright.cap from [guillemetright.cap guillemetright];
-    sub guilsinglleft from [guilsinglleft guilsinglleft.cap];
-    sub guilsinglleft.cap from [guilsinglleft.cap guilsinglleft];
-    sub guilsinglright from [guilsinglright guilsinglright.cap];
-    sub guilsinglright.cap from [guilsinglright.cap guilsinglright];
-	sub hookabovecomb from [hookabovecomb hookabovecomb.cap];
-    sub hookabovecomb.cap from [hookabovecomb.cap hookabovecomb];
-	sub horncomb from [horncomb horncomb.cap];
-    sub horncomb.cap from [horncomb.cap horncomb];
-    sub hungarumlaut from [hungarumlaut hungarumlautcomb hungarumlautcomb.cap];
-    sub hungarumlautcomb.cap from [hungarumlautcomb.cap hungarumlautcomb hungarumlaut];
-    sub hyphen from [hyphen hyphen.cap];
-    sub hyphen.cap from [hyphen.cap hyphen];
-    sub j from [j j.alt];
-    sub j.alt from [j.alt j];
-    sub jdotless from [jdotless jdotless.alt];
-    sub jdotless.alt from [jdotless.alt jdotless];
-    sub jcircumflex from [jcircumflex jcircumflex.alt];    
-    sub jcircumflex.alt from [jcircumflex.alt jcircumflex];    
-    sub k from [k k.alt];
-    sub k.alt from [k.alt k];
-    sub kcommaaccent from [kcommaaccent kcommaaccent.alt];
-    sub kcommaaccent.alt from [kcommaaccent.alt kcommaaccent];
-    sub l from [l l.logo];
-    sub l.logo from [l.logo l];
-    sub less from [less less.tf];
-    sub less.tf from [less.tf less];
-    sub lessequal from [lessequal lessequal.tf];
-    sub lessequal.tf from [lessequal.tf lessequal];
-    sub logicalnot from [logicalnot logicalnot.tf];
-    sub logicalnot.tf from [logicalnot.tf logicalnot];
-    sub macron from [macron macroncomb macroncomb.cap];
-    sub macroncomb.cap from [macroncomb.cap macroncomb macron];
-    sub minus from [minus minus.tf];
-    sub minus.tf from [minus.tf minus];
-    sub multiply from [multiply multiply.tf];
-    sub multiply.tf from [multiply.tf multiply];
-    sub nine from [nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt];
-    sub nine.alt from [nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator];
-    sub nine.numerator from [nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf];
-    sub nine.tf from [nine.tf nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap];
-    sub nine.alt.cap from [nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator nine.cap];
-    sub nine.cap from [nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator];
-    sub nine.denominator from [nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine];
-    sub notequal from [notequal notequal.tf];
-    sub notequal.tf from [notequal.tf notequal];
-    sub numbersign from [numbersign numbersign.tf numbersign.cap];
-    sub numbersign.cap from [numbersign.cap numbersign numbersign.tf];
-    sub numbersign.tf from [numbersign.tf numbersign.cap numbersign];
-    sub o from [o o.logo];
-    sub o.logo from [o.logo o];
-    sub one from [one one.alt one.cap one.numerator one.alt.cap one.denominator one.tf];
-    sub one.tf from [one.tf one one.alt one.cap one.numerator one.alt.cap one.denominator];
-    sub one.denominator from [one.denominator one.tf one one.alt one.cap one.numerator one.alt.cap];
-    sub one.alt.cap from [one.alt.cap one.denominator one.tf one one.alt one.cap one.numerator];
-    sub one.numerator from [one.numerator one.alt.cap one.denominator one.tf one one.alt one.cap];
-    sub one.cap from [one.cap one.numerator one.alt.cap one.denominator one.tf one one.alt];
-    sub one.alt from [one.alt one.cap one.numerator one.alt.cap one.denominator one.tf one];
-    sub parenleft from [parenleft parenleft.cap];
-    sub parenleft.cap from [parenleft.cap parenleft];
-    sub parenright from [parenright parenright.cap];
-    sub parenright.cap from [parenright.cap parenright];
-    sub percent from [percent percent.cap percent.tf];
-    sub percent.tf from [percent.tf percent percent.cap];
-    sub percent.cap from [percent.cap percent.tf percent];
-    sub period from [period period.tf];
-    sub period.tf from [period.tf period];
-    sub pertenthousand from [pertenthousand pertenthousand.cap];
-    sub pertenthousand.cap from [pertenthousand.cap pertenthousand];
-    sub perthousand from [perthousand perthousand.cap];
-    sub perthousand.cap from [perthousand.cap perthousand];
-    sub plus from [plus plus.tf];
-    sub plus.tf from [plus.tf plus];
-    sub plusminus from [plusminus plusminus.tf];
-    sub plusminus.tf from [plusminus.tf plusminus];
-    sub q from [q q.alt];
-    sub q.alt from [q.alt q];
-    sub questiondown from [questiondown questiondown.cap];
-    sub questiondown.cap from [questiondown.cap questiondown];
-    sub quotedblbase from [quotedblbase quotedblbase.alt];
-    sub quotedblbase.alt from [quotedblbase.alt quotedblbase];
-    sub quotedblleft from [quotedblleft quotedblleft.alt];
-    sub quotedblleft.alt from [quotedblleft.alt quotedblleft];
-    sub quotedblright from [quotedblright quotedblright.alt];
-    sub quotedblright.alt from [quotedblright.alt quotedblright];
-    sub quoteleft from [quoteleft quoteleft.alt];
-    sub quoteleft.alt from [quoteleft.alt quoteleft];
-    sub quoteright from [quoteright quoteright.alt];
-    sub quoteright.alt from [quoteright.alt quoteright];
-    sub quotesinglbase from [quotesinglbase quotesinglbase.alt];
-    sub quotesinglbase.alt from [quotesinglbase.alt quotesinglbase];
-    sub r from [r r.alt];
-    sub r.alt from [r.alt r];
-    sub r_t from [r_t r_t.alt];
-    sub r_t.alt from [r_t.alt r_t];
-    sub racute from [racute racute.alt];
-    sub racute.alt from [racute.alt racute];
-    sub rcaron from [rcaron rcaron.alt];
-    sub rcaron.alt from [rcaron.alt rcaron];
-    sub rcommaaccent from [rcommaaccent rcommaaccent.alt];
-    sub rcommaaccent.alt from [rcommaaccent.alt rcommaaccent];
-    sub registered from [registered registered.alt];
-    sub registered.alt from [registered.alt registered];
-    sub ring from [ring ringcomb ringcomb.cap];
-    sub ringcomb.cap from [ringcomb.cap ringcomb ring];
-    sub scedilla from [scedilla scedilla.alt];
-    sub scedilla.alt from [scedilla.alt scedilla];
-    sub section from [section section.tf];
-    sub section.tf from [section.tf section];
-    sub semicolon from [semicolon semicolon.tf semicolon.alt];
-    sub semicolon.alt from [semicolon.alt semicolon semicolon.tf];
-    sub semicolon.tf from [semicolon.tf semicolon.alt semicolon];
-    sub seven from [seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator];
-    sub seven.denominator from [seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf];
-    sub seven.tf from [seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator];
-    sub seven.numerator from [seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt];
-    sub seven.alt from [seven.alt seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap];
-    sub seven.alt.cap from [seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven seven.cap];
-    sub seven.cap from [seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven];
-    sub six from [six six.numerator six.alt.cap six.cap six.tf six.denominator six.alt];
-    sub six.alt from [six.alt six six.numerator six.alt.cap six.cap six.tf six.denominator];
-    sub six.denominator from [six.denominator six.alt six six.numerator six.alt.cap six.cap six.tf];
-    sub six.tf from [six.tf six.denominator six.alt six six.numerator six.alt.cap six.cap];
-    sub six.cap from [six.cap six.tf six.denominator six.alt six six.numerator six.alt.cap];
-    sub six.alt.cap from [six.alt.cap six.cap six.tf six.denominator six.alt six six.numerator];
-    sub six.numerator from [six.numerator six.alt.cap six.cap six.tf six.denominator six.alt six];
-    sub space from [space space.tf];
-    sub space.tf from [space.tf space];
-    sub sterling from [sterling sterling.cap sterling.tf];
-    sub sterling.tf from [sterling.tf sterling sterling.cap];
-    sub sterling.cap from [sterling.cap sterling.tf sterling];
-    sub t from [t t.alt];
-    sub t.alt from [t.alt t];
-    sub tcedilla from [tcedilla tcedilla.alt tcedilla.alt.2];
-    sub tcedilla.alt from [tcedilla.alt tcedilla tcedilla.alt.2];
-    sub tcedilla.alt.2 from [tcedilla.alt.2 tcedilla.alt tcedilla];
-    sub tcommaaccent from [tcommaaccent tcommaaccent.alt];
-    sub tcommaaccent.alt from [tcommaaccent.alt tcommaaccent];
-    sub t_f from [t_f t_f.alt];
-    sub t_f.alt from [t_f.alt t_f];
-    sub t_t from [t_t t_t.alt];
-    sub t_t.alt from [t_t.alt t_t];
-    sub tbar from [tbar tbar.alt];
-    sub tbar.alt from [tbar.alt tbar];
-    sub tcaron from [tcaron tcaron.alt];
-    sub tcaron.alt from [tcaron.alt tcaron];
-    sub three from [three three.denominator three.numerator three.tf three.cap];
-    sub three.cap from [three.cap three three.denominator three.numerator three.tf];
-    sub three.tf from [three.tf three.cap three three.denominator three.numerator];
-    sub three.numerator from [three.numerator three.tf three.cap three three.denominator];
-    sub three.denominator from [three.denominator three.numerator three.tf three.cap three];
-    sub tilde from [tilde tildecomb tildecomb.cap];
-    sub tildecomb.cap from [tildecomb.cap tildecomb tilde];
-    sub trademark from [trademark trademark.alt2 trademark.alt trademark.alt3];
-    sub trademark.alt3 from [trademark.alt3 trademark trademark.alt2 trademark.alt];
-    sub trademark.alt from [trademark.alt trademark.alt3 trademark trademark.alt2];
-    sub trademark.alt2 from [trademark.alt2 trademark.alt trademark.alt3 trademark];
-    sub two from [two two.cap two.denominator two.tf two.numerator];
-    sub two.numerator from [two.numerator two two.cap two.denominator two.tf];
-    sub two.tf from [two.tf two.numerator two two.cap two.denominator];
-    sub two.denominator from [two.denominator two.tf two.numerator two two.cap];
-    sub two.cap from [two.cap two.denominator two.tf two.numerator two];
-    sub baht from [baht baht.cap];
-    sub baht.cap from [baht.cap baht];
-    sub franc from [franc franc.tf franc.cap];
-    sub franc.cap from [franc.cap franc franc.tf];
-    sub franc.tf from [franc.tf franc.cap franc];
-    sub lira from [lira lira.cap lira.tf];
-    sub lira.tf from [lira.tf lira lira.cap];
-    sub lira.cap from [lira.cap lira.tf lira];
-    sub won from [won won.tf won.cap];
-    sub won.cap from [won.cap won won.tf];
-    sub won.tf from [won.tf won.cap won];
-    sub dong from [dong dong.tf dong.cap];
-    sub dong.cap from [dong.cap dong dong.tf];
-    sub dong.tf from [dong.tf dong.cap dong];
-    sub tugrik from [tugrik tugrik.tf tugrik.cap];
-    sub tugrik.cap from [tugrik.cap tugrik tugrik.tf];
-    sub tugrik.tf from [tugrik.tf tugrik.cap tugrik];
-    sub peso from [peso peso.cap peso.tf];
-    sub peso.tf from [peso.tf peso peso.cap];
-    sub peso.cap from [peso.cap peso.tf peso];
-    sub tenge from [tenge tenge.cap tenge.tf];
-    sub tenge.tf from [tenge.tf tenge tenge.cap];
-    sub tenge.cap from [tenge.cap tenge.tf tenge];
-    sub rupeeIndian from [rupeeIndian rupeeIndian.cap rupeeIndian.tf];
-    sub rupeeIndian.tf from [rupeeIndian.tf rupeeIndian rupeeIndian.cap];
-    sub rupeeIndian.cap from [rupeeIndian.cap rupeeIndian.tf rupeeIndian];
-    sub liraTurkish from [liraTurkish liraTurkish.cap liraTurkish.tf];
-    sub liraTurkish.tf from [liraTurkish.tf liraTurkish liraTurkish.cap];
-    sub liraTurkish.cap from [liraTurkish.cap liraTurkish.tf liraTurkish];
-    sub ruble from [ruble ruble.cap ruble.tf];
-    sub ruble.tf from [ruble.tf ruble ruble.cap];
-    sub ruble.cap from [ruble.cap ruble.tf ruble];
-    sub centigrade from [centigrade centigrade.cap];
-    sub centigrade.cap from [centigrade.cap centigrade];
-    sub fahrenheit from [fahrenheit fahrenheit.cap];
-    sub fahrenheit.cap from [fahrenheit.cap fahrenheit];
-    sub published from [published published.alt];
-    sub published.alt from [published.alt published];
-    sub servicemark from [servicemark servicemark.alt3 servicemark.alt servicemark.alt2];
-    sub servicemark.alt2 from [servicemark.alt2 servicemark servicemark.alt3 servicemark.alt];
-    sub servicemark.alt from [servicemark.alt servicemark.alt2 servicemark servicemark.alt3];
-    sub servicemark.alt3 from [servicemark.alt3 servicemark.alt servicemark.alt2 servicemark];
-    sub y from [y y.alt];
-    sub y.alt from [y.alt y];
-    sub yacute from [yacute yacute.alt];
-    sub yacute.alt from [yacute.alt yacute];
-    sub ycircumflex from [ycircumflex ycircumflex.alt];
-    sub ycircumflex.alt from [ycircumflex.alt ycircumflex];
-    sub ydieresis from [ydieresis ydieresis.alt];
-    sub ydieresis.alt from [ydieresis.alt ydieresis];
-    sub ydotbelow from [ydotbelow ydotbelow.alt];
-    sub ydotbelow.alt from [ydotbelow.alt ydotbelow];
-    sub yhookabove from [yhookabove yhookabove.alt];
-    sub yhookabove.alt from [yhookabove.alt yhookabove];
-    sub ytilde from [ytilde ytilde.alt];
-    sub ytilde.alt from [ytilde.alt ytilde];
-    sub yen from [yen yen.tf yen.cap];
-    sub yen.cap from [yen.cap yen yen.tf];
-    sub yen.tf from [yen.tf yen.cap yen];
-    sub ygrave from [ygrave ygrave.alt];
-    sub ygrave.alt from [ygrave.alt ygrave];
-    sub zero from [zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf];
-    sub zero.tf from [zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator];
-    sub zero.numerator from [zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt];
-    sub zero.alt from [zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator];
-    sub zero.denominator from [zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap];
-    sub zero.cap from [zero.cap zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap];
-    sub zero.alt.cap from [zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf zero];
-    
-    # ==============
-    # END LATIN
-    # ==============
-    
-    # ==============
-    # BEGIN HEBREW
-    # ==============
-    
-    feature jalt;
-    
-    # ==============
-    # END HEBREW
-    # ==============";
+code = "    # ==============\012    # BEGIN LATIN\012    # ==============\012    \012    sub Ccedilla from [Ccedilla Ccedilla.alt];\012    sub Ccedilla.alt from [Ccedilla.alt Ccedilla];\012    sub euro from [euro euro.cap euro.tf];\012    sub euro.tf from [euro.tf euro euro.cap];\012    sub euro.cap from [euro.cap euro.tf euro];\012    sub G from [G G.alt G.logo];\012    sub G.logo from [G.logo G G.alt];\012    sub G.alt from [G.alt G.logo G];\012    sub Gbreve from [Gbreve Gbreve.alt];\012    sub Gbreve.alt from [Gbreve.alt Gbreve];\012    sub Gcircumflex from [Gcircumflex Gcircumflex.alt];\012    sub Gcircumflex.alt from [Gcircumflex.alt Gcircumflex];\012    sub Gdotaccent from [Gdotaccent Gdotaccent.alt];\012    sub Gdotaccent.alt from [Gdotaccent.alt Gdotaccent];\012    sub Gcommaaccent from [Gcommaaccent Gcommaaccent.alt];\012    sub Gcommaaccent.alt from [Gcommaaccent.alt Gcommaaccent];\012    sub I from [I I.alt];\012    sub I.alt from [I.alt I];\012    sub Iacute from [Iacute Iacute.alt];\012    sub Iacute.alt from [Iacute.alt Iacute];\012    sub Ibreve from [Ibreve Ibreve.alt];\012    sub Ibreve.alt from [Ibreve.alt Ibreve];\012    sub Icircumflex from [Icircumflex Icircumflex.alt];\012    sub Icircumflex.alt from [Icircumflex.alt Icircumflex];\012    sub Idieresis from [Idieresis Idieresis.alt];\012    sub Idieresis.alt from [Idieresis.alt Idieresis];\012    sub Idotaccent from [Idotaccent Idotaccent.alt];\012    sub Idotaccent.alt from [Idotaccent.alt Idotaccent];\012    sub Igrave from [Igrave Igrave.alt];\012    sub Igrave.alt from [Igrave.alt Igrave];\012    sub Imacron from [Imacron Imacron.alt];\012    sub Imacron.alt from [Imacron.alt Imacron];\012    sub Iogonek from [Iogonek Iogonek.alt];\012    sub Iogonek.alt from [Iogonek.alt Iogonek];\012    sub Itilde from [Itilde Itilde.alt];\012    sub Itilde.alt from [Itilde.alt Itilde];\012    sub J from [J J.alt];\012    sub J.alt from [J.alt J];\012    sub Jcircumflex from [Jcircumflex Jcircumflex.alt];\012    sub Jcircumflex.alt from [Jcircumflex.alt Jcircumflex];\012    sub K from [K K.alt];\012    sub K.alt from [K.alt K];\012    sub Kcommaaccent from [Kcommaaccent Kcommaaccent.alt];\012    sub Kcommaaccent.alt from [Kcommaaccent.alt Kcommaaccent];\012    sub M from [M M.alt];\012    sub M.alt from [M.alt M];\012    sub Q from [Q Q.alt];\012    sub Q.alt from [Q.alt Q];\012    sub R from [R R.alt];\012    sub R.alt from [R.alt R];\012    sub Racute from [Racute Racute.alt];\012    sub Racute.alt from [Racute.alt Racute];\012    sub Rcaron from [Rcaron Rcaron.alt];\012    sub Rcaron.alt from [Rcaron.alt Rcaron];\012    sub Rcommaaccent from [Rcommaaccent Rcommaaccent.alt];\012    sub Rcommaaccent.alt from [Rcommaaccent.alt Rcommaaccent];    \012    sub Scedilla from [Scedilla Scedilla.alt];\012    sub Scedilla.alt from [Scedilla.alt Scedilla];\012    sub W from [W W.alt];\012    sub W.alt from [W.alt W];\012    sub Wacute from [Wacute Wacute.alt];\012    sub Wacute.alt from [Wacute.alt Wacute];\012    sub Wcircumflex from [Wcircumflex Wcircumflex.alt];\012    sub Wcircumflex.alt from [Wcircumflex.alt Wcircumflex];\012    sub Wdieresis from [Wdieresis Wdieresis.alt];\012    sub Wdieresis.alt from [Wdieresis.alt Wdieresis];\012    sub Wgrave from [Wgrave Wgrave.alt];\012    sub Wgrave.alt from [Wgrave.alt Wgrave];\012    sub a from [a a.alt];\012    sub a.alt from [a.alt a];\012    sub aacute from [aacute aacute.alt];\012    sub aacute.alt from [aacute.alt aacute];\012    sub abreve from [abreve abreve.alt];\012    sub abreve.alt from [abreve.alt abreve];\012    sub acircumflex from [acircumflex acircumflex.alt];\012    sub acircumflex.alt from [acircumflex.alt acircumflex];\012    sub acutecomb from [acutecomb acutecomb.cap];\012    sub acutecomb.cap from [acutecomb.cap acute];\012    sub adieresis from [adieresis adieresis.alt];\012    sub adieresis.alt from [adieresis.alt adieresis];\012    sub ae from [ae ae.alt];\012    sub ae.alt from [ae.alt ae];\012    sub aeacute from [aeacute aeacute.alt];\012    sub aeacute.alt from [aeacute.alt aeacute];\012    sub agrave from [agrave agrave.alt];\012    sub agrave.alt from [agrave.alt agrave];\012    sub amacron from [amacron amacron.alt];\012    sub amacron.alt from [amacron.alt amacron];\012    sub ampersand from [ampersand ampersand.alt];\012    sub ampersand.alt from [ampersand.alt ampersand];\012    sub aogonek from [aogonek aogonek.alt];\012    sub aogonek.alt from [aogonek.alt aogonek];\012    sub adotbelow from [adotbelow adotbelow.alt];\012    sub adotbelow.alt from [adotbelow.alt adotbelow];\012    sub ahookabove from [ahookabove ahookabove.alt];\012    sub ahookabove.alt from [ahookabove.alt ahookabove];\012    sub acircumflexacute from [acircumflexacute acircumflexacute.alt];\012    sub acircumflexacute.alt from [acircumflexacute.alt acircumflexacute];\012    sub acircumflexgrave from [acircumflexgrave acircumflexgrave.alt];\012    sub acircumflexgrave.alt from [acircumflexgrave.alt acircumflexgrave];\012	sub acircumflexhookabove from [acircumflexhookabove acircumflexhookabove.alt];\012    sub acircumflexhookabove.alt from [acircumflexhookabove.alt acircumflexhookabove];\012    sub acircumflextilde from [acircumflextilde acircumflextilde.alt];\012    sub acircumflextilde.alt from [acircumflextilde.alt acircumflextilde];    \012    sub acircumflexdotbelow from [acircumflexdotbelow acircumflexdotbelow.alt];\012    sub acircumflexdotbelow.alt from [acircumflexdotbelow.alt acircumflexdotbelow];\012    sub abreveacute from [abreveacute abreveacute.alt];\012    sub abreveacute.alt from [abreveacute.alt abreveacute];\012    sub abrevegrave from [abrevegrave abrevegrave.alt];\012    sub abrevegrave.alt from [abrevegrave.alt abrevegrave];\012    sub abrevehookabove from [abrevehookabove abrevehookabove.alt];\012    sub abrevehookabove.alt from [abrevehookabove.alt abrevehookabove];\012    sub abrevetilde from [abrevetilde abrevetilde.alt];\012    sub abrevetilde.alt from [abrevetilde.alt abrevetilde];\012    sub abrevedotbelow from [abrevedotbelow abrevedotbelow.alt];\012    sub abrevedotbelow.alt from [abrevedotbelow.alt abrevedotbelow];\012    sub quoteright from [quoteright quoteright.alt];\012    sub quoteright.alt from [quoteright.alt quoteright];\012    sub approxequal from [approxequal approxequal.tf];\012    sub approxequal.tf from [approxequal.tf approxequal];\012    sub aring from [aring aring.alt];\012    sub aring.alt from [aring.alt aring];\012    sub aringacute from [aringacute aringacute.alt];\012    sub aringacute.alt from [aringacute.alt aringacute];\012    sub at from [at at.cap];\012    sub at.cap from [at.cap at];\012    sub atilde from [atilde atilde.alt];\012    sub atilde.alt from [atilde.alt atilde];\012    sub braceleft from [braceleft braceleft.cap];\012    sub braceleft.cap from [braceleft.cap braceleft];\012    sub braceright from [braceright braceright.cap];\012    sub braceright.cap from [braceright.cap braceright];\012    sub bracketleft from [bracketleft bracketleft.cap];\012    sub bracketleft.cap from [bracketleft.cap bracketleft];\012    sub bracketright from [bracketright bracketright.cap];\012    sub bracketright.cap from [bracketright.cap bracketright];\012    sub brevecomb from [brevecomb brevecomb.cap];\012    sub brevecomb.cap from [brevecomb.cap brevecomb];\012    sub brevecombcy from [brevecombcy brevecombcy.cap brevecombcy.sc];\012    sub brevecombcy.cap from [brevecombcy.cap brevecombcy brevecombcy.sc];\012    sub brevecombcy.sc from [brevecombcy.sc brevecombcy brevecombcy.cap]; \012    sub brevecomb_hookabovecomb from [brevecomb_hookabovecomb brevecomb_hookabovecomb.cap];\012    sub brevecomb_hookabovecomb.cap from [brevecomb_hookabovecomb.cap brevecomb_hookabovecomb];\012    sub bullet from [bullet bullet.cap];\012    sub bullet.cap from [bullet.cap bullet];\012    sub caroncomb from [caroncomb caron.alt caroncomb.cap];\012    sub caroncomb.cap from [caroncomb.cap caron caroncomb.alt];\012    sub caroncomb.alt from [caroncomb.alt caroncomb.alt.cap];    \012    sub caroncomb.alt.cap from [caroncomb.alt.cap caroncomb.alt];\012    sub caron.alt from [caron.alt caroncomb.cap caron];\012    sub ccedilla from [ccedilla ccedilla.alt];\012    sub ccedilla.alt from [ccedilla.alt ccedilla];\012    sub cedilla from [cedilla cedilla.alt];\012    sub cedilla.alt from [cedilla.alt cedilla];\012    sub cedillacomb from [cedillacomb cedillacomb.alt];\012    sub cedillacomb.alt from [cedillacomb.alt cedillacomb];\012    sub cent from [cent cent.tf cent.cap];\012    sub cent.cap from [cent.cap cent cent.tf];\012    sub cent.tf from [cent.tf cent.cap cent];\012    sub circumflex from [circumflex circumflexcomb.cap];\012    sub circumflexcomb.cap from [circumflexcomb.cap circumflex];\012    sub circumflexcomb_hookabovecomb from [circumflexcomb_hookabovecomb circumflexcomb_hookabovecomb.cap];\012    sub circumflexcomb_hookabovecomb.cap from [circumflexcomb_hookabovecomb.cap circumflexcomb_hookabovecomb];\012    sub colon from [colon colon.tf];\012    sub colon.tf from [colon.tf colon];\012    sub comma from [comma comma.tf comma.alt];\012    sub comma.alt from [comma.alt comma comma.tf];\012    sub comma.tf from [comma.tf comma.alt comma];\012    sub copyright from [copyright copyright.alt];\012    sub copyright.alt from [copyright.alt copyright];\012    sub currency from [currency currency.cap currency.tf];\012    sub currency.tf from [currency.tf currency currency.cap];\012    sub currency.cap from [currency.cap currency.tf currency];\012    sub degree from [degree degree.cap];\012    sub degree.cap from [degree.cap degree];\012    sub dieresis from [dieresis dieresiscomb.cap];\012    sub dieresiscomb.cap from [dieresiscomb.cap dieresis];\012    sub dieresistonos from [dieresistonos];\012    sub divide from [divide divide.tf];\012    sub divide.tf from [divide.tf divide];\012    sub dollar from [dollar dollar.tf dollar.cap];\012    sub dollar.cap from [dollar.cap dollar dollar.tf];\012    sub dollar.tf from [dollar.tf dollar.cap dollar];\012    sub dotaccent from [dotaccent dotaccentcomb dotaccentcomb.cap];\012    sub dotaccentcomb.cap from [dotaccentcomb.cap dotaccentcomb dotaccent];\012    sub e from [e e.logo];\012    sub e.logo from [e.logo e];\012    sub eight from [eight eight.tf eight.cap eight.numerator eight.denominator];\012    sub eight.denominator from [eight.denominator eight eight.tf eight.cap eight.numerator];\012    sub eight.numerator from [eight.numerator eight.denominator eight eight.tf eight.cap];\012    sub eight.cap from [eight.cap eight.numerator eight.denominator eight eight.tf];\012    sub eight.tf from [eight.tf eight.cap eight.numerator eight.denominator eight];\012    sub emdash from [emdash emdash.cap];\012    sub emdash.cap from [emdash.cap emdash];\012    sub endash from [endash endash.cap];\012    sub endash.cap from [endash.cap endash];\012    sub equal from [equal equal.tf];\012    sub equal.tf from [equal.tf equal];\012    sub exclamdown from [exclamdown exclamdown.cap];\012    sub exclamdown.cap from [exclamdown.cap exclamdown];\012    sub f_f_j from [f_f_j f_f_j.alt];\012    sub f_f_j.alt from [f_f_j.alt f_f_j];\012    sub f_f_k from [f_f_k f_f_k.alt];\012    sub f_f_k.alt from [f_f_k.alt f_f_k];\012    sub f_f_t from [f_f_t f_f_t.alt];\012    sub f_f_t.alt from [f_f_t.alt f_f_t];\012    sub f_j from [f_j f_j.alt];\012    sub f_j.alt from [f_j.alt f_j];\012    sub f_k from [f_k f_k.alt];\012    sub f_k.alt from [f_k.alt f_k];\012    sub f_t from [f_t f_t.alt];\012    sub f_t.alt from [f_t.alt f_t];\012    sub five from [five five.cap five.tf five.numerator five.denominator];\012    sub five.denominator from [five.denominator five five.cap five.tf five.numerator];\012    sub five.numerator from [five.numerator five.denominator five five.cap five.tf];\012    sub five.tf from [five.tf five.numerator five.denominator five five.cap];\012    sub five.cap from [five.cap five.tf five.numerator five.denominator five];\012    sub florin from [florin florin.tf];\012    sub florin.tf from [florin.tf florin];\012    sub four from [four four.cap four.tf four.denominator four.numerator];\012    sub four.numerator from [four.numerator four four.cap four.tf four.denominator];\012    sub four.denominator from [four.denominator four.numerator four four.cap four.tf];\012    sub four.tf from [four.tf four.denominator four.numerator four four.cap];\012    sub four.cap from [four.cap four.tf four.denominator four.numerator four];\012    sub g from [g g.logo];\012    sub g.logo from [g.logo g];\012    sub grave from [grave gravecomb gravecomb.cap];\012    sub gravecomb.cap from [gravecomb.cap grave];\012    sub greater from [greater greater.tf];\012    sub greater.tf from [greater.tf greater];\012    sub greaterequal from [greaterequal greaterequal.tf];\012    sub greaterequal.tf from [greaterequal.tf greaterequal];\012    sub guillemetleft from [guillemetleft guillemetleft.cap];\012    sub guillemetleft.cap from [guillemetleft.cap guillemetleft];\012    sub guillemetright from [guillemetright guillemetright.cap];\012    sub guillemetright.cap from [guillemetright.cap guillemetright];\012    sub guilsinglleft from [guilsinglleft guilsinglleft.cap];\012    sub guilsinglleft.cap from [guilsinglleft.cap guilsinglleft];\012    sub guilsinglright from [guilsinglright guilsinglright.cap];\012    sub guilsinglright.cap from [guilsinglright.cap guilsinglright];\012	sub hookabovecomb from [hookabovecomb hookabovecomb.cap];\012    sub hookabovecomb.cap from [hookabovecomb.cap hookabovecomb];\012	sub horncomb from [horncomb horncomb.cap];\012    sub horncomb.cap from [horncomb.cap horncomb];\012    sub hungarumlaut from [hungarumlaut hungarumlautcomb hungarumlautcomb.cap];\012    sub hungarumlautcomb.cap from [hungarumlautcomb.cap hungarumlautcomb hungarumlaut];\012    sub hyphen from [hyphen hyphen.cap];\012    sub hyphen.cap from [hyphen.cap hyphen];\012    sub j from [j j.alt];\012    sub j.alt from [j.alt j];\012    sub jdotless from [jdotless jdotless.alt];\012    sub jdotless.alt from [jdotless.alt jdotless];\012    sub jcircumflex from [jcircumflex jcircumflex.alt];    \012    sub jcircumflex.alt from [jcircumflex.alt jcircumflex];    \012    sub k from [k k.alt];\012    sub k.alt from [k.alt k];\012    sub kcommaaccent from [kcommaaccent kcommaaccent.alt];\012    sub kcommaaccent.alt from [kcommaaccent.alt kcommaaccent];\012    sub l from [l l.logo];\012    sub l.logo from [l.logo l];\012    sub less from [less less.tf];\012    sub less.tf from [less.tf less];\012    sub lessequal from [lessequal lessequal.tf];\012    sub lessequal.tf from [lessequal.tf lessequal];\012    sub logicalnot from [logicalnot logicalnot.tf];\012    sub logicalnot.tf from [logicalnot.tf logicalnot];\012    sub macron from [macron macroncomb macroncomb.cap];\012    sub macroncomb.cap from [macroncomb.cap macroncomb macron];\012    sub minus from [minus minus.tf];\012    sub minus.tf from [minus.tf minus];\012    sub multiply from [multiply multiply.tf];\012    sub multiply.tf from [multiply.tf multiply];\012    sub nine from [nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt];\012    sub nine.alt from [nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator];\012    sub nine.numerator from [nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap nine.tf];\012    sub nine.tf from [nine.tf nine.numerator nine.alt nine nine.denominator nine.cap nine.alt.cap];\012    sub nine.alt.cap from [nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator nine.cap];\012    sub nine.cap from [nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine nine.denominator];\012    sub nine.denominator from [nine.denominator nine.cap nine.alt.cap nine.tf nine.numerator nine.alt nine];\012    sub notequal from [notequal notequal.tf];\012    sub notequal.tf from [notequal.tf notequal];\012    sub numbersign from [numbersign numbersign.tf numbersign.cap];\012    sub numbersign.cap from [numbersign.cap numbersign numbersign.tf];\012    sub numbersign.tf from [numbersign.tf numbersign.cap numbersign];\012    sub o from [o o.logo];\012    sub o.logo from [o.logo o];\012    sub one from [one one.alt one.cap one.numerator one.alt.cap one.denominator one.tf];\012    sub one.tf from [one.tf one one.alt one.cap one.numerator one.alt.cap one.denominator];\012    sub one.denominator from [one.denominator one.tf one one.alt one.cap one.numerator one.alt.cap];\012    sub one.alt.cap from [one.alt.cap one.denominator one.tf one one.alt one.cap one.numerator];\012    sub one.numerator from [one.numerator one.alt.cap one.denominator one.tf one one.alt one.cap];\012    sub one.cap from [one.cap one.numerator one.alt.cap one.denominator one.tf one one.alt];\012    sub one.alt from [one.alt one.cap one.numerator one.alt.cap one.denominator one.tf one];\012    sub parenleft from [parenleft parenleft.cap];\012    sub parenleft.cap from [parenleft.cap parenleft];\012    sub parenright from [parenright parenright.cap];\012    sub parenright.cap from [parenright.cap parenright];\012    sub percent from [percent percent.cap percent.tf];\012    sub percent.tf from [percent.tf percent percent.cap];\012    sub percent.cap from [percent.cap percent.tf percent];\012    sub period from [period period.tf];\012    sub period.tf from [period.tf period];\012    sub pertenthousand from [pertenthousand pertenthousand.cap];\012    sub pertenthousand.cap from [pertenthousand.cap pertenthousand];\012    sub perthousand from [perthousand perthousand.cap];\012    sub perthousand.cap from [perthousand.cap perthousand];\012    sub plus from [plus plus.tf];\012    sub plus.tf from [plus.tf plus];\012    sub plusminus from [plusminus plusminus.tf];\012    sub plusminus.tf from [plusminus.tf plusminus];\012    sub q from [q q.alt];\012    sub q.alt from [q.alt q];\012    sub questiondown from [questiondown questiondown.cap];\012    sub questiondown.cap from [questiondown.cap questiondown];\012    sub quotedblbase from [quotedblbase quotedblbase.alt];\012    sub quotedblbase.alt from [quotedblbase.alt quotedblbase];\012    sub quotedblleft from [quotedblleft quotedblleft.alt];\012    sub quotedblleft.alt from [quotedblleft.alt quotedblleft];\012    sub quotedblright from [quotedblright quotedblright.alt];\012    sub quotedblright.alt from [quotedblright.alt quotedblright];\012    sub quoteleft from [quoteleft quoteleft.alt];\012    sub quoteleft.alt from [quoteleft.alt quoteleft];\012    sub quoteright from [quoteright quoteright.alt];\012    sub quoteright.alt from [quoteright.alt quoteright];\012    sub quotesinglbase from [quotesinglbase quotesinglbase.alt];\012    sub quotesinglbase.alt from [quotesinglbase.alt quotesinglbase];\012    sub r from [r r.alt];\012    sub r.alt from [r.alt r];\012    sub r_t from [r_t r_t.alt];\012    sub r_t.alt from [r_t.alt r_t];\012    sub racute from [racute racute.alt];\012    sub racute.alt from [racute.alt racute];\012    sub rcaron from [rcaron rcaron.alt];\012    sub rcaron.alt from [rcaron.alt rcaron];\012    sub rcommaaccent from [rcommaaccent rcommaaccent.alt];\012    sub rcommaaccent.alt from [rcommaaccent.alt rcommaaccent];\012    sub registered from [registered registered.alt];\012    sub registered.alt from [registered.alt registered];\012    sub ring from [ring ringcomb ringcomb.cap];\012    sub ringcomb.cap from [ringcomb.cap ringcomb ring];\012    sub scedilla from [scedilla scedilla.alt];\012    sub scedilla.alt from [scedilla.alt scedilla];\012    sub section from [section section.tf];\012    sub section.tf from [section.tf section];\012    sub semicolon from [semicolon semicolon.tf semicolon.alt];\012    sub semicolon.alt from [semicolon.alt semicolon semicolon.tf];\012    sub semicolon.tf from [semicolon.tf semicolon.alt semicolon];\012    sub seven from [seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator];\012    sub seven.denominator from [seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator seven.tf];\012    sub seven.tf from [seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt seven.numerator];\012    sub seven.numerator from [seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap seven.alt];\012    sub seven.alt from [seven.alt seven.numerator seven.tf seven.denominator seven seven.cap seven.alt.cap];\012    sub seven.alt.cap from [seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven seven.cap];\012    sub seven.cap from [seven.cap seven.alt.cap seven.alt seven.numerator seven.tf seven.denominator seven];\012    sub six from [six six.numerator six.alt.cap six.cap six.tf six.denominator six.alt];\012    sub six.alt from [six.alt six six.numerator six.alt.cap six.cap six.tf six.denominator];\012    sub six.denominator from [six.denominator six.alt six six.numerator six.alt.cap six.cap six.tf];\012    sub six.tf from [six.tf six.denominator six.alt six six.numerator six.alt.cap six.cap];\012    sub six.cap from [six.cap six.tf six.denominator six.alt six six.numerator six.alt.cap];\012    sub six.alt.cap from [six.alt.cap six.cap six.tf six.denominator six.alt six six.numerator];\012    sub six.numerator from [six.numerator six.alt.cap six.cap six.tf six.denominator six.alt six];\012    sub space from [space space.tf];\012    sub space.tf from [space.tf space];\012    sub sterling from [sterling sterling.cap sterling.tf];\012    sub sterling.tf from [sterling.tf sterling sterling.cap];\012    sub sterling.cap from [sterling.cap sterling.tf sterling];\012    sub t from [t t.alt];\012    sub t.alt from [t.alt t];\012    sub tcedilla from [tcedilla tcedilla.alt tcedilla.alt.2];\012    sub tcedilla.alt from [tcedilla.alt tcedilla tcedilla.alt.2];\012    sub tcedilla.alt.2 from [tcedilla.alt.2 tcedilla.alt tcedilla];\012    sub tcommaaccent from [tcommaaccent tcommaaccent.alt];\012    sub tcommaaccent.alt from [tcommaaccent.alt tcommaaccent];\012    sub t_f from [t_f t_f.alt];\012    sub t_f.alt from [t_f.alt t_f];\012    sub t_t from [t_t t_t.alt];\012    sub t_t.alt from [t_t.alt t_t];\012    sub tbar from [tbar tbar.alt];\012    sub tbar.alt from [tbar.alt tbar];\012    sub tcaron from [tcaron tcaron.alt];\012    sub tcaron.alt from [tcaron.alt tcaron];\012    sub three from [three three.denominator three.numerator three.tf three.cap];\012    sub three.cap from [three.cap three three.denominator three.numerator three.tf];\012    sub three.tf from [three.tf three.cap three three.denominator three.numerator];\012    sub three.numerator from [three.numerator three.tf three.cap three three.denominator];\012    sub three.denominator from [three.denominator three.numerator three.tf three.cap three];\012    sub tilde from [tilde tildecomb tildecomb.cap];\012    sub tildecomb.cap from [tildecomb.cap tildecomb tilde];\012    sub trademark from [trademark trademark.alt2 trademark.alt trademark.alt3];\012    sub trademark.alt3 from [trademark.alt3 trademark trademark.alt2 trademark.alt];\012    sub trademark.alt from [trademark.alt trademark.alt3 trademark trademark.alt2];\012    sub trademark.alt2 from [trademark.alt2 trademark.alt trademark.alt3 trademark];\012    sub two from [two two.cap two.denominator two.tf two.numerator];\012    sub two.numerator from [two.numerator two two.cap two.denominator two.tf];\012    sub two.tf from [two.tf two.numerator two two.cap two.denominator];\012    sub two.denominator from [two.denominator two.tf two.numerator two two.cap];\012    sub two.cap from [two.cap two.denominator two.tf two.numerator two];\012    sub baht from [baht baht.cap];\012    sub baht.cap from [baht.cap baht];\012    sub franc from [franc franc.tf franc.cap];\012    sub franc.cap from [franc.cap franc franc.tf];\012    sub franc.tf from [franc.tf franc.cap franc];\012    sub lira from [lira lira.cap lira.tf];\012    sub lira.tf from [lira.tf lira lira.cap];\012    sub lira.cap from [lira.cap lira.tf lira];\012    sub won from [won won.tf won.cap];\012    sub won.cap from [won.cap won won.tf];\012    sub won.tf from [won.tf won.cap won];\012    sub dong from [dong dong.tf dong.cap];\012    sub dong.cap from [dong.cap dong dong.tf];\012    sub dong.tf from [dong.tf dong.cap dong];\012    sub tugrik from [tugrik tugrik.tf tugrik.cap];\012    sub tugrik.cap from [tugrik.cap tugrik tugrik.tf];\012    sub tugrik.tf from [tugrik.tf tugrik.cap tugrik];\012    sub peso from [peso peso.cap peso.tf];\012    sub peso.tf from [peso.tf peso peso.cap];\012    sub peso.cap from [peso.cap peso.tf peso];\012    sub tenge from [tenge tenge.cap tenge.tf];\012    sub tenge.tf from [tenge.tf tenge tenge.cap];\012    sub tenge.cap from [tenge.cap tenge.tf tenge];\012    sub rupeeIndian from [rupeeIndian rupeeIndian.cap rupeeIndian.tf];\012    sub rupeeIndian.tf from [rupeeIndian.tf rupeeIndian rupeeIndian.cap];\012    sub rupeeIndian.cap from [rupeeIndian.cap rupeeIndian.tf rupeeIndian];\012    sub liraTurkish from [liraTurkish liraTurkish.cap liraTurkish.tf];\012    sub liraTurkish.tf from [liraTurkish.tf liraTurkish liraTurkish.cap];\012    sub liraTurkish.cap from [liraTurkish.cap liraTurkish.tf liraTurkish];\012    sub ruble from [ruble ruble.cap ruble.tf];\012    sub ruble.tf from [ruble.tf ruble ruble.cap];\012    sub ruble.cap from [ruble.cap ruble.tf ruble];\012    sub centigrade from [centigrade centigrade.cap];\012    sub centigrade.cap from [centigrade.cap centigrade];\012    sub fahrenheit from [fahrenheit fahrenheit.cap];\012    sub fahrenheit.cap from [fahrenheit.cap fahrenheit];\012    sub published from [published published.alt];\012    sub published.alt from [published.alt published];\012    sub servicemark from [servicemark servicemark.alt3 servicemark.alt servicemark.alt2];\012    sub servicemark.alt2 from [servicemark.alt2 servicemark servicemark.alt3 servicemark.alt];\012    sub servicemark.alt from [servicemark.alt servicemark.alt2 servicemark servicemark.alt3];\012    sub servicemark.alt3 from [servicemark.alt3 servicemark.alt servicemark.alt2 servicemark];\012    sub y from [y y.alt];\012    sub y.alt from [y.alt y];\012    sub yacute from [yacute yacute.alt];\012    sub yacute.alt from [yacute.alt yacute];\012    sub ycircumflex from [ycircumflex ycircumflex.alt];\012    sub ycircumflex.alt from [ycircumflex.alt ycircumflex];\012    sub ydieresis from [ydieresis ydieresis.alt];\012    sub ydieresis.alt from [ydieresis.alt ydieresis];\012    sub ydotbelow from [ydotbelow ydotbelow.alt];\012    sub ydotbelow.alt from [ydotbelow.alt ydotbelow];\012    sub yhookabove from [yhookabove yhookabove.alt];\012    sub yhookabove.alt from [yhookabove.alt yhookabove];\012    sub ytilde from [ytilde ytilde.alt];\012    sub ytilde.alt from [ytilde.alt ytilde];\012    sub yen from [yen yen.tf yen.cap];\012    sub yen.cap from [yen.cap yen yen.tf];\012    sub yen.tf from [yen.tf yen.cap yen];\012    sub ygrave from [ygrave ygrave.alt];\012    sub ygrave.alt from [ygrave.alt ygrave];\012    sub zero from [zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf];\012    sub zero.tf from [zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator];\012    sub zero.numerator from [zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator zero.alt];\012    sub zero.alt from [zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap zero.denominator];\012    sub zero.denominator from [zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap zero.cap];\012    sub zero.cap from [zero.cap zero.denominator zero.alt zero.numerator zero.tf zero zero.alt.cap];\012    sub zero.alt.cap from [zero.alt.cap zero.cap zero.denominator zero.alt zero.numerator zero.tf zero];\012    \012    # ==============\012    # END LATIN\012    # ==============\012    \012    # ==============\012    # BEGIN HEBREW\012    # ==============\012    \012    feature jalt;\012    \012    # ==============\012    # END HEBREW\012    # ==============";
 name = aalt;
 },
 {
-code = "# ===============
-# BEGIN LATIN
-# ===============
-
-lookup ccmp_Other_1 {
-	@CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb commaturnedabovecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];
-	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb];
-	sub [i j]' @CombiningTopAccents by [idotless jdotless];
-	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];
-	@Markscomb = [tonos psili koronis dasia dasiavaria psilioxia dasiaoxia psiliperispomeni dasiaperispomeni dialytikavaria dialytikaperispomeni varia oxia perispomeni psilivaria dialytikaoxia];
-	@MarkscombCase = [tonos.case psili.case koronis.case dasia.case dasiavaria.case psilioxia.case dasiaoxia.case psiliperispomeni.case dasiaperispomeni.case dialytikavaria.case dialytikaperispomeni.case varia.case oxia.case perispomeni.case psilivaria.case dialytikaoxia.case];
-	sub @Markscomb @Markscomb' by @MarkscombCase;
-	sub @Uppercase @Markscomb' by @MarkscombCase;
-} ccmp_Other_1;
-
-lookup ccmp_Other_2 {
-	sub @Markscomb' @MarkscombCase by @MarkscombCase;
-	sub @MarkscombCase @Markscomb' by @MarkscombCase;
-} ccmp_Other_2;
-
-lookup ccmp_latn_1 {
-	lookupflag 0;
-	sub brevecomb acutecomb by brevecomb_acutecomb;
-	sub brevecomb.cap acutecomb.cap by brevecomb_acutecomb.cap;
-	sub brevecomb.sc acutecomb.sc by brevecomb_acutecomb.sc;
-	sub brevecomb gravecomb by brevecomb_gravecomb;
-	sub brevecomb.cap gravecomb.cap by brevecomb_gravecomb.cap;
-	sub brevecomb.sc gravecomb.sc by brevecomb_gravecomb.sc;
-	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;
-	sub brevecomb.cap hookabovecomb.cap by brevecomb_hookabovecomb.cap;
-	sub brevecomb.sc hookabovecomb.sc by brevecomb_hookabovecomb.sc;
-	sub brevecomb tildecomb by brevecomb_tildecomb;
-	sub brevecomb.cap tildecomb.cap by brevecomb_tildecomb.cap;
-	sub brevecomb.sc tildecomb.sc by brevecomb_tildecomb.sc;
-	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;
-	sub circumflexcomb.cap acutecomb.cap by circumflexcomb_acutecomb.cap;
-	sub circumflexcomb.sc acutecomb.sc by circumflexcomb_acutecomb.sc;
-	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;
-	sub circumflexcomb.cap gravecomb.cap by circumflexcomb_gravecomb.cap;
-	sub circumflexcomb.sc gravecomb.sc by circumflexcomb_gravecomb.sc;
-	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;
-	sub circumflexcomb.cap hookabovecomb.cap by circumflexcomb_hookabovecomb.cap;
-	sub circumflexcomb.sc hookabovecomb.sc by circumflexcomb_hookabovecomb.sc;
-	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;
-	sub circumflexcomb.cap tildecomb.cap by circumflexcomb_tildecomb.cap;
-	sub circumflexcomb.sc tildecomb.sc by circumflexcomb_tildecomb.sc;
-} ccmp_latn_1;
-
-# ===============
-# END LATIN
-# ===============
-
-# ===============
-# BEGIN HEBREW
-# ===============
-
-lookup hb_shinDots {
-	lookupflag 0;
-	lookupflag UseMarkFilteringSet @hb_shinDots;
-	sub shin-hb shindot-hb by shinshindot-hb;
-	sub shin-hb sindot-hb by shinsindot-hb;
-} hb_shinDots;
-
-lookup hb_dagesh {
-	lookupflag 0;
-	lookupflag MarkAttachmentType @hb_dagesh; 
-	sub alef-hb dagesh-hb by alefdagesh-hb;
-	sub bet-hb dagesh-hb by betdagesh-hb;
-	sub gimel-hb dagesh-hb by gimeldagesh-hb;
-	sub dalet-hb dagesh-hb by daletdagesh-hb;
-	sub he-hb dagesh-hb by hedagesh-hb;
-	sub vav-hb dagesh-hb by vavdagesh-hb;
-	sub zayin-hb dagesh-hb by zayindagesh-hb;
-	sub tet-hb dagesh-hb by tetdagesh-hb;
-	sub yod-hb dagesh-hb by yoddagesh-hb;
-	sub kaf-hb dagesh-hb by kafdagesh-hb;
-	sub finalkaf-hb dagesh-hb by finalkafdagesh-hb;
-	sub lamed-hb dagesh-hb by lameddagesh-hb;
-	sub mem-hb dagesh-hb by memdagesh-hb;
-	sub nun-hb dagesh-hb by nundagesh-hb;
-	sub samekh-hb dagesh-hb by samekhdagesh-hb;
-	sub pe-hb dagesh-hb by pedagesh-hb;
-	sub finalpe-hb dagesh-hb by finalpedagesh-hb;
-	sub tsadi-hb dagesh-hb by tsadidagesh-hb;
-	sub qof-hb dagesh-hb by qofdagesh-hb;
-	sub resh-hb dagesh-hb by reshdagesh-hb;
-	sub shinsindot-hb dagesh-hb by shindageshsindot-hb;
-	sub shinshindot-hb dagesh-hb by shindageshshindot-hb;
-	sub shin-hb dagesh-hb by shindagesh-hb;
-	sub tav-hb dagesh-hb by tavdagesh-hb;
-} hb_dagesh;
-	
-lookup hb_diacriticReplacements {
-	lookupflag 0;
-	lookupflag UseMarkFilteringSet @hb_diacriticMarks;
-	sub alef-hb patah-hb by alefpatah-hb;
-	sub alef-hb qamats-hb by alefqamats-hb;
-	sub finalkafdagesh-hb qamats-hb by finalkafdagesh_qamats-hb;
-	sub finalkafdagesh-hb sheva-hb by finalkafdagesh_sheva-hb;	
-	sub finalkaf-hb qamats-hb by finalkaf_qamats-hb;
-	sub finalkaf-hb sheva-hb by finalkaf_sheva-hb;
-	sub vav-hb holam-hb by vavholam-hb;
-	sub lameddagesh-hb holam-hb by lamed_dagesh_holam-hb;
-	sub lamed-hb holam-hb by lamed_holam-hb;
-} hb_diacriticReplacements;
-
-
-lookup hb_rafe {
-	lookupflag 0;
-# 	lookupflag UseMarkFilteringSet @hb_diacriticMarks;
-	sub pe-hb rafe-hb by perafe-hb;
-	sub kaf-hb rafe-hb by kafrafe-hb;
-	sub bet-hb rafe-hb by betrafe-hb;
-} hb_rafe;	
-
-lookup hb_siluqLeft {
-	# cantillation replacements		
-	sub hatafsegol-hb siluqleft-hb by hatafsegol_siluqleft-hb;
-	sub hatafpatah-hb siluqleft-hb by hatafpatah_siluqleft-hb;
-	sub hatafqamats-hb siluqleft-hb by hatafqamats_siluqleft-hb; 
-} hb_siluqLeft;
-
-#If specific letters appear at the end of the word, the cantillation will be replaced by a final alternative
-lookup hb_finalCantillationForms {
-	ignore sub @hb_finalCantillationLetters @hb_finalCantillationSrc' @hb_AllHebrewLetters;
-	sub @hb_finalCantillationLetters @hb_finalCantillationSrc' by @hb_finalCantillationDst;
-} hb_finalCantillationForms;
-
-# ==============
-# END HEBREW
-# ==============
-
-";
+code = "# ===============\012# BEGIN LATIN\012# ===============\012\012lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb commaturnedabovecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012	@Markscomb = [tonos psili koronis dasia dasiavaria psilioxia dasiaoxia psiliperispomeni dasiaperispomeni dialytikavaria dialytikaperispomeni varia oxia perispomeni psilivaria dialytikaoxia];\012	@MarkscombCase = [tonos.case psili.case koronis.case dasia.case dasiavaria.case psilioxia.case dasiaoxia.case psiliperispomeni.case dasiaperispomeni.case dialytikavaria.case dialytikaperispomeni.case varia.case oxia.case perispomeni.case psilivaria.case dialytikaoxia.case];\012	sub @Markscomb @Markscomb' by @MarkscombCase;\012	sub @Uppercase @Markscomb' by @MarkscombCase;\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	sub @Markscomb' @MarkscombCase by @MarkscombCase;\012	sub @MarkscombCase @Markscomb' by @MarkscombCase;\012} ccmp_Other_2;\012\012lookup ccmp_latn_1 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb.cap acutecomb.cap by brevecomb_acutecomb.cap;\012	sub brevecomb.sc acutecomb.sc by brevecomb_acutecomb.sc;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb.cap gravecomb.cap by brevecomb_gravecomb.cap;\012	sub brevecomb.sc gravecomb.sc by brevecomb_gravecomb.sc;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb.cap hookabovecomb.cap by brevecomb_hookabovecomb.cap;\012	sub brevecomb.sc hookabovecomb.sc by brevecomb_hookabovecomb.sc;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub brevecomb.cap tildecomb.cap by brevecomb_tildecomb.cap;\012	sub brevecomb.sc tildecomb.sc by brevecomb_tildecomb.sc;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb.cap acutecomb.cap by circumflexcomb_acutecomb.cap;\012	sub circumflexcomb.sc acutecomb.sc by circumflexcomb_acutecomb.sc;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb.cap gravecomb.cap by circumflexcomb_gravecomb.cap;\012	sub circumflexcomb.sc gravecomb.sc by circumflexcomb_gravecomb.sc;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb.cap hookabovecomb.cap by circumflexcomb_hookabovecomb.cap;\012	sub circumflexcomb.sc hookabovecomb.sc by circumflexcomb_hookabovecomb.sc;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012	sub circumflexcomb.cap tildecomb.cap by circumflexcomb_tildecomb.cap;\012	sub circumflexcomb.sc tildecomb.sc by circumflexcomb_tildecomb.sc;\012} ccmp_latn_1;\012\012# ===============\012# END LATIN\012# ===============\012\012# ===============\012# BEGIN HEBREW\012# ===============\012\012lookup hb_shinDots {\012	lookupflag 0;\012	lookupflag UseMarkFilteringSet @hb_shinDots;\012	sub shin-hb shindot-hb by shinshindot-hb;\012	sub shin-hb sindot-hb by shinsindot-hb;\012} hb_shinDots;\012\012lookup hb_dagesh {\012	lookupflag 0;\012	lookupflag MarkAttachmentType @hb_dagesh; \012	sub alef-hb dagesh-hb by alefdagesh-hb;\012	sub bet-hb dagesh-hb by betdagesh-hb;\012	sub gimel-hb dagesh-hb by gimeldagesh-hb;\012	sub dalet-hb dagesh-hb by daletdagesh-hb;\012	sub he-hb dagesh-hb by hedagesh-hb;\012	sub vav-hb dagesh-hb by vavdagesh-hb;\012	sub zayin-hb dagesh-hb by zayindagesh-hb;\012	sub tet-hb dagesh-hb by tetdagesh-hb;\012	sub yod-hb dagesh-hb by yoddagesh-hb;\012	sub kaf-hb dagesh-hb by kafdagesh-hb;\012	sub finalkaf-hb dagesh-hb by finalkafdagesh-hb;\012	sub lamed-hb dagesh-hb by lameddagesh-hb;\012	sub mem-hb dagesh-hb by memdagesh-hb;\012	sub nun-hb dagesh-hb by nundagesh-hb;\012	sub samekh-hb dagesh-hb by samekhdagesh-hb;\012	sub pe-hb dagesh-hb by pedagesh-hb;\012	sub finalpe-hb dagesh-hb by finalpedagesh-hb;\012	sub tsadi-hb dagesh-hb by tsadidagesh-hb;\012	sub qof-hb dagesh-hb by qofdagesh-hb;\012	sub resh-hb dagesh-hb by reshdagesh-hb;\012	sub shinsindot-hb dagesh-hb by shindageshsindot-hb;\012	sub shinshindot-hb dagesh-hb by shindageshshindot-hb;\012	sub shin-hb dagesh-hb by shindagesh-hb;\012	sub tav-hb dagesh-hb by tavdagesh-hb;\012} hb_dagesh;\012	\012lookup hb_diacriticReplacements {\012	lookupflag 0;\012	lookupflag UseMarkFilteringSet @hb_diacriticMarks;\012	sub alef-hb patah-hb by alefpatah-hb;\012	sub alef-hb qamats-hb by alefqamats-hb;\012	sub finalkafdagesh-hb qamats-hb by finalkafdagesh_qamats-hb;\012	sub finalkafdagesh-hb sheva-hb by finalkafdagesh_sheva-hb;	\012	sub finalkaf-hb qamats-hb by finalkaf_qamats-hb;\012	sub finalkaf-hb sheva-hb by finalkaf_sheva-hb;\012	sub vav-hb holam-hb by vavholam-hb;\012	sub lameddagesh-hb holam-hb by lamed_dagesh_holam-hb;\012	sub lamed-hb holam-hb by lamed_holam-hb;\012} hb_diacriticReplacements;\012\012\012lookup hb_rafe {\012	lookupflag 0;\012# 	lookupflag UseMarkFilteringSet @hb_diacriticMarks;\012	sub pe-hb rafe-hb by perafe-hb;\012	sub kaf-hb rafe-hb by kafrafe-hb;\012	sub bet-hb rafe-hb by betrafe-hb;\012} hb_rafe;	\012\012lookup hb_siluqLeft {\012	# cantillation replacements		\012	sub hatafsegol-hb siluqleft-hb by hatafsegol_siluqleft-hb;\012	sub hatafpatah-hb siluqleft-hb by hatafpatah_siluqleft-hb;\012	sub hatafqamats-hb siluqleft-hb by hatafqamats_siluqleft-hb; \012} hb_siluqLeft;\012\012#If specific letters appear at the end of the word, the cantillation will be replaced by a final alternative\012lookup hb_finalCantillationForms {\012	ignore sub @hb_finalCantillationLetters @hb_finalCantillationSrc' @hb_AllHebrewLetters;\012	sub @hb_finalCantillationLetters @hb_finalCantillationSrc' by @hb_finalCantillationDst;\012} hb_finalCantillationForms;\012\012# ==============\012# END HEBREW\012# ==============\012\012";
 name = ccmp;
 },
 {
-code = "sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;
-script latn;
-language ROM;
-sub Scedilla by Scommaaccent;
-sub scedilla by scommaaccent;
-sub Tcedilla by Tcommaaccent;
-sub tcedilla by tcommaaccent;
-language MOL;
-sub Scedilla by Scommaaccent;
-sub scedilla by scommaaccent;
-sub Tcedilla by Tcommaaccent;
-sub tcedilla by tcommaaccent;
-language CAT;
-sub  L' periodcentered' L by Ldot;
-
-script cyrl;
-language SRB;
-sub be-cy by be-cy.loclSRB;
-language CHU;
-sub Esdescender-cy by Esdescender-cy.loclCHU;
-sub esdescender-cy by esdescender-cy.loclCHU;
-sub esdescender-cy.sc by esdescender-cy.loclCHU.sc;
-language BSH;
-sub Ghestroke-cy by Ghestroke-cy.loclBSH;
-sub Zedescender-cy by Zedescender-cy.loclBSH;
-sub Esdescender-cy by Esdescender-cy.loclBSH;
-sub ghestroke-cy by ghestroke-cy.loclBSH;
-sub zedescender-cy by zedescender-cy.loclBSH;
-sub esdescender-cy by esdescender-cy.loclBSH;
-sub ghestroke-cy.sc by ghestroke-cy.loclBSH.sc;
-sub zedescender-cy.sc by zedescender-cy.loclBSH.sc;
-sub esdescender-cy.sc by esdescender-cy.loclBSH.sc;
-language BGR;
-sub De-cy by De-cy.loclBGR;
-sub El-cy by El-cy.loclBGR;
-sub Ef-cy by Ef-cy.loclBGR;
-sub ve-cy by ve-cy.loclBGR;
-sub ge-cy by ge-cy.loclBGR;
-sub de-cy by de-cy.loclBGR;
-sub zhe-cy by zhe-cy.loclBGR;
-sub ze-cy by ze-cy.loclBGR;
-sub ii-cy by ii-cy.loclBGR;
-sub iishort-cy by iishort-cy.loclBGR;
-sub iigrave-cy by iigrave-cy.loclBGR;
-sub ka-cy by ka-cy.loclBGR;
-sub el-cy by el-cy.loclBGR;
-sub ef-cy by ef-cy.loclBGR;
-sub pe-cy by pe-cy.loclBGR;
-sub te-cy by te-cy.loclBGR;
-sub tse-cy by tse-cy.loclBGR;
-sub sha-cy by sha-cy.loclBGR;
-sub shcha-cy by shcha-cy.loclBGR;
-sub softsign-cy by softsign-cy.loclBGR;
-sub hardsign-cy by hardsign-cy.loclBGR;
-sub iu-cy by iu-cy.loclBGR;
-sub yeru-cy by yeru-cy.loclBGR;
-sub de-cy.sc by de-cy.loclBGR.sc;
-sub el-cy.sc by el-cy.loclBGR.sc;
-sub ef-cy.sc by ef-cy.loclBGR.sc;";
+code = "sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;\012script latn;\012language ROM;\012sub Scedilla by Scommaaccent;\012sub scedilla by scommaaccent;\012sub Tcedilla by Tcommaaccent;\012sub tcedilla by tcommaaccent;\012language MOL;\012sub Scedilla by Scommaaccent;\012sub scedilla by scommaaccent;\012sub Tcedilla by Tcommaaccent;\012sub tcedilla by tcommaaccent;\012language CAT;\012sub  L' periodcentered' L by Ldot;\012\012script cyrl;\012language SRB;\012sub be-cy by be-cy.loclSRB;\012language CHU;\012sub Esdescender-cy by Esdescender-cy.loclCHU;\012sub esdescender-cy by esdescender-cy.loclCHU;\012sub esdescender-cy.sc by esdescender-cy.loclCHU.sc;\012language BSH;\012sub Ghestroke-cy by Ghestroke-cy.loclBSH;\012sub Zedescender-cy by Zedescender-cy.loclBSH;\012sub Esdescender-cy by Esdescender-cy.loclBSH;\012sub ghestroke-cy by ghestroke-cy.loclBSH;\012sub zedescender-cy by zedescender-cy.loclBSH;\012sub esdescender-cy by esdescender-cy.loclBSH;\012sub ghestroke-cy.sc by ghestroke-cy.loclBSH.sc;\012sub zedescender-cy.sc by zedescender-cy.loclBSH.sc;\012sub esdescender-cy.sc by esdescender-cy.loclBSH.sc;\012language BGR;\012sub De-cy by De-cy.loclBGR;\012sub El-cy by El-cy.loclBGR;\012sub Ef-cy by Ef-cy.loclBGR;\012sub ve-cy by ve-cy.loclBGR;\012sub ge-cy by ge-cy.loclBGR;\012sub de-cy by de-cy.loclBGR;\012sub zhe-cy by zhe-cy.loclBGR;\012sub ze-cy by ze-cy.loclBGR;\012sub ii-cy by ii-cy.loclBGR;\012sub iishort-cy by iishort-cy.loclBGR;\012sub iigrave-cy by iigrave-cy.loclBGR;\012sub ka-cy by ka-cy.loclBGR;\012sub el-cy by el-cy.loclBGR;\012sub ef-cy by ef-cy.loclBGR;\012sub pe-cy by pe-cy.loclBGR;\012sub te-cy by te-cy.loclBGR;\012sub tse-cy by tse-cy.loclBGR;\012sub sha-cy by sha-cy.loclBGR;\012sub shcha-cy by shcha-cy.loclBGR;\012sub softsign-cy by softsign-cy.loclBGR;\012sub hardsign-cy by hardsign-cy.loclBGR;\012sub iu-cy by iu-cy.loclBGR;\012sub yeru-cy by yeru-cy.loclBGR;\012sub de-cy.sc by de-cy.loclBGR.sc;\012sub el-cy.sc by el-cy.loclBGR.sc;\012sub ef-cy.sc by ef-cy.loclBGR.sc;";
 name = locl;
 },
 {
-code = "    lookup FractionBar {
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures @figures slash;
-        ignore sub slash @figures @figures @figures slash';
-        ignore sub slash' @figures @figures @figures slash;
-        ignore sub slash @figures @figures slash';
-        ignore sub slash' @figures @figures slash;
-        ignore sub slash @figures slash';
-        ignore sub slash' @figures slash;
-        ignore sub slash slash';
-        ignore sub slash' slash;
-        sub @figures slash' @figures by fraction;
-    } FractionBar;
-
-    lookup Numerator1 {
-        sub @figures' fraction by @figuresNumerator;
-    } Numerator1;
-
-    lookup Numerator2 {
-        sub @figures' @figuresNumerator fraction by @figuresNumerator;
-    } Numerator2;
-
-    lookup Numerator3 {
-        sub @figures' @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator3;
-
-    lookup Numerator4 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator4;
-
-    lookup Numerator5 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator5;
-
-    lookup Numerator6 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator6;
-
-    lookup Numerator7 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator7;
-
-    lookup Numerator8 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator8;
-
-    lookup Numerator9 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator9;
-
-    lookup Numerator10 {
-        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;
-    } Numerator10;
-
-    lookup Denominator {
-        sub [fraction @figuresDenominator] @figures' by @figuresDenominator;
-    } Denominator;
-
-    sub @figures space' @figuresNumerator by thinspace;";
+code = "    lookup FractionBar {\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures @figures slash;\012        ignore sub slash @figures @figures @figures slash';\012        ignore sub slash' @figures @figures @figures slash;\012        ignore sub slash @figures @figures slash';\012        ignore sub slash' @figures @figures slash;\012        ignore sub slash @figures slash';\012        ignore sub slash' @figures slash;\012        ignore sub slash slash';\012        ignore sub slash' slash;\012        sub @figures slash' @figures by fraction;\012    } FractionBar;\012\012    lookup Numerator1 {\012        sub @figures' fraction by @figuresNumerator;\012    } Numerator1;\012\012    lookup Numerator2 {\012        sub @figures' @figuresNumerator fraction by @figuresNumerator;\012    } Numerator2;\012\012    lookup Numerator3 {\012        sub @figures' @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator3;\012\012    lookup Numerator4 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator4;\012\012    lookup Numerator5 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator5;\012\012    lookup Numerator6 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator6;\012\012    lookup Numerator7 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator7;\012\012    lookup Numerator8 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator8;\012\012    lookup Numerator9 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator9;\012\012    lookup Numerator10 {\012        sub @figures' @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator @figuresNumerator fraction by @figuresNumerator;\012    } Numerator10;\012\012    lookup Denominator {\012        sub [fraction @figuresDenominator] @figures' by @figuresDenominator;\012    } Denominator;\012\012    sub @figures space' @figuresNumerator by thinspace;";
 name = frac;
 },
 {
@@ -1668,1755 +234,101 @@ code = "sub @figures by @figuresDenominator;";
 name = dnom;
 },
 {
-code = "sub @figures_tab by @figures;
-sub @symbols_tab by @symbols;";
+code = "sub @figures_tab by @figures;\012sub @symbols_tab by @symbols;";
 name = lnum;
 },
 {
-code = "sub @figures by @figures_tab;
-sub @symbols by @symbols_tab;";
+code = "sub @figures by @figures_tab;\012sub @symbols by @symbols_tab;";
 name = tnum;
 },
 {
-code = "sub [A a] by ordfeminine;
-sub [O o] by ordmasculine;";
+code = "sub [A a] by ordfeminine;\012sub [O o] by ordmasculine;";
 name = ordn;
 },
 {
-code = "sub @cap_off by @cap_on;
-sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;
-";
+code = "sub @cap_off by @cap_on;\012sub [space hyphen softhyphen endash emdash underscore] etatonos' [space hyphen softhyphen endash emdash underscore comma] by Etatonos;\012";
 name = case;
 },
 {
-code = "featureNames {
-    name \"Micro Caps\";
-    name 1 \"Micro Caps\";
-};
-
-sub A by a.sc.ss04;
-sub B by b.sc.ss04;
-sub C by c.sc.ss04;
-sub D by d.sc.ss04;
-sub E by e.sc.ss04;
-sub F by f.sc.ss04;
-sub G by g.sc.ss04;
-sub H by h.sc.ss04;
-sub I by i.sc.ss04;
-sub J by j.sc.ss04;
-sub K by k.sc.ss04;
-sub L by l.sc.ss04;
-sub M by m.sc.ss04;
-sub N by n.sc.ss04;
-sub O by o.sc.ss04;
-sub P by p.sc.ss04;
-sub Q by q.sc.ss04;
-sub R by r.sc.ss04;
-sub S by s.sc.ss04;
-sub T by t.sc.ss04;
-sub U by u.sc.ss04;
-sub V by v.sc.ss04;
-sub W by w.sc.ss04;
-sub X by x.sc.ss04;
-sub Y by y.sc.ss04;
-sub Z by z.sc.ss04;
-sub a by a.sc.lc.ss04;
-sub b by b.sc.lc.ss04;
-sub c by c.sc.lc.ss04;
-sub d by d.sc.lc.ss04;
-sub e by e.sc.lc.ss04;
-sub f by f.sc.lc.ss04;
-sub g by g.sc.lc.ss04;
-sub h by h.sc.lc.ss04;
-sub i by i.sc.lc.ss04;
-sub j by j.sc.lc.ss04;
-sub k by k.sc.lc.ss04;
-sub l by l.sc.lc.ss04;
-sub m by m.sc.lc.ss04;
-sub n by n.sc.lc.ss04;
-sub o by o.sc.lc.ss04;
-sub p by p.sc.lc.ss04;
-sub q by q.sc.lc.ss04;
-sub r by r.sc.lc.ss04;
-sub s by s.sc.lc.ss04;
-sub t by t.sc.lc.ss04;
-sub u by u.sc.lc.ss04;
-sub v by v.sc.lc.ss04;
-sub w by w.sc.lc.ss04;
-sub x by x.sc.lc.ss04;
-sub y by y.sc.lc.ss04;
-sub z by z.sc.lc.ss04;
-sub zero.sc by zero.sc.ss04;
-sub one.sc by one.sc.ss04;
-sub two.sc by two.sc.ss04;
-sub three.sc by three.sc.ss04;
-sub four.sc by four.sc.ss04;
-sub five.sc by five.sc.ss04;
-sub six.sc by six.sc.ss04;
-sub seven.sc by seven.sc.ss04;
-sub eight.sc by eight.sc.ss04;
-sub nine.sc by nine.sc.ss04;
-";
+code = "featureNames {\012    name \"Micro Caps\";\012    name 1 \"Micro Caps\";\012};\012\012sub A by a.sc.ss04;\012sub B by b.sc.ss04;\012sub C by c.sc.ss04;\012sub D by d.sc.ss04;\012sub E by e.sc.ss04;\012sub F by f.sc.ss04;\012sub G by g.sc.ss04;\012sub H by h.sc.ss04;\012sub I by i.sc.ss04;\012sub J by j.sc.ss04;\012sub K by k.sc.ss04;\012sub L by l.sc.ss04;\012sub M by m.sc.ss04;\012sub N by n.sc.ss04;\012sub O by o.sc.ss04;\012sub P by p.sc.ss04;\012sub Q by q.sc.ss04;\012sub R by r.sc.ss04;\012sub S by s.sc.ss04;\012sub T by t.sc.ss04;\012sub U by u.sc.ss04;\012sub V by v.sc.ss04;\012sub W by w.sc.ss04;\012sub X by x.sc.ss04;\012sub Y by y.sc.ss04;\012sub Z by z.sc.ss04;\012sub a by a.sc.lc.ss04;\012sub b by b.sc.lc.ss04;\012sub c by c.sc.lc.ss04;\012sub d by d.sc.lc.ss04;\012sub e by e.sc.lc.ss04;\012sub f by f.sc.lc.ss04;\012sub g by g.sc.lc.ss04;\012sub h by h.sc.lc.ss04;\012sub i by i.sc.lc.ss04;\012sub j by j.sc.lc.ss04;\012sub k by k.sc.lc.ss04;\012sub l by l.sc.lc.ss04;\012sub m by m.sc.lc.ss04;\012sub n by n.sc.lc.ss04;\012sub o by o.sc.lc.ss04;\012sub p by p.sc.lc.ss04;\012sub q by q.sc.lc.ss04;\012sub r by r.sc.lc.ss04;\012sub s by s.sc.lc.ss04;\012sub t by t.sc.lc.ss04;\012sub u by u.sc.lc.ss04;\012sub v by v.sc.lc.ss04;\012sub w by w.sc.lc.ss04;\012sub x by x.sc.lc.ss04;\012sub y by y.sc.lc.ss04;\012sub z by z.sc.lc.ss04;\012sub zero.sc by zero.sc.ss04;\012sub one.sc by one.sc.ss04;\012sub two.sc by two.sc.ss04;\012sub three.sc by three.sc.ss04;\012sub four.sc by four.sc.ss04;\012sub five.sc by five.sc.ss04;\012sub six.sc by six.sc.ss04;\012sub seven.sc by seven.sc.ss04;\012sub eight.sc by eight.sc.ss04;\012sub nine.sc by nine.sc.ss04;\012";
 name = ss04;
 },
 {
-code = "    sub f f b by f_f_b;
-    sub f f h by f_f_h;
-    sub f f i by f_f_i;
-    sub f f j by f_f_j;
-    sub f f k by f_f_k;
-    sub f f l by f_f_l;
-    sub f f t by f_f_t;
-    sub r f f by r_f_f;
-    sub f b by f_b;
-    sub f f by f_f;
-    sub f h by f_h;
-    sub f i by f_i;
-    sub f j by f_j;
-    sub f k by f_k;
-    sub f l by f_l;
-    sub f t by f_t;
-    sub r f by r_f;
-    sub r t by r_t;
-    sub t f by t_f;
-    sub t t by t_t;
-    sub [G g] o o g l e underscore l o g o by Google.logo;
-    
-    sub [G g] o o g l e l o g o l i g a t u r e by Google.logo;
-    sub G l o g o l i g a t u r e by G.logo;
-    sub o l o g o l i g a t u r e by o.logo;
-    sub g l o g o l i g a t u r e by g.logo;
-    sub l l o g o l i g a t u r e by l.logo;
-    sub e l o g o l i g a t u r e by e.logo;";
+code = "    sub f f b by f_f_b;\012    sub f f h by f_f_h;\012    sub f f i by f_f_i;\012    sub f f j by f_f_j;\012    sub f f k by f_f_k;\012    sub f f l by f_f_l;\012    sub f f t by f_f_t;\012    sub r f f by r_f_f;\012    sub f b by f_b;\012    sub f f by f_f;\012    sub f h by f_h;\012    sub f i by f_i;\012    sub f j by f_j;\012    sub f k by f_k;\012    sub f l by f_l;\012    sub f t by f_t;\012    sub r f by r_f;\012    sub r t by r_t;\012    sub t f by t_f;\012    sub t t by t_t;\012    sub [G g] o o g l e underscore l o g o by Google.logo;\012    \012    sub [G g] o o g l e l o g o l i g a t u r e by Google.logo;\012    sub G l o g o l i g a t u r e by G.logo;\012    sub o l o g o l i g a t u r e by o.logo;\012    sub g l o g o l i g a t u r e by g.logo;\012    sub l l o g o l i g a t u r e by l.logo;\012    sub e l o g o l i g a t u r e by e.logo;";
 name = liga;
 },
 {
 automatic = 1;
-code = "sub zero by zerosuperior;
-sub one by onesuperior;
-sub two by twosuperior;
-sub three by threesuperior;
-sub four by foursuperior;
-sub five by fivesuperior;
-sub six by sixsuperior;
-sub seven by sevensuperior;
-sub eight by eightsuperior;
-sub nine by ninesuperior;
-";
+code = "sub zero by zerosuperior;\012sub one by onesuperior;\012sub two by twosuperior;\012sub three by threesuperior;\012sub four by foursuperior;\012sub five by fivesuperior;\012sub six by sixsuperior;\012sub seven by sevensuperior;\012sub eight by eightsuperior;\012sub nine by ninesuperior;\012";
 name = sups;
 },
 {
 automatic = 1;
-code = "sub zero by zeroinferior;
-sub one by oneinferior;
-sub two by twoinferior;
-sub three by threeinferior;
-sub four by fourinferior;
-sub five by fiveinferior;
-sub six by sixinferior;
-sub seven by seveninferior;
-sub eight by eightinferior;
-sub nine by nineinferior;
-";
+code = "sub zero by zeroinferior;\012sub one by oneinferior;\012sub two by twoinferior;\012sub three by threeinferior;\012sub four by fourinferior;\012sub five by fiveinferior;\012sub six by sixinferior;\012sub seven by seveninferior;\012sub eight by eightinferior;\012sub nine by nineinferior;\012";
 name = subs;
 },
 {
 automatic = 1;
-code = "sub zero by zeroinferior;
-sub one by oneinferior;
-sub two by twoinferior;
-sub three by threeinferior;
-sub four by fourinferior;
-sub five by fiveinferior;
-sub six by sixinferior;
-sub seven by seveninferior;
-sub eight by eightinferior;
-sub nine by nineinferior;
-";
+code = "sub zero by zeroinferior;\012sub one by oneinferior;\012sub two by twoinferior;\012sub three by threeinferior;\012sub four by fourinferior;\012sub five by fiveinferior;\012sub six by sixinferior;\012sub seven by seveninferior;\012sub eight by eightinferior;\012sub nine by nineinferior;\012";
 name = sinf;
 },
 {
 automatic = 1;
-code = "sub zero.tf by zero;
-sub one.tf by one;
-sub two.tf by two;
-sub three.tf by three;
-sub four.tf by four;
-sub five.tf by five;
-sub six.tf by six;
-sub seven.tf by seven;
-sub eight.tf by eight;
-sub nine.tf by nine;
-sub period.tf by period;
-sub comma.tf by comma;
-sub colon.tf by colon;
-sub semicolon.tf by semicolon;
-sub numbersign.tf by numbersign;
-sub space.tf by space;
-sub cent.tf by cent;
-sub currency.tf by currency;
-sub dollar.tf by dollar;
-sub dong.tf by dong;
-sub euro.tf by euro;
-sub florin.tf by florin;
-sub franc.tf by franc;
-sub lira.tf by lira;
-sub liraTurkish.tf by liraTurkish;
-sub peso.tf by peso;
-sub ruble.tf by ruble;
-sub rupeeIndian.tf by rupeeIndian;
-sub sterling.tf by sterling;
-sub tenge.tf by tenge;
-sub tugrik.tf by tugrik;
-sub won.tf by won;
-sub yen.tf by yen;
-sub plus.tf by plus;
-sub minus.tf by minus;
-sub multiply.tf by multiply;
-sub divide.tf by divide;
-sub equal.tf by equal;
-sub notequal.tf by notequal;
-sub greater.tf by greater;
-sub less.tf by less;
-sub greaterequal.tf by greaterequal;
-sub lessequal.tf by lessequal;
-sub plusminus.tf by plusminus;
-sub approxequal.tf by approxequal;
-sub logicalnot.tf by logicalnot;
-sub percent.tf by percent;
-sub section.tf by section;
-";
+code = "sub zero.tf by zero;\012sub one.tf by one;\012sub two.tf by two;\012sub three.tf by three;\012sub four.tf by four;\012sub five.tf by five;\012sub six.tf by six;\012sub seven.tf by seven;\012sub eight.tf by eight;\012sub nine.tf by nine;\012sub period.tf by period;\012sub comma.tf by comma;\012sub colon.tf by colon;\012sub semicolon.tf by semicolon;\012sub numbersign.tf by numbersign;\012sub space.tf by space;\012sub cent.tf by cent;\012sub currency.tf by currency;\012sub dollar.tf by dollar;\012sub dong.tf by dong;\012sub euro.tf by euro;\012sub florin.tf by florin;\012sub franc.tf by franc;\012sub lira.tf by lira;\012sub liraTurkish.tf by liraTurkish;\012sub peso.tf by peso;\012sub ruble.tf by ruble;\012sub rupeeIndian.tf by rupeeIndian;\012sub sterling.tf by sterling;\012sub tenge.tf by tenge;\012sub tugrik.tf by tugrik;\012sub won.tf by won;\012sub yen.tf by yen;\012sub plus.tf by plus;\012sub minus.tf by minus;\012sub multiply.tf by multiply;\012sub divide.tf by divide;\012sub equal.tf by equal;\012sub notequal.tf by notequal;\012sub greater.tf by greater;\012sub less.tf by less;\012sub greaterequal.tf by greaterequal;\012sub lessequal.tf by lessequal;\012sub plusminus.tf by plusminus;\012sub approxequal.tf by approxequal;\012sub logicalnot.tf by logicalnot;\012sub percent.tf by percent;\012sub section.tf by section;\012";
 name = pnum;
 },
 {
 automatic = 1;
-code = "sub A by a.sc;
-sub Aacute by aacute.sc;
-sub Abreve by abreve.sc;
-sub Abreveacute by abreveacute.sc;
-sub Abrevedotbelow by abrevedotbelow.sc;
-sub Abrevegrave by abrevegrave.sc;
-sub Abrevehookabove by abrevehookabove.sc;
-sub Abrevetilde by abrevetilde.sc;
-sub Acaron by acaron.sc;
-sub Acircumflex by acircumflex.sc;
-sub Acircumflexacute by acircumflexacute.sc;
-sub Acircumflexdotbelow by acircumflexdotbelow.sc;
-sub Acircumflexgrave by acircumflexgrave.sc;
-sub Acircumflexhookabove by acircumflexhookabove.sc;
-sub Acircumflextilde by acircumflextilde.sc;
-sub Adieresis by adieresis.sc;
-sub Adotbelow by adotbelow.sc;
-sub Agrave by agrave.sc;
-sub Ahookabove by ahookabove.sc;
-sub Amacron by amacron.sc;
-sub Aogonek by aogonek.sc;
-sub Aring by aring.sc;
-sub Aringacute by aringacute.sc;
-sub Atilde by atilde.sc;
-sub AE by ae.sc;
-sub AEacute by aeacute.sc;
-sub B by b.sc;
-sub C by c.sc;
-sub Cacute by cacute.sc;
-sub Ccaron by ccaron.sc;
-sub Ccedilla by ccedilla.sc;
-sub Ccircumflex by ccircumflex.sc;
-sub Cdotaccent by cdotaccent.sc;
-sub D by d.sc;
-sub Eth by eth.sc;
-sub Dcaron by dcaron.sc;
-sub Dcroat by dcroat.sc;
-sub E by e.sc;
-sub Eacute by eacute.sc;
-sub Ebreve by ebreve.sc;
-sub Ecaron by ecaron.sc;
-sub Ecircumflex by ecircumflex.sc;
-sub Ecircumflexacute by ecircumflexacute.sc;
-sub Ecircumflexdotbelow by ecircumflexdotbelow.sc;
-sub Ecircumflexgrave by ecircumflexgrave.sc;
-sub Ecircumflexhookabove by ecircumflexhookabove.sc;
-sub Ecircumflextilde by ecircumflextilde.sc;
-sub Edieresis by edieresis.sc;
-sub Edotaccent by edotaccent.sc;
-sub Edotbelow by edotbelow.sc;
-sub Egrave by egrave.sc;
-sub Ehookabove by ehookabove.sc;
-sub Emacron by emacron.sc;
-sub Eogonek by eogonek.sc;
-sub Etilde by etilde.sc;
-sub F by f.sc;
-sub G by g.sc;
-sub Gbreve by gbreve.sc;
-sub Gcircumflex by gcircumflex.sc;
-sub Gcommaaccent by gcommaaccent.sc;
-sub Gdotaccent by gdotaccent.sc;
-sub H by h.sc;
-sub Hbar by hbar.sc;
-sub Hcircumflex by hcircumflex.sc;
-sub I by i.sc;
-sub Iacute by iacute.sc;
-sub Ibreve by ibreve.sc;
-sub Icircumflex by icircumflex.sc;
-sub Idieresis by idieresis.sc;
-sub Idotaccent by idotaccent.sc;
-sub Idotbelow by idotbelow.sc;
-sub Igrave by igrave.sc;
-sub Ihookabove by ihookabove.sc;
-sub Imacron by imacron.sc;
-sub Iogonek by iogonek.sc;
-sub Itilde by itilde.sc;
-sub J by j.sc;
-sub Jcircumflex by jcircumflex.sc;
-sub K by k.sc;
-sub Kcommaaccent by kcommaaccent.sc;
-sub L by l.sc;
-sub Lacute by lacute.sc;
-sub Lcaron by lcaron.sc;
-sub Lcommaaccent by lcommaaccent.sc;
-sub Ldot by ldot.sc;
-sub Lslash by lslash.sc;
-sub M by m.sc;
-sub N by n.sc;
-sub Nacute by nacute.sc;
-sub Ncaron by ncaron.sc;
-sub Ncommaaccent by ncommaaccent.sc;
-sub Eng by eng.sc;
-sub Ntilde by ntilde.sc;
-sub O by o.sc;
-sub Oacute by oacute.sc;
-sub Obreve by obreve.sc;
-sub Ocircumflex by ocircumflex.sc;
-sub Ocircumflexacute by ocircumflexacute.sc;
-sub Ocircumflexdotbelow by ocircumflexdotbelow.sc;
-sub Ocircumflexgrave by ocircumflexgrave.sc;
-sub Ocircumflexhookabove by ocircumflexhookabove.sc;
-sub Ocircumflextilde by ocircumflextilde.sc;
-sub Odieresis by odieresis.sc;
-sub Odotbelow by odotbelow.sc;
-sub Ograve by ograve.sc;
-sub Ohookabove by ohookabove.sc;
-sub Ohorn by ohorn.sc;
-sub Ohornacute by ohornacute.sc;
-sub Ohorndotbelow by ohorndotbelow.sc;
-sub Ohorngrave by ohorngrave.sc;
-sub Ohornhookabove by ohornhookabove.sc;
-sub Ohorntilde by ohorntilde.sc;
-sub Ohungarumlaut by ohungarumlaut.sc;
-sub Omacron by omacron.sc;
-sub Oslash by oslash.sc;
-sub Oslashacute by oslashacute.sc;
-sub Otilde by otilde.sc;
-sub OE by oe.sc;
-sub P by p.sc;
-sub Thorn by thorn.sc;
-sub Q by q.sc;
-sub R by r.sc;
-sub Racute by racute.sc;
-sub Rcaron by rcaron.sc;
-sub Rcommaaccent by rcommaaccent.sc;
-sub S by s.sc;
-sub Sacute by sacute.sc;
-sub Scaron by scaron.sc;
-sub Scedilla by scedilla.sc;
-sub Scircumflex by scircumflex.sc;
-sub Scommaaccent by scommaaccent.sc;
-sub T by t.sc;
-sub Tbar by tbar.sc;
-sub Tcaron by tcaron.sc;
-sub Tcedilla by tcedilla.sc;
-sub Tcommaaccent by tcommaaccent.sc;
-sub U by u.sc;
-sub Uacute by uacute.sc;
-sub Ubreve by ubreve.sc;
-sub Ucircumflex by ucircumflex.sc;
-sub Udieresis by udieresis.sc;
-sub Udotbelow by udotbelow.sc;
-sub Ugrave by ugrave.sc;
-sub Uhookabove by uhookabove.sc;
-sub Uhorn by uhorn.sc;
-sub Uhornacute by uhornacute.sc;
-sub Uhorndotbelow by uhorndotbelow.sc;
-sub Uhorngrave by uhorngrave.sc;
-sub Uhornhookabove by uhornhookabove.sc;
-sub Uhorntilde by uhorntilde.sc;
-sub Uhungarumlaut by uhungarumlaut.sc;
-sub Umacron by umacron.sc;
-sub Uogonek by uogonek.sc;
-sub Uring by uring.sc;
-sub Utilde by utilde.sc;
-sub V by v.sc;
-sub W by w.sc;
-sub Wacute by wacute.sc;
-sub Wcircumflex by wcircumflex.sc;
-sub Wdieresis by wdieresis.sc;
-sub Wgrave by wgrave.sc;
-sub X by x.sc;
-sub Y by y.sc;
-sub Yacute by yacute.sc;
-sub Ycircumflex by ycircumflex.sc;
-sub Ydieresis by ydieresis.sc;
-sub Ydotbelow by ydotbelow.sc;
-sub Ygrave by ygrave.sc;
-sub Yhookabove by yhookabove.sc;
-sub Ytilde by ytilde.sc;
-sub Z by z.sc;
-sub Zacute by zacute.sc;
-sub Zcaron by zcaron.sc;
-sub Zdotaccent by zdotaccent.sc;
-sub A-cy by a-cy.sc;
-sub Be-cy by be-cy.sc;
-sub Ve-cy by ve-cy.sc;
-sub Ge-cy by ge-cy.sc;
-sub Gje-cy by gje-cy.sc;
-sub Gheupturn-cy by gheupturn-cy.sc;
-sub De-cy by de-cy.sc;
-sub Ie-cy by ie-cy.sc;
-sub Iegrave-cy by iegrave-cy.sc;
-sub Io-cy by io-cy.sc;
-sub Zhe-cy by zhe-cy.sc;
-sub Ze-cy by ze-cy.sc;
-sub Ii-cy by ii-cy.sc;
-sub Iishort-cy by iishort-cy.sc;
-sub Iigrave-cy by iigrave-cy.sc;
-sub Iishorttail-cy by iishorttail-cy.sc;
-sub Ka-cy by ka-cy.sc;
-sub Kje-cy by kje-cy.sc;
-sub El-cy by el-cy.sc;
-sub Em-cy by em-cy.sc;
-sub En-cy by en-cy.sc;
-sub O-cy by o-cy.sc;
-sub Pe-cy by pe-cy.sc;
-sub Er-cy by er-cy.sc;
-sub Es-cy by es-cy.sc;
-sub Te-cy by te-cy.sc;
-sub U-cy by u-cy.sc;
-sub Ushort-cy by ushort-cy.sc;
-sub Ef-cy by ef-cy.sc;
-sub Ha-cy by ha-cy.sc;
-sub Che-cy by che-cy.sc;
-sub Tse-cy by tse-cy.sc;
-sub Sha-cy by sha-cy.sc;
-sub Shcha-cy by shcha-cy.sc;
-sub Dzhe-cy by dzhe-cy.sc;
-sub Softsign-cy by softsign-cy.sc;
-sub Hardsign-cy by hardsign-cy.sc;
-sub Yeru-cy by yeru-cy.sc;
-sub Lje-cy by lje-cy.sc;
-sub Nje-cy by nje-cy.sc;
-sub Dze-cy by dze-cy.sc;
-sub E-cy by e-cy.sc;
-sub Ereversed-cy by ereversed-cy.sc;
-sub I-cy by i-cy.sc;
-sub Yi-cy by yi-cy.sc;
-sub Je-cy by je-cy.sc;
-sub Tshe-cy by tshe-cy.sc;
-sub Iu-cy by iu-cy.sc;
-sub Ia-cy by ia-cy.sc;
-sub Dje-cy by dje-cy.sc;
-sub Yat-cy by yat-cy.sc;
-sub Yusbig-cy by yusbig-cy.sc;
-sub Fita-cy by fita-cy.sc;
-sub Izhitsa-cy by izhitsa-cy.sc;
-sub Ghestroke-cy by ghestroke-cy.sc;
-sub Ghemiddlehook-cy by ghemiddlehook-cy.sc;
-sub Zhedescender-cy by zhedescender-cy.sc;
-sub Zedescender-cy by zedescender-cy.sc;
-sub Kadescender-cy by kadescender-cy.sc;
-sub Kaverticalstroke-cy by kaverticalstroke-cy.sc;
-sub Kastroke-cy by kastroke-cy.sc;
-sub Kabashkir-cy by kabashkir-cy.sc;
-sub Endescender-cy by endescender-cy.sc;
-sub Enghe-cy by enghe-cy.sc;
-sub Pedescender-cy by pedescender-cy.sc;
-sub Haabkhasian-cy by haabkhasian-cy.sc;
-sub Esdescender-cy by esdescender-cy.sc;
-sub Tedescender-cy by tedescender-cy.sc;
-sub Ustraight-cy by ustraight-cy.sc;
-sub Ustraightstroke-cy by ustraightstroke-cy.sc;
-sub Hadescender-cy by hadescender-cy.sc;
-sub Tetse-cy by tetse-cy.sc;
-sub Chedescender-cy by chedescender-cy.sc;
-sub Cheverticalstroke-cy by cheverticalstroke-cy.sc;
-sub Shha-cy by shha-cy.sc;
-sub Shhadescender-cy by shhadescender-cy.sc;
-sub Cheabkhasian-cy by cheabkhasian-cy.sc;
-sub Chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;
-sub Palochka-cy by palochka-cy.sc;
-sub Zhebreve-cy by zhebreve-cy.sc;
-sub Kahook-cy by kahook-cy.sc;
-sub Eltail-cy by eltail-cy.sc;
-sub Enhook-cy by enhook-cy.sc;
-sub Entail-cy by entail-cy.sc;
-sub Chekhakassian-cy by chekhakassian-cy.sc;
-sub Emtail-cy by emtail-cy.sc;
-sub Abreve-cy by abreve-cy.sc;
-sub Adieresis-cy by adieresis-cy.sc;
-sub Aie-cy by aie-cy.sc;
-sub Iebreve-cy by iebreve-cy.sc;
-sub Schwa-cy by schwa-cy.sc;
-sub Schwadieresis-cy by schwadieresis-cy.sc;
-sub Zhedieresis-cy by zhedieresis-cy.sc;
-sub Zedieresis-cy by zedieresis-cy.sc;
-sub Dzeabkhasian-cy by dzeabkhasian-cy.sc;
-sub Imacron-cy by imacron-cy.sc;
-sub Idieresis-cy by idieresis-cy.sc;
-sub Odieresis-cy by odieresis-cy.sc;
-sub Obarred-cy by obarred-cy.sc;
-sub Obarreddieresis-cy by obarreddieresis-cy.sc;
-sub Edieresis-cy by edieresis-cy.sc;
-sub Umacron-cy by umacron-cy.sc;
-sub Udieresis-cy by udieresis-cy.sc;
-sub Uhungarumlaut-cy by uhungarumlaut-cy.sc;
-sub Chedieresis-cy by chedieresis-cy.sc;
-sub Gedescender-cy by gedescender-cy.sc;
-sub Yerudieresis-cy by yerudieresis-cy.sc;
-sub Gestrokehook-cy by gestrokehook-cy.sc;
-sub Hahook-cy by hahook-cy.sc;
-sub Hastroke-cy by hastroke-cy.sc;
-sub Reversedze-cy by reversedze-cy.sc;
-sub Elhook-cy by elhook-cy.sc;
-sub Qa-cy by qa-cy.sc;
-sub We-cy by we-cy.sc;
-sub Semisoftsign-cy by semisoftsign-cy.sc;
-sub Ertick-cy by ertick-cy.sc;
-sub EnLeftHook-cy by enlefthook-cy.sc;
-sub Eldescender-cy by eldescender-cy.sc;
-sub De-cy.loclBGR by de-cy.loclBGR.sc;
-sub El-cy.loclBGR by el-cy.loclBGR.sc;
-sub Ef-cy.loclBGR by ef-cy.loclBGR.sc;
-sub Ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;
-sub Zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;
-sub Esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;
-sub Esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;
-sub Alpha by alpha.sc;
-sub Beta by beta.sc;
-sub Gamma by gamma.sc;
-sub Delta by delta.sc;
-sub Epsilon by epsilon.sc;
-sub Zeta by zeta.sc;
-sub Eta by eta.sc;
-sub Theta by theta.sc;
-sub Iota by iota.sc;
-sub Kappa by kappa.sc;
-sub Lambda by lambda.sc;
-sub Mu by mu.sc;
-sub Nu by nu.sc;
-sub Xi by xi.sc;
-sub Omicron by omicron.sc;
-sub Pi by pi.sc;
-sub Rho by rho.sc;
-sub Sigma by sigma.sc;
-sub Tau by tau.sc;
-sub Upsilon by upsilon.sc;
-sub Phi by phi.sc;
-sub Chi by chi.sc;
-sub Psi by psi.sc;
-sub Omega by omega.sc;
-sub Alphatonos by alphatonos.sc;
-sub Epsilontonos by epsilontonos.sc;
-sub Etatonos by etatonos.sc;
-sub Iotatonos by iotatonos.sc;
-sub Omicrontonos by omicrontonos.sc;
-sub Upsilontonos by upsilontonos.sc;
-sub Omegatonos by omegatonos.sc;
-sub Iotadieresis by iotadieresis.sc;
-sub Upsilondieresis by upsilondieresis.sc;
-sub KaiSymbol by kaiSymbol.sc;
-sub Alphapsili by alphapsili.sc;
-sub Alphadasia by alphadasia.sc;
-sub Alphapsilivaria by alphapsilivaria.sc;
-sub Alphadasiavaria by alphadasiavaria.sc;
-sub Alphapsilioxia by alphapsilioxia.sc;
-sub Alphadasiaoxia by alphadasiaoxia.sc;
-sub Alphapsiliperispomeni by alphapsiliperispomeni.sc;
-sub Alphadasiaperispomeni by alphadasiaperispomeni.sc;
-sub Alphavaria by alphavaria.sc;
-sub Alphaoxia by alphaoxia.sc;
-sub Alphavrachy by alphavrachy.sc;
-sub Alphamacron by alphamacron.sc;
-sub Alphaprosgegrammeni by alphaypogegrammeni.sc;
-sub Alphapsiliprosgegrammeni by alphapsiliypogegrammeni.sc;
-sub Alphadasiaprosgegrammeni by alphadasiaypogegrammeni.sc;
-sub Alphapsilivariaprosgegrammeni by alphapsilivariaypogegrammeni.sc;
-sub Alphadasiavariaprosgegrammeni by alphadasiavariaypogegrammeni.sc;
-sub Alphapsilioxiaprosgegrammeni by alphapsilioxiaypogegrammeni.sc;
-sub Alphadasiaoxiaprosgegrammeni by alphadasiaoxiaypogegrammeni.sc;
-sub Alphapsiliperispomeniprosgegrammeni by alphapsiliperispomeniypogegrammeni.sc;
-sub Alphadasiaperispomeniprosgegrammeni by alphadasiaperispomeniypogegrammeni.sc;
-sub Epsilonpsili by epsilonpsili.sc;
-sub Epsilondasia by epsilondasia.sc;
-sub Epsilonpsilivaria by epsilonpsilivaria.sc;
-sub Epsilondasiavaria by epsilondasiavaria.sc;
-sub Epsilonpsilioxia by epsilonpsilioxia.sc;
-sub Epsilondasiaoxia by epsilondasiaoxia.sc;
-sub Epsilonvaria by epsilonvaria.sc;
-sub Epsilonoxia by epsilonoxia.sc;
-sub Etapsili by etapsili.sc;
-sub Etadasia by etadasia.sc;
-sub Etapsilivaria by etapsilivaria.sc;
-sub Etadasiavaria by etadasiavaria.sc;
-sub Etapsilioxia by etapsilioxia.sc;
-sub Etadasiaoxia by etadasiaoxia.sc;
-sub Etapsiliperispomeni by etapsiliperispomeni.sc;
-sub Etadasiaperispomeni by etadasiaperispomeni.sc;
-sub Etavaria by etavaria.sc;
-sub Etaoxia by etaoxia.sc;
-sub Etaprosgegrammeni by etaypogegrammeni.sc;
-sub Etapsiliprosgegrammeni by etapsiliypogegrammeni.sc;
-sub Etadasiaprosgegrammeni by etadasiaypogegrammeni.sc;
-sub Etapsilivariaprosgegrammeni by etapsilivariaypogegrammeni.sc;
-sub Etadasiavariaprosgegrammeni by etadasiavariaypogegrammeni.sc;
-sub Etapsilioxiaprosgegrammeni by etapsilioxiaypogegrammeni.sc;
-sub Etadasiaoxiaprosgegrammeni by etadasiaoxiaypogegrammeni.sc;
-sub Etapsiliperispomeniprosgegrammeni by etapsiliperispomeniypogegrammeni.sc;
-sub Etadasiaperispomeniprosgegrammeni by etadasiaperispomeniypogegrammeni.sc;
-sub Iotapsili by iotapsili.sc;
-sub Iotadasia by iotadasia.sc;
-sub Iotapsilivaria by iotapsilivaria.sc;
-sub Iotadasiavaria by iotadasiavaria.sc;
-sub Iotapsilioxia by iotapsilioxia.sc;
-sub Iotadasiaoxia by iotadasiaoxia.sc;
-sub Iotapsiliperispomeni by iotapsiliperispomeni.sc;
-sub Iotadasiaperispomeni by iotadasiaperispomeni.sc;
-sub Iotavaria by iotavaria.sc;
-sub Iotaoxia by iotaoxia.sc;
-sub Iotavrachy by iotavrachy.sc;
-sub Iotamacron by iotamacron.sc;
-sub Omicronpsili by omicronpsili.sc;
-sub Omicrondasia by omicrondasia.sc;
-sub Omicronpsilivaria by omicronpsilivaria.sc;
-sub Omicrondasiavaria by omicrondasiavaria.sc;
-sub Omicronpsilioxia by omicronpsilioxia.sc;
-sub Omicrondasiaoxia by omicrondasiaoxia.sc;
-sub Omicronvaria by omicronvaria.sc;
-sub Omicronoxia by omicronoxia.sc;
-sub Rhodasia by rhodasia.sc;
-sub Upsilondasia by upsilondasia.sc;
-sub Upsilondasiavaria by upsilondasiavaria.sc;
-sub Upsilondasiaoxia by upsilondasiaoxia.sc;
-sub Upsilondasiaperispomeni by upsilondasiaperispomeni.sc;
-sub Upsilonvaria by upsilonvaria.sc;
-sub Upsilonoxia by upsilonoxia.sc;
-sub Upsilonvrachy by upsilonvrachy.sc;
-sub Upsilonmacron by upsilonmacron.sc;
-sub Omegapsili by omegapsili.sc;
-sub Omegadasia by omegadasia.sc;
-sub Omegapsilivaria by omegapsilivaria.sc;
-sub Omegadasiavaria by omegadasiavaria.sc;
-sub Omegapsilioxia by omegapsilioxia.sc;
-sub Omegadasiaoxia by omegadasiaoxia.sc;
-sub Omegapsiliperispomeni by omegapsiliperispomeni.sc;
-sub Omegadasiaperispomeni by omegadasiaperispomeni.sc;
-sub Omegavaria by omegavaria.sc;
-sub Omegaoxia by omegaoxia.sc;
-sub Omegaprosgegrammeni by omegaypogegrammeni.sc;
-sub Omegapsiliprosgegrammeni by omegapsiliypogegrammeni.sc;
-sub Omegadasiaprosgegrammeni by omegadasiaypogegrammeni.sc;
-sub Omegapsilivariaprosgegrammeni by omegapsilivariaypogegrammeni.sc;
-sub Omegadasiavariaprosgegrammeni by omegadasiavariaypogegrammeni.sc;
-sub Omegapsilioxiaprosgegrammeni by omegapsilioxiaypogegrammeni.sc;
-sub Omegadasiaoxiaprosgegrammeni by omegadasiaoxiaypogegrammeni.sc;
-sub Omegapsiliperispomeniprosgegrammeni by omegapsiliperispomeniypogegrammeni.sc;
-sub Omegadasiaperispomeniprosgegrammeni by omegadasiaperispomeniypogegrammeni.sc;
-sub zero by zero.sc;
-sub one by one.sc;
-sub two by two.sc;
-sub three by three.sc;
-sub four by four.sc;
-sub five by five.sc;
-sub six by six.sc;
-sub seven by seven.sc;
-sub eight by eight.sc;
-sub nine by nine.sc;
-sub anoteleia by anoteleia.sc;
-sub dieresiscomb by dieresiscomb.sc;
-sub dotaccentcomb by dotaccentcomb.sc;
-sub gravecomb by gravecomb.sc;
-sub acutecomb by acutecomb.sc;
-sub hungarumlautcomb by hungarumlautcomb.sc;
-sub circumflexcomb by circumflexcomb.sc;
-sub caroncomb by caroncomb.sc;
-sub brevecomb by brevecomb.sc;
-sub ringcomb by ringcomb.sc;
-sub tildecomb by tildecomb.sc;
-sub macroncomb by macroncomb.sc;
-sub hookabovecomb by hookabovecomb.sc;
-sub tonos by tonos.sc;
-sub dieresistonos by dieresistonos.sc;
-sub psili by psili.sc;
-sub koronis by koronis.sc;
-sub dasia by dasia.sc;
-sub psilivaria by psilivaria.sc;
-sub dasiavaria by dasiavaria.sc;
-sub psilioxia by psilioxia.sc;
-sub dasiaoxia by dasiaoxia.sc;
-sub psiliperispomeni by psiliperispomeni.sc;
-sub dasiaperispomeni by dasiaperispomeni.sc;
-sub dialytikavaria by dialytikavaria.sc;
-sub dialytikaoxia by dialytikaoxia.sc;
-sub dialytikaperispomeni by dialytikaperispomeni.sc;
-sub varia by varia.sc;
-sub oxia by oxia.sc;
-sub perispomeni by perispomeni.sc;
-sub brevecomb_acutecomb by brevecomb_acutecomb.sc;
-sub brevecomb_gravecomb by brevecomb_gravecomb.sc;
-sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;
-sub brevecomb_tildecomb by brevecomb_tildecomb.sc;
-sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;
-sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;
-sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;
-sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;
-sub brevecombcy by brevecombcy.sc;
-";
+code = "sub A by a.sc;\012sub Aacute by aacute.sc;\012sub Abreve by abreve.sc;\012sub Abreveacute by abreveacute.sc;\012sub Abrevedotbelow by abrevedotbelow.sc;\012sub Abrevegrave by abrevegrave.sc;\012sub Abrevehookabove by abrevehookabove.sc;\012sub Abrevetilde by abrevetilde.sc;\012sub Acaron by acaron.sc;\012sub Acircumflex by acircumflex.sc;\012sub Acircumflexacute by acircumflexacute.sc;\012sub Acircumflexdotbelow by acircumflexdotbelow.sc;\012sub Acircumflexgrave by acircumflexgrave.sc;\012sub Acircumflexhookabove by acircumflexhookabove.sc;\012sub Acircumflextilde by acircumflextilde.sc;\012sub Adieresis by adieresis.sc;\012sub Adotbelow by adotbelow.sc;\012sub Agrave by agrave.sc;\012sub Ahookabove by ahookabove.sc;\012sub Amacron by amacron.sc;\012sub Aogonek by aogonek.sc;\012sub Aring by aring.sc;\012sub Aringacute by aringacute.sc;\012sub Atilde by atilde.sc;\012sub AE by ae.sc;\012sub AEacute by aeacute.sc;\012sub B by b.sc;\012sub C by c.sc;\012sub Cacute by cacute.sc;\012sub Ccaron by ccaron.sc;\012sub Ccedilla by ccedilla.sc;\012sub Ccircumflex by ccircumflex.sc;\012sub Cdotaccent by cdotaccent.sc;\012sub D by d.sc;\012sub Eth by eth.sc;\012sub Dcaron by dcaron.sc;\012sub Dcroat by dcroat.sc;\012sub E by e.sc;\012sub Eacute by eacute.sc;\012sub Ebreve by ebreve.sc;\012sub Ecaron by ecaron.sc;\012sub Ecircumflex by ecircumflex.sc;\012sub Ecircumflexacute by ecircumflexacute.sc;\012sub Ecircumflexdotbelow by ecircumflexdotbelow.sc;\012sub Ecircumflexgrave by ecircumflexgrave.sc;\012sub Ecircumflexhookabove by ecircumflexhookabove.sc;\012sub Ecircumflextilde by ecircumflextilde.sc;\012sub Edieresis by edieresis.sc;\012sub Edotaccent by edotaccent.sc;\012sub Edotbelow by edotbelow.sc;\012sub Egrave by egrave.sc;\012sub Ehookabove by ehookabove.sc;\012sub Emacron by emacron.sc;\012sub Eogonek by eogonek.sc;\012sub Etilde by etilde.sc;\012sub F by f.sc;\012sub G by g.sc;\012sub Gbreve by gbreve.sc;\012sub Gcircumflex by gcircumflex.sc;\012sub Gcommaaccent by gcommaaccent.sc;\012sub Gdotaccent by gdotaccent.sc;\012sub H by h.sc;\012sub Hbar by hbar.sc;\012sub Hcircumflex by hcircumflex.sc;\012sub I by i.sc;\012sub Iacute by iacute.sc;\012sub Ibreve by ibreve.sc;\012sub Icircumflex by icircumflex.sc;\012sub Idieresis by idieresis.sc;\012sub Idotaccent by idotaccent.sc;\012sub Idotbelow by idotbelow.sc;\012sub Igrave by igrave.sc;\012sub Ihookabove by ihookabove.sc;\012sub Imacron by imacron.sc;\012sub Iogonek by iogonek.sc;\012sub Itilde by itilde.sc;\012sub J by j.sc;\012sub Jcircumflex by jcircumflex.sc;\012sub K by k.sc;\012sub Kcommaaccent by kcommaaccent.sc;\012sub L by l.sc;\012sub Lacute by lacute.sc;\012sub Lcaron by lcaron.sc;\012sub Lcommaaccent by lcommaaccent.sc;\012sub Ldot by ldot.sc;\012sub Lslash by lslash.sc;\012sub M by m.sc;\012sub N by n.sc;\012sub Nacute by nacute.sc;\012sub Ncaron by ncaron.sc;\012sub Ncommaaccent by ncommaaccent.sc;\012sub Eng by eng.sc;\012sub Ntilde by ntilde.sc;\012sub O by o.sc;\012sub Oacute by oacute.sc;\012sub Obreve by obreve.sc;\012sub Ocircumflex by ocircumflex.sc;\012sub Ocircumflexacute by ocircumflexacute.sc;\012sub Ocircumflexdotbelow by ocircumflexdotbelow.sc;\012sub Ocircumflexgrave by ocircumflexgrave.sc;\012sub Ocircumflexhookabove by ocircumflexhookabove.sc;\012sub Ocircumflextilde by ocircumflextilde.sc;\012sub Odieresis by odieresis.sc;\012sub Odotbelow by odotbelow.sc;\012sub Ograve by ograve.sc;\012sub Ohookabove by ohookabove.sc;\012sub Ohorn by ohorn.sc;\012sub Ohornacute by ohornacute.sc;\012sub Ohorndotbelow by ohorndotbelow.sc;\012sub Ohorngrave by ohorngrave.sc;\012sub Ohornhookabove by ohornhookabove.sc;\012sub Ohorntilde by ohorntilde.sc;\012sub Ohungarumlaut by ohungarumlaut.sc;\012sub Omacron by omacron.sc;\012sub Oslash by oslash.sc;\012sub Oslashacute by oslashacute.sc;\012sub Otilde by otilde.sc;\012sub OE by oe.sc;\012sub P by p.sc;\012sub Thorn by thorn.sc;\012sub Q by q.sc;\012sub R by r.sc;\012sub Racute by racute.sc;\012sub Rcaron by rcaron.sc;\012sub Rcommaaccent by rcommaaccent.sc;\012sub S by s.sc;\012sub Sacute by sacute.sc;\012sub Scaron by scaron.sc;\012sub Scedilla by scedilla.sc;\012sub Scircumflex by scircumflex.sc;\012sub Scommaaccent by scommaaccent.sc;\012sub T by t.sc;\012sub Tbar by tbar.sc;\012sub Tcaron by tcaron.sc;\012sub Tcedilla by tcedilla.sc;\012sub Tcommaaccent by tcommaaccent.sc;\012sub U by u.sc;\012sub Uacute by uacute.sc;\012sub Ubreve by ubreve.sc;\012sub Ucircumflex by ucircumflex.sc;\012sub Udieresis by udieresis.sc;\012sub Udotbelow by udotbelow.sc;\012sub Ugrave by ugrave.sc;\012sub Uhookabove by uhookabove.sc;\012sub Uhorn by uhorn.sc;\012sub Uhornacute by uhornacute.sc;\012sub Uhorndotbelow by uhorndotbelow.sc;\012sub Uhorngrave by uhorngrave.sc;\012sub Uhornhookabove by uhornhookabove.sc;\012sub Uhorntilde by uhorntilde.sc;\012sub Uhungarumlaut by uhungarumlaut.sc;\012sub Umacron by umacron.sc;\012sub Uogonek by uogonek.sc;\012sub Uring by uring.sc;\012sub Utilde by utilde.sc;\012sub V by v.sc;\012sub W by w.sc;\012sub Wacute by wacute.sc;\012sub Wcircumflex by wcircumflex.sc;\012sub Wdieresis by wdieresis.sc;\012sub Wgrave by wgrave.sc;\012sub X by x.sc;\012sub Y by y.sc;\012sub Yacute by yacute.sc;\012sub Ycircumflex by ycircumflex.sc;\012sub Ydieresis by ydieresis.sc;\012sub Ydotbelow by ydotbelow.sc;\012sub Ygrave by ygrave.sc;\012sub Yhookabove by yhookabove.sc;\012sub Ytilde by ytilde.sc;\012sub Z by z.sc;\012sub Zacute by zacute.sc;\012sub Zcaron by zcaron.sc;\012sub Zdotaccent by zdotaccent.sc;\012sub A-cy by a-cy.sc;\012sub Be-cy by be-cy.sc;\012sub Ve-cy by ve-cy.sc;\012sub Ge-cy by ge-cy.sc;\012sub Gje-cy by gje-cy.sc;\012sub Gheupturn-cy by gheupturn-cy.sc;\012sub De-cy by de-cy.sc;\012sub Ie-cy by ie-cy.sc;\012sub Iegrave-cy by iegrave-cy.sc;\012sub Io-cy by io-cy.sc;\012sub Zhe-cy by zhe-cy.sc;\012sub Ze-cy by ze-cy.sc;\012sub Ii-cy by ii-cy.sc;\012sub Iishort-cy by iishort-cy.sc;\012sub Iigrave-cy by iigrave-cy.sc;\012sub Iishorttail-cy by iishorttail-cy.sc;\012sub Ka-cy by ka-cy.sc;\012sub Kje-cy by kje-cy.sc;\012sub El-cy by el-cy.sc;\012sub Em-cy by em-cy.sc;\012sub En-cy by en-cy.sc;\012sub O-cy by o-cy.sc;\012sub Pe-cy by pe-cy.sc;\012sub Er-cy by er-cy.sc;\012sub Es-cy by es-cy.sc;\012sub Te-cy by te-cy.sc;\012sub U-cy by u-cy.sc;\012sub Ushort-cy by ushort-cy.sc;\012sub Ef-cy by ef-cy.sc;\012sub Ha-cy by ha-cy.sc;\012sub Che-cy by che-cy.sc;\012sub Tse-cy by tse-cy.sc;\012sub Sha-cy by sha-cy.sc;\012sub Shcha-cy by shcha-cy.sc;\012sub Dzhe-cy by dzhe-cy.sc;\012sub Softsign-cy by softsign-cy.sc;\012sub Hardsign-cy by hardsign-cy.sc;\012sub Yeru-cy by yeru-cy.sc;\012sub Lje-cy by lje-cy.sc;\012sub Nje-cy by nje-cy.sc;\012sub Dze-cy by dze-cy.sc;\012sub E-cy by e-cy.sc;\012sub Ereversed-cy by ereversed-cy.sc;\012sub I-cy by i-cy.sc;\012sub Yi-cy by yi-cy.sc;\012sub Je-cy by je-cy.sc;\012sub Tshe-cy by tshe-cy.sc;\012sub Iu-cy by iu-cy.sc;\012sub Ia-cy by ia-cy.sc;\012sub Dje-cy by dje-cy.sc;\012sub Yat-cy by yat-cy.sc;\012sub Yusbig-cy by yusbig-cy.sc;\012sub Fita-cy by fita-cy.sc;\012sub Izhitsa-cy by izhitsa-cy.sc;\012sub Ghestroke-cy by ghestroke-cy.sc;\012sub Ghemiddlehook-cy by ghemiddlehook-cy.sc;\012sub Zhedescender-cy by zhedescender-cy.sc;\012sub Zedescender-cy by zedescender-cy.sc;\012sub Kadescender-cy by kadescender-cy.sc;\012sub Kaverticalstroke-cy by kaverticalstroke-cy.sc;\012sub Kastroke-cy by kastroke-cy.sc;\012sub Kabashkir-cy by kabashkir-cy.sc;\012sub Endescender-cy by endescender-cy.sc;\012sub Enghe-cy by enghe-cy.sc;\012sub Pedescender-cy by pedescender-cy.sc;\012sub Haabkhasian-cy by haabkhasian-cy.sc;\012sub Esdescender-cy by esdescender-cy.sc;\012sub Tedescender-cy by tedescender-cy.sc;\012sub Ustraight-cy by ustraight-cy.sc;\012sub Ustraightstroke-cy by ustraightstroke-cy.sc;\012sub Hadescender-cy by hadescender-cy.sc;\012sub Tetse-cy by tetse-cy.sc;\012sub Chedescender-cy by chedescender-cy.sc;\012sub Cheverticalstroke-cy by cheverticalstroke-cy.sc;\012sub Shha-cy by shha-cy.sc;\012sub Shhadescender-cy by shhadescender-cy.sc;\012sub Cheabkhasian-cy by cheabkhasian-cy.sc;\012sub Chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;\012sub Palochka-cy by palochka-cy.sc;\012sub Zhebreve-cy by zhebreve-cy.sc;\012sub Kahook-cy by kahook-cy.sc;\012sub Eltail-cy by eltail-cy.sc;\012sub Enhook-cy by enhook-cy.sc;\012sub Entail-cy by entail-cy.sc;\012sub Chekhakassian-cy by chekhakassian-cy.sc;\012sub Emtail-cy by emtail-cy.sc;\012sub Abreve-cy by abreve-cy.sc;\012sub Adieresis-cy by adieresis-cy.sc;\012sub Aie-cy by aie-cy.sc;\012sub Iebreve-cy by iebreve-cy.sc;\012sub Schwa-cy by schwa-cy.sc;\012sub Schwadieresis-cy by schwadieresis-cy.sc;\012sub Zhedieresis-cy by zhedieresis-cy.sc;\012sub Zedieresis-cy by zedieresis-cy.sc;\012sub Dzeabkhasian-cy by dzeabkhasian-cy.sc;\012sub Imacron-cy by imacron-cy.sc;\012sub Idieresis-cy by idieresis-cy.sc;\012sub Odieresis-cy by odieresis-cy.sc;\012sub Obarred-cy by obarred-cy.sc;\012sub Obarreddieresis-cy by obarreddieresis-cy.sc;\012sub Edieresis-cy by edieresis-cy.sc;\012sub Umacron-cy by umacron-cy.sc;\012sub Udieresis-cy by udieresis-cy.sc;\012sub Uhungarumlaut-cy by uhungarumlaut-cy.sc;\012sub Chedieresis-cy by chedieresis-cy.sc;\012sub Gedescender-cy by gedescender-cy.sc;\012sub Yerudieresis-cy by yerudieresis-cy.sc;\012sub Gestrokehook-cy by gestrokehook-cy.sc;\012sub Hahook-cy by hahook-cy.sc;\012sub Hastroke-cy by hastroke-cy.sc;\012sub Reversedze-cy by reversedze-cy.sc;\012sub Elhook-cy by elhook-cy.sc;\012sub Qa-cy by qa-cy.sc;\012sub We-cy by we-cy.sc;\012sub Semisoftsign-cy by semisoftsign-cy.sc;\012sub Ertick-cy by ertick-cy.sc;\012sub EnLeftHook-cy by enlefthook-cy.sc;\012sub Eldescender-cy by eldescender-cy.sc;\012sub De-cy.loclBGR by de-cy.loclBGR.sc;\012sub El-cy.loclBGR by el-cy.loclBGR.sc;\012sub Ef-cy.loclBGR by ef-cy.loclBGR.sc;\012sub Ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;\012sub Zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;\012sub Esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;\012sub Esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;\012sub Alpha by alpha.sc;\012sub Beta by beta.sc;\012sub Gamma by gamma.sc;\012sub Delta by delta.sc;\012sub Epsilon by epsilon.sc;\012sub Zeta by zeta.sc;\012sub Eta by eta.sc;\012sub Theta by theta.sc;\012sub Iota by iota.sc;\012sub Kappa by kappa.sc;\012sub Lambda by lambda.sc;\012sub Mu by mu.sc;\012sub Nu by nu.sc;\012sub Xi by xi.sc;\012sub Omicron by omicron.sc;\012sub Pi by pi.sc;\012sub Rho by rho.sc;\012sub Sigma by sigma.sc;\012sub Tau by tau.sc;\012sub Upsilon by upsilon.sc;\012sub Phi by phi.sc;\012sub Chi by chi.sc;\012sub Psi by psi.sc;\012sub Omega by omega.sc;\012sub Alphatonos by alphatonos.sc;\012sub Epsilontonos by epsilontonos.sc;\012sub Etatonos by etatonos.sc;\012sub Iotatonos by iotatonos.sc;\012sub Omicrontonos by omicrontonos.sc;\012sub Upsilontonos by upsilontonos.sc;\012sub Omegatonos by omegatonos.sc;\012sub Iotadieresis by iotadieresis.sc;\012sub Upsilondieresis by upsilondieresis.sc;\012sub KaiSymbol by kaiSymbol.sc;\012sub Alphapsili by alphapsili.sc;\012sub Alphadasia by alphadasia.sc;\012sub Alphapsilivaria by alphapsilivaria.sc;\012sub Alphadasiavaria by alphadasiavaria.sc;\012sub Alphapsilioxia by alphapsilioxia.sc;\012sub Alphadasiaoxia by alphadasiaoxia.sc;\012sub Alphapsiliperispomeni by alphapsiliperispomeni.sc;\012sub Alphadasiaperispomeni by alphadasiaperispomeni.sc;\012sub Alphavaria by alphavaria.sc;\012sub Alphaoxia by alphaoxia.sc;\012sub Alphavrachy by alphavrachy.sc;\012sub Alphamacron by alphamacron.sc;\012sub Alphaprosgegrammeni by alphaypogegrammeni.sc;\012sub Alphapsiliprosgegrammeni by alphapsiliypogegrammeni.sc;\012sub Alphadasiaprosgegrammeni by alphadasiaypogegrammeni.sc;\012sub Alphapsilivariaprosgegrammeni by alphapsilivariaypogegrammeni.sc;\012sub Alphadasiavariaprosgegrammeni by alphadasiavariaypogegrammeni.sc;\012sub Alphapsilioxiaprosgegrammeni by alphapsilioxiaypogegrammeni.sc;\012sub Alphadasiaoxiaprosgegrammeni by alphadasiaoxiaypogegrammeni.sc;\012sub Alphapsiliperispomeniprosgegrammeni by alphapsiliperispomeniypogegrammeni.sc;\012sub Alphadasiaperispomeniprosgegrammeni by alphadasiaperispomeniypogegrammeni.sc;\012sub Epsilonpsili by epsilonpsili.sc;\012sub Epsilondasia by epsilondasia.sc;\012sub Epsilonpsilivaria by epsilonpsilivaria.sc;\012sub Epsilondasiavaria by epsilondasiavaria.sc;\012sub Epsilonpsilioxia by epsilonpsilioxia.sc;\012sub Epsilondasiaoxia by epsilondasiaoxia.sc;\012sub Epsilonvaria by epsilonvaria.sc;\012sub Epsilonoxia by epsilonoxia.sc;\012sub Etapsili by etapsili.sc;\012sub Etadasia by etadasia.sc;\012sub Etapsilivaria by etapsilivaria.sc;\012sub Etadasiavaria by etadasiavaria.sc;\012sub Etapsilioxia by etapsilioxia.sc;\012sub Etadasiaoxia by etadasiaoxia.sc;\012sub Etapsiliperispomeni by etapsiliperispomeni.sc;\012sub Etadasiaperispomeni by etadasiaperispomeni.sc;\012sub Etavaria by etavaria.sc;\012sub Etaoxia by etaoxia.sc;\012sub Etaprosgegrammeni by etaypogegrammeni.sc;\012sub Etapsiliprosgegrammeni by etapsiliypogegrammeni.sc;\012sub Etadasiaprosgegrammeni by etadasiaypogegrammeni.sc;\012sub Etapsilivariaprosgegrammeni by etapsilivariaypogegrammeni.sc;\012sub Etadasiavariaprosgegrammeni by etadasiavariaypogegrammeni.sc;\012sub Etapsilioxiaprosgegrammeni by etapsilioxiaypogegrammeni.sc;\012sub Etadasiaoxiaprosgegrammeni by etadasiaoxiaypogegrammeni.sc;\012sub Etapsiliperispomeniprosgegrammeni by etapsiliperispomeniypogegrammeni.sc;\012sub Etadasiaperispomeniprosgegrammeni by etadasiaperispomeniypogegrammeni.sc;\012sub Iotapsili by iotapsili.sc;\012sub Iotadasia by iotadasia.sc;\012sub Iotapsilivaria by iotapsilivaria.sc;\012sub Iotadasiavaria by iotadasiavaria.sc;\012sub Iotapsilioxia by iotapsilioxia.sc;\012sub Iotadasiaoxia by iotadasiaoxia.sc;\012sub Iotapsiliperispomeni by iotapsiliperispomeni.sc;\012sub Iotadasiaperispomeni by iotadasiaperispomeni.sc;\012sub Iotavaria by iotavaria.sc;\012sub Iotaoxia by iotaoxia.sc;\012sub Iotavrachy by iotavrachy.sc;\012sub Iotamacron by iotamacron.sc;\012sub Omicronpsili by omicronpsili.sc;\012sub Omicrondasia by omicrondasia.sc;\012sub Omicronpsilivaria by omicronpsilivaria.sc;\012sub Omicrondasiavaria by omicrondasiavaria.sc;\012sub Omicronpsilioxia by omicronpsilioxia.sc;\012sub Omicrondasiaoxia by omicrondasiaoxia.sc;\012sub Omicronvaria by omicronvaria.sc;\012sub Omicronoxia by omicronoxia.sc;\012sub Rhodasia by rhodasia.sc;\012sub Upsilondasia by upsilondasia.sc;\012sub Upsilondasiavaria by upsilondasiavaria.sc;\012sub Upsilondasiaoxia by upsilondasiaoxia.sc;\012sub Upsilondasiaperispomeni by upsilondasiaperispomeni.sc;\012sub Upsilonvaria by upsilonvaria.sc;\012sub Upsilonoxia by upsilonoxia.sc;\012sub Upsilonvrachy by upsilonvrachy.sc;\012sub Upsilonmacron by upsilonmacron.sc;\012sub Omegapsili by omegapsili.sc;\012sub Omegadasia by omegadasia.sc;\012sub Omegapsilivaria by omegapsilivaria.sc;\012sub Omegadasiavaria by omegadasiavaria.sc;\012sub Omegapsilioxia by omegapsilioxia.sc;\012sub Omegadasiaoxia by omegadasiaoxia.sc;\012sub Omegapsiliperispomeni by omegapsiliperispomeni.sc;\012sub Omegadasiaperispomeni by omegadasiaperispomeni.sc;\012sub Omegavaria by omegavaria.sc;\012sub Omegaoxia by omegaoxia.sc;\012sub Omegaprosgegrammeni by omegaypogegrammeni.sc;\012sub Omegapsiliprosgegrammeni by omegapsiliypogegrammeni.sc;\012sub Omegadasiaprosgegrammeni by omegadasiaypogegrammeni.sc;\012sub Omegapsilivariaprosgegrammeni by omegapsilivariaypogegrammeni.sc;\012sub Omegadasiavariaprosgegrammeni by omegadasiavariaypogegrammeni.sc;\012sub Omegapsilioxiaprosgegrammeni by omegapsilioxiaypogegrammeni.sc;\012sub Omegadasiaoxiaprosgegrammeni by omegadasiaoxiaypogegrammeni.sc;\012sub Omegapsiliperispomeniprosgegrammeni by omegapsiliperispomeniypogegrammeni.sc;\012sub Omegadasiaperispomeniprosgegrammeni by omegadasiaperispomeniypogegrammeni.sc;\012sub zero by zero.sc;\012sub one by one.sc;\012sub two by two.sc;\012sub three by three.sc;\012sub four by four.sc;\012sub five by five.sc;\012sub six by six.sc;\012sub seven by seven.sc;\012sub eight by eight.sc;\012sub nine by nine.sc;\012sub anoteleia by anoteleia.sc;\012sub dieresiscomb by dieresiscomb.sc;\012sub dotaccentcomb by dotaccentcomb.sc;\012sub gravecomb by gravecomb.sc;\012sub acutecomb by acutecomb.sc;\012sub hungarumlautcomb by hungarumlautcomb.sc;\012sub circumflexcomb by circumflexcomb.sc;\012sub caroncomb by caroncomb.sc;\012sub brevecomb by brevecomb.sc;\012sub ringcomb by ringcomb.sc;\012sub tildecomb by tildecomb.sc;\012sub macroncomb by macroncomb.sc;\012sub hookabovecomb by hookabovecomb.sc;\012sub tonos by tonos.sc;\012sub dieresistonos by dieresistonos.sc;\012sub psili by psili.sc;\012sub koronis by koronis.sc;\012sub dasia by dasia.sc;\012sub psilivaria by psilivaria.sc;\012sub dasiavaria by dasiavaria.sc;\012sub psilioxia by psilioxia.sc;\012sub dasiaoxia by dasiaoxia.sc;\012sub psiliperispomeni by psiliperispomeni.sc;\012sub dasiaperispomeni by dasiaperispomeni.sc;\012sub dialytikavaria by dialytikavaria.sc;\012sub dialytikaoxia by dialytikaoxia.sc;\012sub dialytikaperispomeni by dialytikaperispomeni.sc;\012sub varia by varia.sc;\012sub oxia by oxia.sc;\012sub perispomeni by perispomeni.sc;\012sub brevecomb_acutecomb by brevecomb_acutecomb.sc;\012sub brevecomb_gravecomb by brevecomb_gravecomb.sc;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;\012sub brevecomb_tildecomb by brevecomb_tildecomb.sc;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;\012sub brevecombcy by brevecombcy.sc;\012";
 name = c2sc;
 },
 {
 automatic = 1;
-code = "sub a by a.sc;
-sub aacute by aacute.sc;
-sub abreve by abreve.sc;
-sub abreveacute by abreveacute.sc;
-sub abrevedotbelow by abrevedotbelow.sc;
-sub abrevegrave by abrevegrave.sc;
-sub abrevehookabove by abrevehookabove.sc;
-sub abrevetilde by abrevetilde.sc;
-sub acircumflex by acircumflex.sc;
-sub acircumflexacute by acircumflexacute.sc;
-sub acircumflexdotbelow by acircumflexdotbelow.sc;
-sub acircumflexgrave by acircumflexgrave.sc;
-sub acircumflexhookabove by acircumflexhookabove.sc;
-sub acircumflextilde by acircumflextilde.sc;
-sub adieresis by adieresis.sc;
-sub adotbelow by adotbelow.sc;
-sub agrave by agrave.sc;
-sub ahookabove by ahookabove.sc;
-sub amacron by amacron.sc;
-sub aogonek by aogonek.sc;
-sub aring by aring.sc;
-sub aringacute by aringacute.sc;
-sub atilde by atilde.sc;
-sub ae by ae.sc;
-sub aeacute by aeacute.sc;
-sub b by b.sc;
-sub c by c.sc;
-sub cacute by cacute.sc;
-sub ccaron by ccaron.sc;
-sub ccedilla by ccedilla.sc;
-sub ccircumflex by ccircumflex.sc;
-sub cdotaccent by cdotaccent.sc;
-sub d by d.sc;
-sub eth by eth.sc;
-sub dcaron by dcaron.sc;
-sub dcroat by dcroat.sc;
-sub e by e.sc;
-sub eacute by eacute.sc;
-sub ebreve by ebreve.sc;
-sub ecaron by ecaron.sc;
-sub ecircumflex by ecircumflex.sc;
-sub ecircumflexacute by ecircumflexacute.sc;
-sub ecircumflexdotbelow by ecircumflexdotbelow.sc;
-sub ecircumflexgrave by ecircumflexgrave.sc;
-sub ecircumflexhookabove by ecircumflexhookabove.sc;
-sub ecircumflextilde by ecircumflextilde.sc;
-sub edieresis by edieresis.sc;
-sub edotaccent by edotaccent.sc;
-sub edotbelow by edotbelow.sc;
-sub egrave by egrave.sc;
-sub ehookabove by ehookabove.sc;
-sub emacron by emacron.sc;
-sub eogonek by eogonek.sc;
-sub etilde by etilde.sc;
-sub f by f.sc;
-sub g by g.sc;
-sub gbreve by gbreve.sc;
-sub gcircumflex by gcircumflex.sc;
-sub gcommaaccent by gcommaaccent.sc;
-sub gdotaccent by gdotaccent.sc;
-sub h by h.sc;
-sub hbar by hbar.sc;
-sub hcircumflex by hcircumflex.sc;
-sub i by i.sc;
-sub iacute by iacute.sc;
-sub ibreve by ibreve.sc;
-sub icircumflex by icircumflex.sc;
-sub idieresis by idieresis.sc;
-sub idotbelow by idotbelow.sc;
-sub igrave by igrave.sc;
-sub ihookabove by ihookabove.sc;
-sub imacron by imacron.sc;
-sub iogonek by iogonek.sc;
-sub itilde by itilde.sc;
-sub j by j.sc;
-sub jcircumflex by jcircumflex.sc;
-sub k by k.sc;
-sub kcommaaccent by kcommaaccent.sc;
-sub l by l.sc;
-sub lacute by lacute.sc;
-sub lcaron by lcaron.sc;
-sub lcommaaccent by lcommaaccent.sc;
-sub lslash by lslash.sc;
-sub m by m.sc;
-sub n by n.sc;
-sub nacute by nacute.sc;
-sub ncaron by ncaron.sc;
-sub ncommaaccent by ncommaaccent.sc;
-sub eng by eng.sc;
-sub ntilde by ntilde.sc;
-sub o by o.sc;
-sub oacute by oacute.sc;
-sub obreve by obreve.sc;
-sub ocircumflex by ocircumflex.sc;
-sub ocircumflexacute by ocircumflexacute.sc;
-sub ocircumflexdotbelow by ocircumflexdotbelow.sc;
-sub ocircumflexgrave by ocircumflexgrave.sc;
-sub ocircumflexhookabove by ocircumflexhookabove.sc;
-sub ocircumflextilde by ocircumflextilde.sc;
-sub odieresis by odieresis.sc;
-sub odotbelow by odotbelow.sc;
-sub ograve by ograve.sc;
-sub ohookabove by ohookabove.sc;
-sub ohorn by ohorn.sc;
-sub ohornacute by ohornacute.sc;
-sub ohorndotbelow by ohorndotbelow.sc;
-sub ohorngrave by ohorngrave.sc;
-sub ohornhookabove by ohornhookabove.sc;
-sub ohorntilde by ohorntilde.sc;
-sub ohungarumlaut by ohungarumlaut.sc;
-sub omacron by omacron.sc;
-sub oslash by oslash.sc;
-sub oslashacute by oslashacute.sc;
-sub otilde by otilde.sc;
-sub oe by oe.sc;
-sub p by p.sc;
-sub thorn by thorn.sc;
-sub q by q.sc;
-sub r by r.sc;
-sub racute by racute.sc;
-sub rcaron by rcaron.sc;
-sub rcommaaccent by rcommaaccent.sc;
-sub s by s.sc;
-sub sacute by sacute.sc;
-sub scaron by scaron.sc;
-sub scedilla by scedilla.sc;
-sub scircumflex by scircumflex.sc;
-sub scommaaccent by scommaaccent.sc;
-sub t by t.sc;
-sub tbar by tbar.sc;
-sub tcaron by tcaron.sc;
-sub tcedilla by tcedilla.sc;
-sub tcommaaccent by tcommaaccent.sc;
-sub u by u.sc;
-sub uacute by uacute.sc;
-sub ubreve by ubreve.sc;
-sub ucircumflex by ucircumflex.sc;
-sub udieresis by udieresis.sc;
-sub udotbelow by udotbelow.sc;
-sub ugrave by ugrave.sc;
-sub uhookabove by uhookabove.sc;
-sub uhorn by uhorn.sc;
-sub uhornacute by uhornacute.sc;
-sub uhorndotbelow by uhorndotbelow.sc;
-sub uhorngrave by uhorngrave.sc;
-sub uhornhookabove by uhornhookabove.sc;
-sub uhorntilde by uhorntilde.sc;
-sub uhungarumlaut by uhungarumlaut.sc;
-sub umacron by umacron.sc;
-sub uogonek by uogonek.sc;
-sub uring by uring.sc;
-sub utilde by utilde.sc;
-sub v by v.sc;
-sub w by w.sc;
-sub wacute by wacute.sc;
-sub wcircumflex by wcircumflex.sc;
-sub wdieresis by wdieresis.sc;
-sub wgrave by wgrave.sc;
-sub x by x.sc;
-sub y by y.sc;
-sub yacute by yacute.sc;
-sub ycircumflex by ycircumflex.sc;
-sub ydieresis by ydieresis.sc;
-sub ydotbelow by ydotbelow.sc;
-sub ygrave by ygrave.sc;
-sub yhookabove by yhookabove.sc;
-sub ytilde by ytilde.sc;
-sub z by z.sc;
-sub zacute by zacute.sc;
-sub zcaron by zcaron.sc;
-sub zdotaccent by zdotaccent.sc;
-sub a-cy by a-cy.sc;
-sub be-cy by be-cy.sc;
-sub ve-cy by ve-cy.sc;
-sub ge-cy by ge-cy.sc;
-sub gje-cy by gje-cy.sc;
-sub gheupturn-cy by gheupturn-cy.sc;
-sub de-cy by de-cy.sc;
-sub ie-cy by ie-cy.sc;
-sub iegrave-cy by iegrave-cy.sc;
-sub io-cy by io-cy.sc;
-sub zhe-cy by zhe-cy.sc;
-sub ze-cy by ze-cy.sc;
-sub ii-cy by ii-cy.sc;
-sub iishort-cy by iishort-cy.sc;
-sub iigrave-cy by iigrave-cy.sc;
-sub iishorttail-cy by iishorttail-cy.sc;
-sub ka-cy by ka-cy.sc;
-sub kje-cy by kje-cy.sc;
-sub el-cy by el-cy.sc;
-sub em-cy by em-cy.sc;
-sub en-cy by en-cy.sc;
-sub o-cy by o-cy.sc;
-sub pe-cy by pe-cy.sc;
-sub er-cy by er-cy.sc;
-sub es-cy by es-cy.sc;
-sub te-cy by te-cy.sc;
-sub u-cy by u-cy.sc;
-sub ushort-cy by ushort-cy.sc;
-sub ef-cy by ef-cy.sc;
-sub ha-cy by ha-cy.sc;
-sub che-cy by che-cy.sc;
-sub tse-cy by tse-cy.sc;
-sub sha-cy by sha-cy.sc;
-sub shcha-cy by shcha-cy.sc;
-sub dzhe-cy by dzhe-cy.sc;
-sub softsign-cy by softsign-cy.sc;
-sub hardsign-cy by hardsign-cy.sc;
-sub yeru-cy by yeru-cy.sc;
-sub lje-cy by lje-cy.sc;
-sub nje-cy by nje-cy.sc;
-sub dze-cy by dze-cy.sc;
-sub e-cy by e-cy.sc;
-sub ereversed-cy by ereversed-cy.sc;
-sub i-cy by i-cy.sc;
-sub yi-cy by yi-cy.sc;
-sub je-cy by je-cy.sc;
-sub tshe-cy by tshe-cy.sc;
-sub iu-cy by iu-cy.sc;
-sub ia-cy by ia-cy.sc;
-sub dje-cy by dje-cy.sc;
-sub yat-cy by yat-cy.sc;
-sub yusbig-cy by yusbig-cy.sc;
-sub fita-cy by fita-cy.sc;
-sub izhitsa-cy by izhitsa-cy.sc;
-sub ghestroke-cy by ghestroke-cy.sc;
-sub ghemiddlehook-cy by ghemiddlehook-cy.sc;
-sub zhedescender-cy by zhedescender-cy.sc;
-sub zedescender-cy by zedescender-cy.sc;
-sub kadescender-cy by kadescender-cy.sc;
-sub kaverticalstroke-cy by kaverticalstroke-cy.sc;
-sub kastroke-cy by kastroke-cy.sc;
-sub kabashkir-cy by kabashkir-cy.sc;
-sub endescender-cy by endescender-cy.sc;
-sub enghe-cy by enghe-cy.sc;
-sub pedescender-cy by pedescender-cy.sc;
-sub haabkhasian-cy by haabkhasian-cy.sc;
-sub esdescender-cy by esdescender-cy.sc;
-sub tedescender-cy by tedescender-cy.sc;
-sub ustraight-cy by ustraight-cy.sc;
-sub ustraightstroke-cy by ustraightstroke-cy.sc;
-sub hadescender-cy by hadescender-cy.sc;
-sub tetse-cy by tetse-cy.sc;
-sub chedescender-cy by chedescender-cy.sc;
-sub cheverticalstroke-cy by cheverticalstroke-cy.sc;
-sub shha-cy by shha-cy.sc;
-sub shhadescender-cy by shhadescender-cy.sc;
-sub cheabkhasian-cy by cheabkhasian-cy.sc;
-sub chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;
-sub palochka-cy by palochka-cy.sc;
-sub zhebreve-cy by zhebreve-cy.sc;
-sub kahook-cy by kahook-cy.sc;
-sub eltail-cy by eltail-cy.sc;
-sub enhook-cy by enhook-cy.sc;
-sub entail-cy by entail-cy.sc;
-sub chekhakassian-cy by chekhakassian-cy.sc;
-sub emtail-cy by emtail-cy.sc;
-sub abreve-cy by abreve-cy.sc;
-sub adieresis-cy by adieresis-cy.sc;
-sub aie-cy by aie-cy.sc;
-sub iebreve-cy by iebreve-cy.sc;
-sub schwa-cy by schwa-cy.sc;
-sub schwadieresis-cy by schwadieresis-cy.sc;
-sub zhedieresis-cy by zhedieresis-cy.sc;
-sub zedieresis-cy by zedieresis-cy.sc;
-sub dzeabkhasian-cy by dzeabkhasian-cy.sc;
-sub imacron-cy by imacron-cy.sc;
-sub idieresis-cy by idieresis-cy.sc;
-sub odieresis-cy by odieresis-cy.sc;
-sub obarred-cy by obarred-cy.sc;
-sub obarreddieresis-cy by obarreddieresis-cy.sc;
-sub edieresis-cy by edieresis-cy.sc;
-sub umacron-cy by umacron-cy.sc;
-sub udieresis-cy by udieresis-cy.sc;
-sub uhungarumlaut-cy by uhungarumlaut-cy.sc;
-sub chedieresis-cy by chedieresis-cy.sc;
-sub gedescender-cy by gedescender-cy.sc;
-sub yerudieresis-cy by yerudieresis-cy.sc;
-sub gestrokehook-cy by gestrokehook-cy.sc;
-sub hahook-cy by hahook-cy.sc;
-sub hastroke-cy by hastroke-cy.sc;
-sub reversedze-cy by reversedze-cy.sc;
-sub elhook-cy by elhook-cy.sc;
-sub qa-cy by qa-cy.sc;
-sub we-cy by we-cy.sc;
-sub semisoftsign-cy by semisoftsign-cy.sc;
-sub ertick-cy by ertick-cy.sc;
-sub enlefthook-cy by enlefthook-cy.sc;
-sub eldescender-cy by eldescender-cy.sc;
-sub ve-cy.loclBGR by ve-cy.sc;
-sub ge-cy.loclBGR by ge-cy.sc;
-sub de-cy.loclBGR by de-cy.loclBGR.sc;
-sub zhe-cy.loclBGR by zhe-cy.sc;
-sub ze-cy.loclBGR by ze-cy.sc;
-sub ii-cy.loclBGR by ii-cy.sc;
-sub iishort-cy.loclBGR by iishort-cy.sc;
-sub iigrave-cy.loclBGR by iigrave-cy.sc;
-sub ka-cy.loclBGR by ka-cy.sc;
-sub el-cy.loclBGR by el-cy.loclBGR.sc;
-sub pe-cy.loclBGR by pe-cy.sc;
-sub te-cy.loclBGR by te-cy.sc;
-sub ef-cy.loclBGR by ef-cy.loclBGR.sc;
-sub tse-cy.loclBGR by tse-cy.sc;
-sub sha-cy.loclBGR by sha-cy.sc;
-sub shcha-cy.loclBGR by shcha-cy.sc;
-sub softsign-cy.loclBGR by softsign-cy.sc;
-sub hardsign-cy.loclBGR by hardsign-cy.sc;
-sub yeru-cy.loclBGR by yeru-cy.sc;
-sub iu-cy.loclBGR by iu-cy.sc;
-sub ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;
-sub zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;
-sub esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;
-sub esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;
-sub be-cy.loclSRB by be-cy.sc;
-sub alpha by alpha.sc;
-sub beta by beta.sc;
-sub gamma by gamma.sc;
-sub delta by delta.sc;
-sub epsilon by epsilon.sc;
-sub zeta by zeta.sc;
-sub eta by eta.sc;
-sub theta by theta.sc;
-sub iota by iota.sc;
-sub kappa by kappa.sc;
-sub lambda by lambda.sc;
-sub mu by mu.sc;
-sub nu by nu.sc;
-sub xi by xi.sc;
-sub omicron by omicron.sc;
-sub pi by pi.sc;
-sub rho by rho.sc;
-sub sigmafinal by sigmafinal.sc;
-sub sigma by sigma.sc;
-sub tau by tau.sc;
-sub upsilon by upsilon.sc;
-sub phi by phi.sc;
-sub chi by chi.sc;
-sub psi by psi.sc;
-sub omega by omega.sc;
-sub iotatonos by iotatonos.sc;
-sub iotadieresis by iotadieresis.sc;
-sub iotadieresistonos by iotadieresistonos.sc;
-sub upsilontonos by upsilontonos.sc;
-sub upsilondieresis by upsilondieresis.sc;
-sub upsilondieresistonos by upsilondieresistonos.sc;
-sub omicrontonos by omicrontonos.sc;
-sub omegatonos by omegatonos.sc;
-sub alphatonos by alphatonos.sc;
-sub epsilontonos by epsilontonos.sc;
-sub etatonos by etatonos.sc;
-sub kaiSymbol by kaiSymbol.sc;
-sub alphapsili by alphapsili.sc;
-sub alphadasia by alphadasia.sc;
-sub alphapsilivaria by alphapsilivaria.sc;
-sub alphadasiavaria by alphadasiavaria.sc;
-sub alphapsilioxia by alphapsilioxia.sc;
-sub alphadasiaoxia by alphadasiaoxia.sc;
-sub alphapsiliperispomeni by alphapsiliperispomeni.sc;
-sub alphadasiaperispomeni by alphadasiaperispomeni.sc;
-sub alphavaria by alphavaria.sc;
-sub alphaoxia by alphaoxia.sc;
-sub alphaperispomeni by alphaperispomeni.sc;
-sub alphavrachy by alphavrachy.sc;
-sub alphamacron by alphamacron.sc;
-sub alphaypogegrammeni by alphaypogegrammeni.sc;
-sub alphavariaypogegrammeni by alphavariaypogegrammeni.sc;
-sub alphaoxiaypogegrammeni by alphaoxiaypogegrammeni.sc;
-sub alphapsiliypogegrammeni by alphapsiliypogegrammeni.sc;
-sub alphadasiaypogegrammeni by alphadasiaypogegrammeni.sc;
-sub alphapsilivariaypogegrammeni by alphapsilivariaypogegrammeni.sc;
-sub alphadasiavariaypogegrammeni by alphadasiavariaypogegrammeni.sc;
-sub alphapsilioxiaypogegrammeni by alphapsilioxiaypogegrammeni.sc;
-sub alphadasiaoxiaypogegrammeni by alphadasiaoxiaypogegrammeni.sc;
-sub alphapsiliperispomeniypogegrammeni by alphapsiliperispomeniypogegrammeni.sc;
-sub alphadasiaperispomeniypogegrammeni by alphadasiaperispomeniypogegrammeni.sc;
-sub alphaperispomeniypogegrammeni by alphaperispomeniypogegrammeni.sc;
-sub epsilonpsili by epsilonpsili.sc;
-sub epsilondasia by epsilondasia.sc;
-sub epsilonpsilivaria by epsilonpsilivaria.sc;
-sub epsilondasiavaria by epsilondasiavaria.sc;
-sub epsilonpsilioxia by epsilonpsilioxia.sc;
-sub epsilondasiaoxia by epsilondasiaoxia.sc;
-sub epsilonvaria by epsilonvaria.sc;
-sub epsilonoxia by epsilonoxia.sc;
-sub etapsili by etapsili.sc;
-sub etadasia by etadasia.sc;
-sub etapsilivaria by etapsilivaria.sc;
-sub etadasiavaria by etadasiavaria.sc;
-sub etapsilioxia by etapsilioxia.sc;
-sub etadasiaoxia by etadasiaoxia.sc;
-sub etapsiliperispomeni by etapsiliperispomeni.sc;
-sub etadasiaperispomeni by etadasiaperispomeni.sc;
-sub etavaria by etavaria.sc;
-sub etaoxia by etaoxia.sc;
-sub etaperispomeni by etaperispomeni.sc;
-sub etaypogegrammeni by etaypogegrammeni.sc;
-sub etavariaypogegrammeni by etavariaypogegrammeni.sc;
-sub etaoxiaypogegrammeni by etaoxiaypogegrammeni.sc;
-sub etapsiliypogegrammeni by etapsiliypogegrammeni.sc;
-sub etadasiaypogegrammeni by etadasiaypogegrammeni.sc;
-sub etapsilivariaypogegrammeni by etapsilivariaypogegrammeni.sc;
-sub etadasiavariaypogegrammeni by etadasiavariaypogegrammeni.sc;
-sub etapsilioxiaypogegrammeni by etapsilioxiaypogegrammeni.sc;
-sub etadasiaoxiaypogegrammeni by etadasiaoxiaypogegrammeni.sc;
-sub etapsiliperispomeniypogegrammeni by etapsiliperispomeniypogegrammeni.sc;
-sub etadasiaperispomeniypogegrammeni by etadasiaperispomeniypogegrammeni.sc;
-sub etaperispomeniypogegrammeni by etaperispomeniypogegrammeni.sc;
-sub iotapsili by iotapsili.sc;
-sub iotadasia by iotadasia.sc;
-sub iotapsilivaria by iotapsilivaria.sc;
-sub iotadasiavaria by iotadasiavaria.sc;
-sub iotapsilioxia by iotapsilioxia.sc;
-sub iotadasiaoxia by iotadasiaoxia.sc;
-sub iotapsiliperispomeni by iotapsiliperispomeni.sc;
-sub iotadasiaperispomeni by iotadasiaperispomeni.sc;
-sub iotavaria by iotavaria.sc;
-sub iotaoxia by iotaoxia.sc;
-sub iotaperispomeni by iotaperispomeni.sc;
-sub iotavrachy by iotavrachy.sc;
-sub iotamacron by iotamacron.sc;
-sub iotadialytikavaria by iotadialytikavaria.sc;
-sub iotadialytikaoxia by iotadialytikaoxia.sc;
-sub iotadialytikaperispomeni by iotadialytikaperispomeni.sc;
-sub omicronpsili by omicronpsili.sc;
-sub omicrondasia by omicrondasia.sc;
-sub omicronpsilivaria by omicronpsilivaria.sc;
-sub omicrondasiavaria by omicrondasiavaria.sc;
-sub omicronpsilioxia by omicronpsilioxia.sc;
-sub omicrondasiaoxia by omicrondasiaoxia.sc;
-sub omicronvaria by omicronvaria.sc;
-sub omicronoxia by omicronoxia.sc;
-sub rhopsili by rhopsili.sc;
-sub rhodasia by rhodasia.sc;
-sub upsilonpsili by upsilonpsili.sc;
-sub upsilondasia by upsilondasia.sc;
-sub upsilonpsilivaria by upsilonpsilivaria.sc;
-sub upsilondasiavaria by upsilondasiavaria.sc;
-sub upsilonpsilioxia by upsilonpsilioxia.sc;
-sub upsilondasiaoxia by upsilondasiaoxia.sc;
-sub upsilonpsiliperispomeni by upsilonpsiliperispomeni.sc;
-sub upsilondasiaperispomeni by upsilondasiaperispomeni.sc;
-sub upsilonvaria by upsilonvaria.sc;
-sub upsilonoxia by upsilonoxia.sc;
-sub upsilonperispomeni by upsilonperispomeni.sc;
-sub upsilonvrachy by upsilonvrachy.sc;
-sub upsilonmacron by upsilonmacron.sc;
-sub upsilondialytikavaria by upsilondialytikavaria.sc;
-sub upsilondialytikaoxia by upsilondialytikaoxia.sc;
-sub upsilondialytikaperispomeni by upsilondialytikaperispomeni.sc;
-sub omegapsili by omegapsili.sc;
-sub omegadasia by omegadasia.sc;
-sub omegapsilivaria by omegapsilivaria.sc;
-sub omegadasiavaria by omegadasiavaria.sc;
-sub omegapsilioxia by omegapsilioxia.sc;
-sub omegadasiaoxia by omegadasiaoxia.sc;
-sub omegapsiliperispomeni by omegapsiliperispomeni.sc;
-sub omegadasiaperispomeni by omegadasiaperispomeni.sc;
-sub omegavaria by omegavaria.sc;
-sub omegaoxia by omegaoxia.sc;
-sub omegaperispomeni by omegaperispomeni.sc;
-sub omegaypogegrammeni by omegaypogegrammeni.sc;
-sub omegavariaypogegrammeni by omegavariaypogegrammeni.sc;
-sub omegaoxiaypogegrammeni by omegaoxiaypogegrammeni.sc;
-sub omegapsiliypogegrammeni by omegapsiliypogegrammeni.sc;
-sub omegadasiaypogegrammeni by omegadasiaypogegrammeni.sc;
-sub omegapsilivariaypogegrammeni by omegapsilivariaypogegrammeni.sc;
-sub omegadasiavariaypogegrammeni by omegadasiavariaypogegrammeni.sc;
-sub omegapsilioxiaypogegrammeni by omegapsilioxiaypogegrammeni.sc;
-sub omegadasiaoxiaypogegrammeni by omegadasiaoxiaypogegrammeni.sc;
-sub omegapsiliperispomeniypogegrammeni by omegapsiliperispomeniypogegrammeni.sc;
-sub omegadasiaperispomeniypogegrammeni by omegadasiaperispomeniypogegrammeni.sc;
-sub omegaperispomeniypogegrammeni by omegaperispomeniypogegrammeni.sc;
-sub zero by zero.sc;
-sub one by one.sc;
-sub two by two.sc;
-sub three by three.sc;
-sub four by four.sc;
-sub five by five.sc;
-sub six by six.sc;
-sub seven by seven.sc;
-sub eight by eight.sc;
-sub nine by nine.sc;
-sub anoteleia by anoteleia.sc;
-sub dieresiscomb by dieresiscomb.sc;
-sub dotaccentcomb by dotaccentcomb.sc;
-sub gravecomb by gravecomb.sc;
-sub acutecomb by acutecomb.sc;
-sub hungarumlautcomb by hungarumlautcomb.sc;
-sub circumflexcomb by circumflexcomb.sc;
-sub caroncomb by caroncomb.sc;
-sub brevecomb by brevecomb.sc;
-sub ringcomb by ringcomb.sc;
-sub tildecomb by tildecomb.sc;
-sub macroncomb by macroncomb.sc;
-sub hookabovecomb by hookabovecomb.sc;
-sub tonos by tonos.sc;
-sub dieresistonos by dieresistonos.sc;
-sub psili by psili.sc;
-sub koronis by koronis.sc;
-sub dasia by dasia.sc;
-sub psilivaria by psilivaria.sc;
-sub dasiavaria by dasiavaria.sc;
-sub psilioxia by psilioxia.sc;
-sub dasiaoxia by dasiaoxia.sc;
-sub psiliperispomeni by psiliperispomeni.sc;
-sub dasiaperispomeni by dasiaperispomeni.sc;
-sub dialytikavaria by dialytikavaria.sc;
-sub dialytikaoxia by dialytikaoxia.sc;
-sub dialytikaperispomeni by dialytikaperispomeni.sc;
-sub varia by varia.sc;
-sub oxia by oxia.sc;
-sub perispomeni by perispomeni.sc;
-sub brevecomb_acutecomb by brevecomb_acutecomb.sc;
-sub brevecomb_gravecomb by brevecomb_gravecomb.sc;
-sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;
-sub brevecomb_tildecomb by brevecomb_tildecomb.sc;
-sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;
-sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;
-sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;
-sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;
-sub brevecombcy by brevecombcy.sc;
-";
+code = "sub a by a.sc;\012sub aacute by aacute.sc;\012sub abreve by abreve.sc;\012sub abreveacute by abreveacute.sc;\012sub abrevedotbelow by abrevedotbelow.sc;\012sub abrevegrave by abrevegrave.sc;\012sub abrevehookabove by abrevehookabove.sc;\012sub abrevetilde by abrevetilde.sc;\012sub acircumflex by acircumflex.sc;\012sub acircumflexacute by acircumflexacute.sc;\012sub acircumflexdotbelow by acircumflexdotbelow.sc;\012sub acircumflexgrave by acircumflexgrave.sc;\012sub acircumflexhookabove by acircumflexhookabove.sc;\012sub acircumflextilde by acircumflextilde.sc;\012sub adieresis by adieresis.sc;\012sub adotbelow by adotbelow.sc;\012sub agrave by agrave.sc;\012sub ahookabove by ahookabove.sc;\012sub amacron by amacron.sc;\012sub aogonek by aogonek.sc;\012sub aring by aring.sc;\012sub aringacute by aringacute.sc;\012sub atilde by atilde.sc;\012sub ae by ae.sc;\012sub aeacute by aeacute.sc;\012sub b by b.sc;\012sub c by c.sc;\012sub cacute by cacute.sc;\012sub ccaron by ccaron.sc;\012sub ccedilla by ccedilla.sc;\012sub ccircumflex by ccircumflex.sc;\012sub cdotaccent by cdotaccent.sc;\012sub d by d.sc;\012sub eth by eth.sc;\012sub dcaron by dcaron.sc;\012sub dcroat by dcroat.sc;\012sub e by e.sc;\012sub eacute by eacute.sc;\012sub ebreve by ebreve.sc;\012sub ecaron by ecaron.sc;\012sub ecircumflex by ecircumflex.sc;\012sub ecircumflexacute by ecircumflexacute.sc;\012sub ecircumflexdotbelow by ecircumflexdotbelow.sc;\012sub ecircumflexgrave by ecircumflexgrave.sc;\012sub ecircumflexhookabove by ecircumflexhookabove.sc;\012sub ecircumflextilde by ecircumflextilde.sc;\012sub edieresis by edieresis.sc;\012sub edotaccent by edotaccent.sc;\012sub edotbelow by edotbelow.sc;\012sub egrave by egrave.sc;\012sub ehookabove by ehookabove.sc;\012sub emacron by emacron.sc;\012sub eogonek by eogonek.sc;\012sub etilde by etilde.sc;\012sub f by f.sc;\012sub g by g.sc;\012sub gbreve by gbreve.sc;\012sub gcircumflex by gcircumflex.sc;\012sub gcommaaccent by gcommaaccent.sc;\012sub gdotaccent by gdotaccent.sc;\012sub h by h.sc;\012sub hbar by hbar.sc;\012sub hcircumflex by hcircumflex.sc;\012sub i by i.sc;\012sub iacute by iacute.sc;\012sub ibreve by ibreve.sc;\012sub icircumflex by icircumflex.sc;\012sub idieresis by idieresis.sc;\012sub idotbelow by idotbelow.sc;\012sub igrave by igrave.sc;\012sub ihookabove by ihookabove.sc;\012sub imacron by imacron.sc;\012sub iogonek by iogonek.sc;\012sub itilde by itilde.sc;\012sub j by j.sc;\012sub jcircumflex by jcircumflex.sc;\012sub k by k.sc;\012sub kcommaaccent by kcommaaccent.sc;\012sub l by l.sc;\012sub lacute by lacute.sc;\012sub lcaron by lcaron.sc;\012sub lcommaaccent by lcommaaccent.sc;\012sub lslash by lslash.sc;\012sub m by m.sc;\012sub n by n.sc;\012sub nacute by nacute.sc;\012sub ncaron by ncaron.sc;\012sub ncommaaccent by ncommaaccent.sc;\012sub eng by eng.sc;\012sub ntilde by ntilde.sc;\012sub o by o.sc;\012sub oacute by oacute.sc;\012sub obreve by obreve.sc;\012sub ocircumflex by ocircumflex.sc;\012sub ocircumflexacute by ocircumflexacute.sc;\012sub ocircumflexdotbelow by ocircumflexdotbelow.sc;\012sub ocircumflexgrave by ocircumflexgrave.sc;\012sub ocircumflexhookabove by ocircumflexhookabove.sc;\012sub ocircumflextilde by ocircumflextilde.sc;\012sub odieresis by odieresis.sc;\012sub odotbelow by odotbelow.sc;\012sub ograve by ograve.sc;\012sub ohookabove by ohookabove.sc;\012sub ohorn by ohorn.sc;\012sub ohornacute by ohornacute.sc;\012sub ohorndotbelow by ohorndotbelow.sc;\012sub ohorngrave by ohorngrave.sc;\012sub ohornhookabove by ohornhookabove.sc;\012sub ohorntilde by ohorntilde.sc;\012sub ohungarumlaut by ohungarumlaut.sc;\012sub omacron by omacron.sc;\012sub oslash by oslash.sc;\012sub oslashacute by oslashacute.sc;\012sub otilde by otilde.sc;\012sub oe by oe.sc;\012sub p by p.sc;\012sub thorn by thorn.sc;\012sub q by q.sc;\012sub r by r.sc;\012sub racute by racute.sc;\012sub rcaron by rcaron.sc;\012sub rcommaaccent by rcommaaccent.sc;\012sub s by s.sc;\012sub sacute by sacute.sc;\012sub scaron by scaron.sc;\012sub scedilla by scedilla.sc;\012sub scircumflex by scircumflex.sc;\012sub scommaaccent by scommaaccent.sc;\012sub t by t.sc;\012sub tbar by tbar.sc;\012sub tcaron by tcaron.sc;\012sub tcedilla by tcedilla.sc;\012sub tcommaaccent by tcommaaccent.sc;\012sub u by u.sc;\012sub uacute by uacute.sc;\012sub ubreve by ubreve.sc;\012sub ucircumflex by ucircumflex.sc;\012sub udieresis by udieresis.sc;\012sub udotbelow by udotbelow.sc;\012sub ugrave by ugrave.sc;\012sub uhookabove by uhookabove.sc;\012sub uhorn by uhorn.sc;\012sub uhornacute by uhornacute.sc;\012sub uhorndotbelow by uhorndotbelow.sc;\012sub uhorngrave by uhorngrave.sc;\012sub uhornhookabove by uhornhookabove.sc;\012sub uhorntilde by uhorntilde.sc;\012sub uhungarumlaut by uhungarumlaut.sc;\012sub umacron by umacron.sc;\012sub uogonek by uogonek.sc;\012sub uring by uring.sc;\012sub utilde by utilde.sc;\012sub v by v.sc;\012sub w by w.sc;\012sub wacute by wacute.sc;\012sub wcircumflex by wcircumflex.sc;\012sub wdieresis by wdieresis.sc;\012sub wgrave by wgrave.sc;\012sub x by x.sc;\012sub y by y.sc;\012sub yacute by yacute.sc;\012sub ycircumflex by ycircumflex.sc;\012sub ydieresis by ydieresis.sc;\012sub ydotbelow by ydotbelow.sc;\012sub ygrave by ygrave.sc;\012sub yhookabove by yhookabove.sc;\012sub ytilde by ytilde.sc;\012sub z by z.sc;\012sub zacute by zacute.sc;\012sub zcaron by zcaron.sc;\012sub zdotaccent by zdotaccent.sc;\012sub a-cy by a-cy.sc;\012sub be-cy by be-cy.sc;\012sub ve-cy by ve-cy.sc;\012sub ge-cy by ge-cy.sc;\012sub gje-cy by gje-cy.sc;\012sub gheupturn-cy by gheupturn-cy.sc;\012sub de-cy by de-cy.sc;\012sub ie-cy by ie-cy.sc;\012sub iegrave-cy by iegrave-cy.sc;\012sub io-cy by io-cy.sc;\012sub zhe-cy by zhe-cy.sc;\012sub ze-cy by ze-cy.sc;\012sub ii-cy by ii-cy.sc;\012sub iishort-cy by iishort-cy.sc;\012sub iigrave-cy by iigrave-cy.sc;\012sub iishorttail-cy by iishorttail-cy.sc;\012sub ka-cy by ka-cy.sc;\012sub kje-cy by kje-cy.sc;\012sub el-cy by el-cy.sc;\012sub em-cy by em-cy.sc;\012sub en-cy by en-cy.sc;\012sub o-cy by o-cy.sc;\012sub pe-cy by pe-cy.sc;\012sub er-cy by er-cy.sc;\012sub es-cy by es-cy.sc;\012sub te-cy by te-cy.sc;\012sub u-cy by u-cy.sc;\012sub ushort-cy by ushort-cy.sc;\012sub ef-cy by ef-cy.sc;\012sub ha-cy by ha-cy.sc;\012sub che-cy by che-cy.sc;\012sub tse-cy by tse-cy.sc;\012sub sha-cy by sha-cy.sc;\012sub shcha-cy by shcha-cy.sc;\012sub dzhe-cy by dzhe-cy.sc;\012sub softsign-cy by softsign-cy.sc;\012sub hardsign-cy by hardsign-cy.sc;\012sub yeru-cy by yeru-cy.sc;\012sub lje-cy by lje-cy.sc;\012sub nje-cy by nje-cy.sc;\012sub dze-cy by dze-cy.sc;\012sub e-cy by e-cy.sc;\012sub ereversed-cy by ereversed-cy.sc;\012sub i-cy by i-cy.sc;\012sub yi-cy by yi-cy.sc;\012sub je-cy by je-cy.sc;\012sub tshe-cy by tshe-cy.sc;\012sub iu-cy by iu-cy.sc;\012sub ia-cy by ia-cy.sc;\012sub dje-cy by dje-cy.sc;\012sub yat-cy by yat-cy.sc;\012sub yusbig-cy by yusbig-cy.sc;\012sub fita-cy by fita-cy.sc;\012sub izhitsa-cy by izhitsa-cy.sc;\012sub ghestroke-cy by ghestroke-cy.sc;\012sub ghemiddlehook-cy by ghemiddlehook-cy.sc;\012sub zhedescender-cy by zhedescender-cy.sc;\012sub zedescender-cy by zedescender-cy.sc;\012sub kadescender-cy by kadescender-cy.sc;\012sub kaverticalstroke-cy by kaverticalstroke-cy.sc;\012sub kastroke-cy by kastroke-cy.sc;\012sub kabashkir-cy by kabashkir-cy.sc;\012sub endescender-cy by endescender-cy.sc;\012sub enghe-cy by enghe-cy.sc;\012sub pedescender-cy by pedescender-cy.sc;\012sub haabkhasian-cy by haabkhasian-cy.sc;\012sub esdescender-cy by esdescender-cy.sc;\012sub tedescender-cy by tedescender-cy.sc;\012sub ustraight-cy by ustraight-cy.sc;\012sub ustraightstroke-cy by ustraightstroke-cy.sc;\012sub hadescender-cy by hadescender-cy.sc;\012sub tetse-cy by tetse-cy.sc;\012sub chedescender-cy by chedescender-cy.sc;\012sub cheverticalstroke-cy by cheverticalstroke-cy.sc;\012sub shha-cy by shha-cy.sc;\012sub shhadescender-cy by shhadescender-cy.sc;\012sub cheabkhasian-cy by cheabkhasian-cy.sc;\012sub chedescenderabkhasian-cy by chedescenderabkhasian-cy.sc;\012sub palochka-cy by palochka-cy.sc;\012sub zhebreve-cy by zhebreve-cy.sc;\012sub kahook-cy by kahook-cy.sc;\012sub eltail-cy by eltail-cy.sc;\012sub enhook-cy by enhook-cy.sc;\012sub entail-cy by entail-cy.sc;\012sub chekhakassian-cy by chekhakassian-cy.sc;\012sub emtail-cy by emtail-cy.sc;\012sub abreve-cy by abreve-cy.sc;\012sub adieresis-cy by adieresis-cy.sc;\012sub aie-cy by aie-cy.sc;\012sub iebreve-cy by iebreve-cy.sc;\012sub schwa-cy by schwa-cy.sc;\012sub schwadieresis-cy by schwadieresis-cy.sc;\012sub zhedieresis-cy by zhedieresis-cy.sc;\012sub zedieresis-cy by zedieresis-cy.sc;\012sub dzeabkhasian-cy by dzeabkhasian-cy.sc;\012sub imacron-cy by imacron-cy.sc;\012sub idieresis-cy by idieresis-cy.sc;\012sub odieresis-cy by odieresis-cy.sc;\012sub obarred-cy by obarred-cy.sc;\012sub obarreddieresis-cy by obarreddieresis-cy.sc;\012sub edieresis-cy by edieresis-cy.sc;\012sub umacron-cy by umacron-cy.sc;\012sub udieresis-cy by udieresis-cy.sc;\012sub uhungarumlaut-cy by uhungarumlaut-cy.sc;\012sub chedieresis-cy by chedieresis-cy.sc;\012sub gedescender-cy by gedescender-cy.sc;\012sub yerudieresis-cy by yerudieresis-cy.sc;\012sub gestrokehook-cy by gestrokehook-cy.sc;\012sub hahook-cy by hahook-cy.sc;\012sub hastroke-cy by hastroke-cy.sc;\012sub reversedze-cy by reversedze-cy.sc;\012sub elhook-cy by elhook-cy.sc;\012sub qa-cy by qa-cy.sc;\012sub we-cy by we-cy.sc;\012sub semisoftsign-cy by semisoftsign-cy.sc;\012sub ertick-cy by ertick-cy.sc;\012sub enlefthook-cy by enlefthook-cy.sc;\012sub eldescender-cy by eldescender-cy.sc;\012sub ve-cy.loclBGR by ve-cy.sc;\012sub ge-cy.loclBGR by ge-cy.sc;\012sub de-cy.loclBGR by de-cy.loclBGR.sc;\012sub zhe-cy.loclBGR by zhe-cy.sc;\012sub ze-cy.loclBGR by ze-cy.sc;\012sub ii-cy.loclBGR by ii-cy.sc;\012sub iishort-cy.loclBGR by iishort-cy.sc;\012sub iigrave-cy.loclBGR by iigrave-cy.sc;\012sub ka-cy.loclBGR by ka-cy.sc;\012sub el-cy.loclBGR by el-cy.loclBGR.sc;\012sub pe-cy.loclBGR by pe-cy.sc;\012sub te-cy.loclBGR by te-cy.sc;\012sub ef-cy.loclBGR by ef-cy.loclBGR.sc;\012sub tse-cy.loclBGR by tse-cy.sc;\012sub sha-cy.loclBGR by sha-cy.sc;\012sub shcha-cy.loclBGR by shcha-cy.sc;\012sub softsign-cy.loclBGR by softsign-cy.sc;\012sub hardsign-cy.loclBGR by hardsign-cy.sc;\012sub yeru-cy.loclBGR by yeru-cy.sc;\012sub iu-cy.loclBGR by iu-cy.sc;\012sub ghestroke-cy.loclBSH by ghestroke-cy.loclBSH.sc;\012sub zedescender-cy.loclBSH by zedescender-cy.loclBSH.sc;\012sub esdescender-cy.loclBSH by esdescender-cy.loclBSH.sc;\012sub esdescender-cy.loclCHU by esdescender-cy.loclCHU.sc;\012sub be-cy.loclSRB by be-cy.sc;\012sub alpha by alpha.sc;\012sub beta by beta.sc;\012sub gamma by gamma.sc;\012sub delta by delta.sc;\012sub epsilon by epsilon.sc;\012sub zeta by zeta.sc;\012sub eta by eta.sc;\012sub theta by theta.sc;\012sub iota by iota.sc;\012sub kappa by kappa.sc;\012sub lambda by lambda.sc;\012sub mu by mu.sc;\012sub nu by nu.sc;\012sub xi by xi.sc;\012sub omicron by omicron.sc;\012sub pi by pi.sc;\012sub rho by rho.sc;\012sub sigmafinal by sigmafinal.sc;\012sub sigma by sigma.sc;\012sub tau by tau.sc;\012sub upsilon by upsilon.sc;\012sub phi by phi.sc;\012sub chi by chi.sc;\012sub psi by psi.sc;\012sub omega by omega.sc;\012sub iotatonos by iotatonos.sc;\012sub iotadieresis by iotadieresis.sc;\012sub iotadieresistonos by iotadieresistonos.sc;\012sub upsilontonos by upsilontonos.sc;\012sub upsilondieresis by upsilondieresis.sc;\012sub upsilondieresistonos by upsilondieresistonos.sc;\012sub omicrontonos by omicrontonos.sc;\012sub omegatonos by omegatonos.sc;\012sub alphatonos by alphatonos.sc;\012sub epsilontonos by epsilontonos.sc;\012sub etatonos by etatonos.sc;\012sub kaiSymbol by kaiSymbol.sc;\012sub alphapsili by alphapsili.sc;\012sub alphadasia by alphadasia.sc;\012sub alphapsilivaria by alphapsilivaria.sc;\012sub alphadasiavaria by alphadasiavaria.sc;\012sub alphapsilioxia by alphapsilioxia.sc;\012sub alphadasiaoxia by alphadasiaoxia.sc;\012sub alphapsiliperispomeni by alphapsiliperispomeni.sc;\012sub alphadasiaperispomeni by alphadasiaperispomeni.sc;\012sub alphavaria by alphavaria.sc;\012sub alphaoxia by alphaoxia.sc;\012sub alphaperispomeni by alphaperispomeni.sc;\012sub alphavrachy by alphavrachy.sc;\012sub alphamacron by alphamacron.sc;\012sub alphaypogegrammeni by alphaypogegrammeni.sc;\012sub alphavariaypogegrammeni by alphavariaypogegrammeni.sc;\012sub alphaoxiaypogegrammeni by alphaoxiaypogegrammeni.sc;\012sub alphapsiliypogegrammeni by alphapsiliypogegrammeni.sc;\012sub alphadasiaypogegrammeni by alphadasiaypogegrammeni.sc;\012sub alphapsilivariaypogegrammeni by alphapsilivariaypogegrammeni.sc;\012sub alphadasiavariaypogegrammeni by alphadasiavariaypogegrammeni.sc;\012sub alphapsilioxiaypogegrammeni by alphapsilioxiaypogegrammeni.sc;\012sub alphadasiaoxiaypogegrammeni by alphadasiaoxiaypogegrammeni.sc;\012sub alphapsiliperispomeniypogegrammeni by alphapsiliperispomeniypogegrammeni.sc;\012sub alphadasiaperispomeniypogegrammeni by alphadasiaperispomeniypogegrammeni.sc;\012sub alphaperispomeniypogegrammeni by alphaperispomeniypogegrammeni.sc;\012sub epsilonpsili by epsilonpsili.sc;\012sub epsilondasia by epsilondasia.sc;\012sub epsilonpsilivaria by epsilonpsilivaria.sc;\012sub epsilondasiavaria by epsilondasiavaria.sc;\012sub epsilonpsilioxia by epsilonpsilioxia.sc;\012sub epsilondasiaoxia by epsilondasiaoxia.sc;\012sub epsilonvaria by epsilonvaria.sc;\012sub epsilonoxia by epsilonoxia.sc;\012sub etapsili by etapsili.sc;\012sub etadasia by etadasia.sc;\012sub etapsilivaria by etapsilivaria.sc;\012sub etadasiavaria by etadasiavaria.sc;\012sub etapsilioxia by etapsilioxia.sc;\012sub etadasiaoxia by etadasiaoxia.sc;\012sub etapsiliperispomeni by etapsiliperispomeni.sc;\012sub etadasiaperispomeni by etadasiaperispomeni.sc;\012sub etavaria by etavaria.sc;\012sub etaoxia by etaoxia.sc;\012sub etaperispomeni by etaperispomeni.sc;\012sub etaypogegrammeni by etaypogegrammeni.sc;\012sub etavariaypogegrammeni by etavariaypogegrammeni.sc;\012sub etaoxiaypogegrammeni by etaoxiaypogegrammeni.sc;\012sub etapsiliypogegrammeni by etapsiliypogegrammeni.sc;\012sub etadasiaypogegrammeni by etadasiaypogegrammeni.sc;\012sub etapsilivariaypogegrammeni by etapsilivariaypogegrammeni.sc;\012sub etadasiavariaypogegrammeni by etadasiavariaypogegrammeni.sc;\012sub etapsilioxiaypogegrammeni by etapsilioxiaypogegrammeni.sc;\012sub etadasiaoxiaypogegrammeni by etadasiaoxiaypogegrammeni.sc;\012sub etapsiliperispomeniypogegrammeni by etapsiliperispomeniypogegrammeni.sc;\012sub etadasiaperispomeniypogegrammeni by etadasiaperispomeniypogegrammeni.sc;\012sub etaperispomeniypogegrammeni by etaperispomeniypogegrammeni.sc;\012sub iotapsili by iotapsili.sc;\012sub iotadasia by iotadasia.sc;\012sub iotapsilivaria by iotapsilivaria.sc;\012sub iotadasiavaria by iotadasiavaria.sc;\012sub iotapsilioxia by iotapsilioxia.sc;\012sub iotadasiaoxia by iotadasiaoxia.sc;\012sub iotapsiliperispomeni by iotapsiliperispomeni.sc;\012sub iotadasiaperispomeni by iotadasiaperispomeni.sc;\012sub iotavaria by iotavaria.sc;\012sub iotaoxia by iotaoxia.sc;\012sub iotaperispomeni by iotaperispomeni.sc;\012sub iotavrachy by iotavrachy.sc;\012sub iotamacron by iotamacron.sc;\012sub iotadialytikavaria by iotadialytikavaria.sc;\012sub iotadialytikaoxia by iotadialytikaoxia.sc;\012sub iotadialytikaperispomeni by iotadialytikaperispomeni.sc;\012sub omicronpsili by omicronpsili.sc;\012sub omicrondasia by omicrondasia.sc;\012sub omicronpsilivaria by omicronpsilivaria.sc;\012sub omicrondasiavaria by omicrondasiavaria.sc;\012sub omicronpsilioxia by omicronpsilioxia.sc;\012sub omicrondasiaoxia by omicrondasiaoxia.sc;\012sub omicronvaria by omicronvaria.sc;\012sub omicronoxia by omicronoxia.sc;\012sub rhopsili by rhopsili.sc;\012sub rhodasia by rhodasia.sc;\012sub upsilonpsili by upsilonpsili.sc;\012sub upsilondasia by upsilondasia.sc;\012sub upsilonpsilivaria by upsilonpsilivaria.sc;\012sub upsilondasiavaria by upsilondasiavaria.sc;\012sub upsilonpsilioxia by upsilonpsilioxia.sc;\012sub upsilondasiaoxia by upsilondasiaoxia.sc;\012sub upsilonpsiliperispomeni by upsilonpsiliperispomeni.sc;\012sub upsilondasiaperispomeni by upsilondasiaperispomeni.sc;\012sub upsilonvaria by upsilonvaria.sc;\012sub upsilonoxia by upsilonoxia.sc;\012sub upsilonperispomeni by upsilonperispomeni.sc;\012sub upsilonvrachy by upsilonvrachy.sc;\012sub upsilonmacron by upsilonmacron.sc;\012sub upsilondialytikavaria by upsilondialytikavaria.sc;\012sub upsilondialytikaoxia by upsilondialytikaoxia.sc;\012sub upsilondialytikaperispomeni by upsilondialytikaperispomeni.sc;\012sub omegapsili by omegapsili.sc;\012sub omegadasia by omegadasia.sc;\012sub omegapsilivaria by omegapsilivaria.sc;\012sub omegadasiavaria by omegadasiavaria.sc;\012sub omegapsilioxia by omegapsilioxia.sc;\012sub omegadasiaoxia by omegadasiaoxia.sc;\012sub omegapsiliperispomeni by omegapsiliperispomeni.sc;\012sub omegadasiaperispomeni by omegadasiaperispomeni.sc;\012sub omegavaria by omegavaria.sc;\012sub omegaoxia by omegaoxia.sc;\012sub omegaperispomeni by omegaperispomeni.sc;\012sub omegaypogegrammeni by omegaypogegrammeni.sc;\012sub omegavariaypogegrammeni by omegavariaypogegrammeni.sc;\012sub omegaoxiaypogegrammeni by omegaoxiaypogegrammeni.sc;\012sub omegapsiliypogegrammeni by omegapsiliypogegrammeni.sc;\012sub omegadasiaypogegrammeni by omegadasiaypogegrammeni.sc;\012sub omegapsilivariaypogegrammeni by omegapsilivariaypogegrammeni.sc;\012sub omegadasiavariaypogegrammeni by omegadasiavariaypogegrammeni.sc;\012sub omegapsilioxiaypogegrammeni by omegapsilioxiaypogegrammeni.sc;\012sub omegadasiaoxiaypogegrammeni by omegadasiaoxiaypogegrammeni.sc;\012sub omegapsiliperispomeniypogegrammeni by omegapsiliperispomeniypogegrammeni.sc;\012sub omegadasiaperispomeniypogegrammeni by omegadasiaperispomeniypogegrammeni.sc;\012sub omegaperispomeniypogegrammeni by omegaperispomeniypogegrammeni.sc;\012sub zero by zero.sc;\012sub one by one.sc;\012sub two by two.sc;\012sub three by three.sc;\012sub four by four.sc;\012sub five by five.sc;\012sub six by six.sc;\012sub seven by seven.sc;\012sub eight by eight.sc;\012sub nine by nine.sc;\012sub anoteleia by anoteleia.sc;\012sub dieresiscomb by dieresiscomb.sc;\012sub dotaccentcomb by dotaccentcomb.sc;\012sub gravecomb by gravecomb.sc;\012sub acutecomb by acutecomb.sc;\012sub hungarumlautcomb by hungarumlautcomb.sc;\012sub circumflexcomb by circumflexcomb.sc;\012sub caroncomb by caroncomb.sc;\012sub brevecomb by brevecomb.sc;\012sub ringcomb by ringcomb.sc;\012sub tildecomb by tildecomb.sc;\012sub macroncomb by macroncomb.sc;\012sub hookabovecomb by hookabovecomb.sc;\012sub tonos by tonos.sc;\012sub dieresistonos by dieresistonos.sc;\012sub psili by psili.sc;\012sub koronis by koronis.sc;\012sub dasia by dasia.sc;\012sub psilivaria by psilivaria.sc;\012sub dasiavaria by dasiavaria.sc;\012sub psilioxia by psilioxia.sc;\012sub dasiaoxia by dasiaoxia.sc;\012sub psiliperispomeni by psiliperispomeni.sc;\012sub dasiaperispomeni by dasiaperispomeni.sc;\012sub dialytikavaria by dialytikavaria.sc;\012sub dialytikaoxia by dialytikaoxia.sc;\012sub dialytikaperispomeni by dialytikaperispomeni.sc;\012sub varia by varia.sc;\012sub oxia by oxia.sc;\012sub perispomeni by perispomeni.sc;\012sub brevecomb_acutecomb by brevecomb_acutecomb.sc;\012sub brevecomb_gravecomb by brevecomb_gravecomb.sc;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.sc;\012sub brevecomb_tildecomb by brevecomb_tildecomb.sc;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.sc;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.sc;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.sc;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.sc;\012sub brevecombcy by brevecombcy.sc;\012";
 name = smcp;
 },
 {
-code = "# ===============
-# BEGIN LATIN
-# ===============
-
-sub f f b by f_f_b;
-sub f f h by f_f_h;
-sub f f j by f_f_j;
-sub f f k by f_f_k;
-sub f f t by f_f_t;
-sub r f f by r_f_f;
-sub f b by f_b;
-sub f h by f_h;
-sub f i by f_i;
-sub f j by f_j;
-sub f k by f_k;
-sub f l by f_l;
-sub f t by f_t;
-sub r f by r_f;
-sub r t by r_t;
-sub t f by t_f;
-sub t t by t_t;
-sub r.alt t.alt by r_t.alt;
-sub t.alt t.alt by t_t.alt;
-
-ignore substitute @grk_UPPERCASE kappa' alpha' iota', kappa' alpha' iota' @grk_UPPERCASE;
-ignore substitute @grk_lowercase kappa' alpha' iota', kappa' alpha' iota' @grk_lowercase;
-ignore substitute @grk_smallcaps kappa' alpha' iota', kappa' alpha' iota' @grk_smallcaps;
-
-sub [space hyphen softhyphen endash emdash underscore] kappa' alpha' iota' [space hyphen softhyphen endash emdash underscore] by kaiSymbol ;
-sub [space hyphen.cap endash.cap emdash.cap] Kappa' Alpha' Iota' [space hyphen.cap endash.cap emdash.cap] by KaiSymbol ;
-
-sub [space hyphen softhyphen endash emdash underscore] kappa.sc' alpha.sc' iota.sc' [space hyphen softhyphen endash emdash underscore] by kaiSymbol.sc ;
-
-# ===============
-# END LATIN
-# ===============
-
-# ===============
-# BEGIN HEBREW
-# ===============
-
-lookup hb_yiddish {
-	lookupflag IgnoreMarks;
-	sub alef-hb lamed-hb by aleflamed-hb;
-	sub vav-hb vav-hb by vavvav-hb;
-	sub yod-hb vav-hb by vavyod-hb;
-	sub yod-hb yod-hb by yodyod-hb;
-} hb_yiddish;
-
-# ===============
-# END HEBREW
-# ===============
-";
+code = "# ===============\012# BEGIN LATIN\012# ===============\012\012sub f f b by f_f_b;\012sub f f h by f_f_h;\012sub f f j by f_f_j;\012sub f f k by f_f_k;\012sub f f t by f_f_t;\012sub r f f by r_f_f;\012sub f b by f_b;\012sub f h by f_h;\012sub f i by f_i;\012sub f j by f_j;\012sub f k by f_k;\012sub f l by f_l;\012sub f t by f_t;\012sub r f by r_f;\012sub r t by r_t;\012sub t f by t_f;\012sub t t by t_t;\012sub r.alt t.alt by r_t.alt;\012sub t.alt t.alt by t_t.alt;\012\012ignore substitute @grk_UPPERCASE kappa' alpha' iota', kappa' alpha' iota' @grk_UPPERCASE;\012ignore substitute @grk_lowercase kappa' alpha' iota', kappa' alpha' iota' @grk_lowercase;\012ignore substitute @grk_smallcaps kappa' alpha' iota', kappa' alpha' iota' @grk_smallcaps;\012\012sub [space hyphen softhyphen endash emdash underscore] kappa' alpha' iota' [space hyphen softhyphen endash emdash underscore] by kaiSymbol ;\012sub [space hyphen.cap endash.cap emdash.cap] Kappa' Alpha' Iota' [space hyphen.cap endash.cap emdash.cap] by KaiSymbol ;\012\012sub [space hyphen softhyphen endash emdash underscore] kappa.sc' alpha.sc' iota.sc' [space hyphen softhyphen endash emdash underscore] by kaiSymbol.sc ;\012\012# ===============\012# END LATIN\012# ===============\012\012# ===============\012# BEGIN HEBREW\012# ===============\012\012lookup hb_yiddish {\012	lookupflag IgnoreMarks;\012	sub alef-hb lamed-hb by aleflamed-hb;\012	sub vav-hb vav-hb by vavvav-hb;\012	sub yod-hb vav-hb by vavyod-hb;\012	sub yod-hb yod-hb by yodyod-hb;\012} hb_yiddish;\012\012# ===============\012# END HEBREW\012# ===============\012";
 name = dlig;
 },
 {
-code = "sub [G g] o o g l e underscore l o g o by Google.logo;
-sub g o o g l e underscore [G g] by G.logo;
-sub s u p e r underscore [G g] underscore l o g o by G.super;
-sub G underscore l o g o by G.logo;
-sub e underscore l o g o by e.logo;
-sub g underscore l o g o by g.logo;
-sub l underscore l o g o by l.logo;
-sub o underscore l o g o by o.logo;
-
-sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;
-
-sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
-sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;
-sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;
-sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.time;";
+code = "sub [G g] o o g l e underscore l o g o by Google.logo;\012sub g o o g l e underscore [G g] by G.logo;\012sub s u p e r underscore [G g] underscore l o g o by G.super;\012sub G underscore l o g o by G.logo;\012sub e underscore l o g o by e.logo;\012sub g underscore l o g o by g.logo;\012sub l underscore l o g o by l.logo;\012sub o underscore l o g o by o.logo;\012\012sub [space hyphen softhyphen endash emdash underscore] etatonos.sc' [space hyphen softhyphen endash emdash underscore comma] by etatonos.sc.ss06;\012\012sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;\012sub [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] colon' [zero.cap one.cap two.cap three.cap four.cap five.cap six.cap seven.cap eight.cap nine.cap zero.alt.cap one.alt.cap six.alt.cap seven.alt.cap nine.alt.cap] by colon.time;\012sub [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] colon.tf' [zero.tf one.tf two.tf three.tf four.tf five.tf six.tf seven.tf eight.tf nine.tf] by colon.time;\012sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.time;";
 name = calt;
 },
 {
-code = "featureNames {
-    name \"Number pad asterisk\";
-    name 1 \"Number pad asterisk\";
-};
-sub asterisk by asterisk.num;";
+code = "featureNames {\012    name \"Number pad asterisk\";\012    name 1 \"Number pad asterisk\";\012};\012sub asterisk by asterisk.num;";
 name = ss01;
 },
 {
-code = "featureNames {
-    name \"Colon time\";
-    name 1 \"Colon time\";
-};
-sub colon by colon.time;";
+code = "featureNames {\012    name \"Colon time\";\012    name 1 \"Colon time\";\012};\012sub colon by colon.time;";
 name = ss02;
 },
 {
-code = "featureNames {
-    name \"Thin Numbers\";
-    name 1 \"Thin Numbers\";
-};
-sub zero by zero.ss03;
-sub one by one.ss03;
-sub two by two.ss03;
-sub three by three.ss03;
-sub four by four.ss03;
-sub five by five.ss03;
-sub six by six.ss03;
-sub seven by seven.ss03;
-sub eight by eight.ss03;
-sub nine by nine.ss03;
-sub colon by colon.ss03;
-";
+code = "featureNames {\012    name \"Thin Numbers\";\012    name 1 \"Thin Numbers\";\012};\012sub zero by zero.ss03;\012sub one by one.ss03;\012sub two by two.ss03;\012sub three by three.ss03;\012sub four by four.ss03;\012sub five by five.ss03;\012sub six by six.ss03;\012sub seven by seven.ss03;\012sub eight by eight.ss03;\012sub nine by nine.ss03;\012sub colon by colon.ss03;\012";
 name = ss03;
 },
 {
-code = "featureNames {
-    name \"Alternate Arrows\";
-    name 1 \"Alternate Arrows\";
-};
-sub upArrow by upArrow.ss05;
-sub northEastArrow by northEastArrow.ss05;
-sub rightArrow by rightArrow.ss05;
-sub southEastArrow by southEastArrow.ss05;
-sub downArrow by downArrow.ss05;
-sub southWestArrow by southWestArrow.ss05;
-sub leftArrow by leftArrow.ss05;
-sub northWestArrow by northWestArrow.ss05;
-";
+code = "featureNames {\012    name \"Alternate Arrows\";\012    name 1 \"Alternate Arrows\";\012};\012sub upArrow by upArrow.ss05;\012sub northEastArrow by northEastArrow.ss05;\012sub rightArrow by rightArrow.ss05;\012sub southEastArrow by southEastArrow.ss05;\012sub downArrow by downArrow.ss05;\012sub southWestArrow by southWestArrow.ss05;\012sub leftArrow by leftArrow.ss05;\012sub northWestArrow by northWestArrow.ss05;\012";
 name = ss05;
 },
 {
-code = "featureNames {
-    name \"Accented Greek SC\";
-    name 1 \"Accented Greek SC\";
-};
-
-sub alphaypogegrammeni.sc.ad by alphaypogegrammeni.sc.ad.ss06;
-sub alphavariaypogegrammeni.sc.ad by alphavariaypogegrammeni.sc.ad.ss06;
-sub alphaoxiaypogegrammeni.sc.ad by alphaoxiaypogegrammeni.sc.ad.ss06;
-sub alphapsiliypogegrammeni.sc.ad by alphapsiliypogegrammeni.sc.ad.ss06;
-sub alphadasiaypogegrammeni.sc.ad by alphadasiaypogegrammeni.sc.ad.ss06;
-sub alphapsilivariaypogegrammeni.sc.ad by alphapsilivariaypogegrammeni.sc.ad.ss06;
-sub alphadasiavariaypogegrammeni.sc.ad by alphadasiavariaypogegrammeni.sc.ad.ss06;
-sub alphapsilioxiaypogegrammeni.sc.ad by alphapsilioxiaypogegrammeni.sc.ad.ss06;
-sub alphadasiaoxiaypogegrammeni.sc.ad by alphadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub alphapsiliperispomeniypogegrammeni.sc.ad by alphapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub alphadasiaperispomeniypogegrammeni.sc.ad by alphadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub alphaperispomeniypogegrammeni.sc.ad by alphaperispomeniypogegrammeni.sc.ad.ss06;
-sub etaypogegrammeni.sc.ad by etaypogegrammeni.sc.ad.ss06;
-sub etavariaypogegrammeni.sc.ad by etavariaypogegrammeni.sc.ad.ss06;
-sub etaoxiaypogegrammeni.sc.ad by etaoxiaypogegrammeni.sc.ad.ss06;
-sub etapsiliypogegrammeni.sc.ad by etapsiliypogegrammeni.sc.ad.ss06;
-sub etadasiaypogegrammeni.sc.ad by etadasiaypogegrammeni.sc.ad.ss06;
-sub etapsilivariaypogegrammeni.sc.ad by etapsilivariaypogegrammeni.sc.ad.ss06;
-sub etadasiavariaypogegrammeni.sc.ad by etadasiavariaypogegrammeni.sc.ad.ss06;
-sub etapsilioxiaypogegrammeni.sc.ad by etapsilioxiaypogegrammeni.sc.ad.ss06;
-sub etadasiaoxiaypogegrammeni.sc.ad by etadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub etapsiliperispomeniypogegrammeni.sc.ad by etapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub etadasiaperispomeniypogegrammeni.sc.ad by etadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub etaperispomeniypogegrammeni.sc.ad by etaperispomeniypogegrammeni.sc.ad.ss06;
-sub omegaypogegrammeni.sc.ad by omegaypogegrammeni.sc.ad.ss06;
-sub omegavariaypogegrammeni.sc.ad by omegavariaypogegrammeni.sc.ad.ss06;
-sub omegaoxiaypogegrammeni.sc.ad by omegaoxiaypogegrammeni.sc.ad.ss06;
-sub omegapsiliypogegrammeni.sc.ad by omegapsiliypogegrammeni.sc.ad.ss06;
-sub omegadasiaypogegrammeni.sc.ad by omegadasiaypogegrammeni.sc.ad.ss06;
-sub omegapsilivariaypogegrammeni.sc.ad by omegapsilivariaypogegrammeni.sc.ad.ss06;
-sub omegadasiavariaypogegrammeni.sc.ad by omegadasiavariaypogegrammeni.sc.ad.ss06;
-sub omegapsilioxiaypogegrammeni.sc.ad by omegapsilioxiaypogegrammeni.sc.ad.ss06;
-sub omegadasiaoxiaypogegrammeni.sc.ad by omegadasiaoxiaypogegrammeni.sc.ad.ss06;
-sub omegapsiliperispomeniypogegrammeni.sc.ad by omegapsiliperispomeniypogegrammeni.sc.ad.ss06;
-sub omegadasiaperispomeniypogegrammeni.sc.ad by omegadasiaperispomeniypogegrammeni.sc.ad.ss06;
-sub omegaperispomeniypogegrammeni.sc.ad by omegaperispomeniypogegrammeni.sc.ad.ss06;
-sub iotatonos.sc by iotatonos.sc.ss06;
-sub iotadieresis.sc by iotadieresis.sc.ss06;
-sub iotadieresistonos.sc by iotadieresistonos.sc.ss06;
-sub upsilontonos.sc by upsilontonos.sc.ss06;
-sub upsilondieresis.sc by upsilondieresis.sc.ss06;
-sub upsilondieresistonos.sc by upsilondieresistonos.sc.ss06;
-sub omicrontonos.sc by omicrontonos.sc.ss06;
-sub omegatonos.sc by omegatonos.sc.ss06;
-sub alphatonos.sc by alphatonos.sc.ss06;
-sub epsilontonos.sc by epsilontonos.sc.ss06;
-sub etatonos.sc by etatonos.sc.ss06;
-sub alphapsili.sc by alphapsili.sc.ss06;
-sub alphadasia.sc by alphadasia.sc.ss06;
-sub alphapsilivaria.sc by alphapsilivaria.sc.ss06;
-sub alphadasiavaria.sc by alphadasiavaria.sc.ss06;
-sub alphapsilioxia.sc by alphapsilioxia.sc.ss06;
-sub alphadasiaoxia.sc by alphadasiaoxia.sc.ss06;
-sub alphapsiliperispomeni.sc by alphapsiliperispomeni.sc.ss06;
-sub alphadasiaperispomeni.sc by alphadasiaperispomeni.sc.ss06;
-sub alphavaria.sc by alphavaria.sc.ss06;
-sub alphaoxia.sc by alphaoxia.sc.ss06;
-sub alphaperispomeni.sc by alphaperispomeni.sc.ss06;
-sub alphavrachy.sc by alphavrachy.sc.ss06;
-sub alphamacron.sc by alphamacron.sc.ss06;
-sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ss06;
-sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ss06;
-sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ss06;
-sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ss06;
-sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ss06;
-sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ss06;
-sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ss06;
-sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ss06;
-sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ss06;
-sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ss06;
-sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ss06;
-sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ss06;
-sub epsilonpsili.sc by epsilonpsili.sc.ss06;
-sub epsilondasia.sc by epsilondasia.sc.ss06;
-sub epsilonpsilivaria.sc by epsilonpsilivaria.sc.ss06;
-sub epsilondasiavaria.sc by epsilondasiavaria.sc.ss06;
-sub epsilonpsilioxia.sc by epsilonpsilioxia.sc.ss06;
-sub epsilondasiaoxia.sc by epsilondasiaoxia.sc.ss06;
-sub epsilonvaria.sc by epsilonvaria.sc.ss06;
-sub epsilonoxia.sc by epsilonoxia.sc.ss06;
-sub etapsili.sc by etapsili.sc.ss06;
-sub etadasia.sc by etadasia.sc.ss06;
-sub etapsilivaria.sc by etapsilivaria.sc.ss06;
-sub etadasiavaria.sc by etadasiavaria.sc.ss06;
-sub etapsilioxia.sc by etapsilioxia.sc.ss06;
-sub etadasiaoxia.sc by etadasiaoxia.sc.ss06;
-sub etapsiliperispomeni.sc by etapsiliperispomeni.sc.ss06;
-sub etadasiaperispomeni.sc by etadasiaperispomeni.sc.ss06;
-sub etavaria.sc by etavaria.sc.ss06;
-sub etaoxia.sc by etaoxia.sc.ss06;
-sub etaperispomeni.sc by etaperispomeni.sc.ss06;
-sub etaypogegrammeni.sc by etaypogegrammeni.sc.ss06;
-sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ss06;
-sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ss06;
-sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ss06;
-sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ss06;
-sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ss06;
-sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ss06;
-sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ss06;
-sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ss06;
-sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ss06;
-sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ss06;
-sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ss06;
-sub iotapsili.sc by iotapsili.sc.ss06;
-sub iotadasia.sc by iotadasia.sc.ss06;
-sub iotapsilivaria.sc by iotapsilivaria.sc.ss06;
-sub iotadasiavaria.sc by iotadasiavaria.sc.ss06;
-sub iotapsilioxia.sc by iotapsilioxia.sc.ss06;
-sub iotadasiaoxia.sc by iotadasiaoxia.sc.ss06;
-sub iotapsiliperispomeni.sc by iotapsiliperispomeni.sc.ss06;
-sub iotadasiaperispomeni.sc by iotadasiaperispomeni.sc.ss06;
-sub iotavaria.sc by iotavaria.sc.ss06;
-sub iotaoxia.sc by iotaoxia.sc.ss06;
-sub iotaperispomeni.sc by iotaperispomeni.sc.ss06;
-sub iotavrachy.sc by iotavrachy.sc.ss06;
-sub iotamacron.sc by iotamacron.sc.ss06;
-sub iotadialytikavaria.sc by iotadialytikavaria.sc.ss06;
-sub iotadialytikaoxia.sc by iotadialytikaoxia.sc.ss06;
-sub iotadialytikaperispomeni.sc by iotadialytikaperispomeni.sc.ss06;
-sub omicronpsili.sc by omicronpsili.sc.ss06;
-sub omicrondasia.sc by omicrondasia.sc.ss06;
-sub omicronpsilivaria.sc by omicronpsilivaria.sc.ss06;
-sub omicrondasiavaria.sc by omicrondasiavaria.sc.ss06;
-sub omicronpsilioxia.sc by omicronpsilioxia.sc.ss06;
-sub omicrondasiaoxia.sc by omicrondasiaoxia.sc.ss06;
-sub omicronvaria.sc by omicronvaria.sc.ss06;
-sub omicronoxia.sc by omicronoxia.sc.ss06;
-sub rhopsili.sc by rhopsili.sc.ss06;
-sub rhodasia.sc by rhodasia.sc.ss06;
-sub upsilonpsili.sc by upsilonpsili.sc.ss06;
-sub upsilondasia.sc by upsilondasia.sc.ss06;
-sub upsilonpsilivaria.sc by upsilonpsilivaria.sc.ss06;
-sub upsilondasiavaria.sc by upsilondasiavaria.sc.ss06;
-sub upsilonpsilioxia.sc by upsilonpsilioxia.sc.ss06;
-sub upsilondasiaoxia.sc by upsilondasiaoxia.sc.ss06;
-sub upsilonpsiliperispomeni.sc by upsilonpsiliperispomeni.sc.ss06;
-sub upsilondasiaperispomeni.sc by upsilondasiaperispomeni.sc.ss06;
-sub upsilonvaria.sc by upsilonvaria.sc.ss06;
-sub upsilonoxia.sc by upsilonoxia.sc.ss06;
-sub upsilonperispomeni.sc by upsilonperispomeni.sc.ss06;
-sub upsilonvrachy.sc by upsilonvrachy.sc.ss06;
-sub upsilonmacron.sc by upsilonmacron.sc.ss06;
-sub upsilondialytikavaria.sc by upsilondialytikavaria.sc.ss06;
-sub upsilondialytikaoxia.sc by upsilondialytikaoxia.sc.ss06;
-sub upsilondialytikaperispomeni.sc by upsilondialytikaperispomeni.sc.ss06;
-sub omegapsili.sc by omegapsili.sc.ss06;
-sub omegadasia.sc by omegadasia.sc.ss06;
-sub omegapsilivaria.sc by omegapsilivaria.sc.ss06;
-sub omegadasiavaria.sc by omegadasiavaria.sc.ss06;
-sub omegapsilioxia.sc by omegapsilioxia.sc.ss06;
-sub omegadasiaoxia.sc by omegadasiaoxia.sc.ss06;
-sub omegapsiliperispomeni.sc by omegapsiliperispomeni.sc.ss06;
-sub omegadasiaperispomeni.sc by omegadasiaperispomeni.sc.ss06;
-sub omegavaria.sc by omegavaria.sc.ss06;
-sub omegaoxia.sc by omegaoxia.sc.ss06;
-sub omegaperispomeni.sc by omegaperispomeni.sc.ss06;
-sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ss06;
-sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ss06;
-sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ss06;
-sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ss06;
-sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ss06;
-sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ss06;
-sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ss06;
-sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ss06;
-sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ss06;
-sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ss06;
-sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ss06;
-sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ss06;
-";
+code = "featureNames {\012    name \"Accented Greek SC\";\012    name 1 \"Accented Greek SC\";\012};\012\012sub alphaypogegrammeni.sc.ad by alphaypogegrammeni.sc.ad.ss06;\012sub alphavariaypogegrammeni.sc.ad by alphavariaypogegrammeni.sc.ad.ss06;\012sub alphaoxiaypogegrammeni.sc.ad by alphaoxiaypogegrammeni.sc.ad.ss06;\012sub alphapsiliypogegrammeni.sc.ad by alphapsiliypogegrammeni.sc.ad.ss06;\012sub alphadasiaypogegrammeni.sc.ad by alphadasiaypogegrammeni.sc.ad.ss06;\012sub alphapsilivariaypogegrammeni.sc.ad by alphapsilivariaypogegrammeni.sc.ad.ss06;\012sub alphadasiavariaypogegrammeni.sc.ad by alphadasiavariaypogegrammeni.sc.ad.ss06;\012sub alphapsilioxiaypogegrammeni.sc.ad by alphapsilioxiaypogegrammeni.sc.ad.ss06;\012sub alphadasiaoxiaypogegrammeni.sc.ad by alphadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub alphapsiliperispomeniypogegrammeni.sc.ad by alphapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub alphadasiaperispomeniypogegrammeni.sc.ad by alphadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub alphaperispomeniypogegrammeni.sc.ad by alphaperispomeniypogegrammeni.sc.ad.ss06;\012sub etaypogegrammeni.sc.ad by etaypogegrammeni.sc.ad.ss06;\012sub etavariaypogegrammeni.sc.ad by etavariaypogegrammeni.sc.ad.ss06;\012sub etaoxiaypogegrammeni.sc.ad by etaoxiaypogegrammeni.sc.ad.ss06;\012sub etapsiliypogegrammeni.sc.ad by etapsiliypogegrammeni.sc.ad.ss06;\012sub etadasiaypogegrammeni.sc.ad by etadasiaypogegrammeni.sc.ad.ss06;\012sub etapsilivariaypogegrammeni.sc.ad by etapsilivariaypogegrammeni.sc.ad.ss06;\012sub etadasiavariaypogegrammeni.sc.ad by etadasiavariaypogegrammeni.sc.ad.ss06;\012sub etapsilioxiaypogegrammeni.sc.ad by etapsilioxiaypogegrammeni.sc.ad.ss06;\012sub etadasiaoxiaypogegrammeni.sc.ad by etadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub etapsiliperispomeniypogegrammeni.sc.ad by etapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub etadasiaperispomeniypogegrammeni.sc.ad by etadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub etaperispomeniypogegrammeni.sc.ad by etaperispomeniypogegrammeni.sc.ad.ss06;\012sub omegaypogegrammeni.sc.ad by omegaypogegrammeni.sc.ad.ss06;\012sub omegavariaypogegrammeni.sc.ad by omegavariaypogegrammeni.sc.ad.ss06;\012sub omegaoxiaypogegrammeni.sc.ad by omegaoxiaypogegrammeni.sc.ad.ss06;\012sub omegapsiliypogegrammeni.sc.ad by omegapsiliypogegrammeni.sc.ad.ss06;\012sub omegadasiaypogegrammeni.sc.ad by omegadasiaypogegrammeni.sc.ad.ss06;\012sub omegapsilivariaypogegrammeni.sc.ad by omegapsilivariaypogegrammeni.sc.ad.ss06;\012sub omegadasiavariaypogegrammeni.sc.ad by omegadasiavariaypogegrammeni.sc.ad.ss06;\012sub omegapsilioxiaypogegrammeni.sc.ad by omegapsilioxiaypogegrammeni.sc.ad.ss06;\012sub omegadasiaoxiaypogegrammeni.sc.ad by omegadasiaoxiaypogegrammeni.sc.ad.ss06;\012sub omegapsiliperispomeniypogegrammeni.sc.ad by omegapsiliperispomeniypogegrammeni.sc.ad.ss06;\012sub omegadasiaperispomeniypogegrammeni.sc.ad by omegadasiaperispomeniypogegrammeni.sc.ad.ss06;\012sub omegaperispomeniypogegrammeni.sc.ad by omegaperispomeniypogegrammeni.sc.ad.ss06;\012sub iotatonos.sc by iotatonos.sc.ss06;\012sub iotadieresis.sc by iotadieresis.sc.ss06;\012sub iotadieresistonos.sc by iotadieresistonos.sc.ss06;\012sub upsilontonos.sc by upsilontonos.sc.ss06;\012sub upsilondieresis.sc by upsilondieresis.sc.ss06;\012sub upsilondieresistonos.sc by upsilondieresistonos.sc.ss06;\012sub omicrontonos.sc by omicrontonos.sc.ss06;\012sub omegatonos.sc by omegatonos.sc.ss06;\012sub alphatonos.sc by alphatonos.sc.ss06;\012sub epsilontonos.sc by epsilontonos.sc.ss06;\012sub etatonos.sc by etatonos.sc.ss06;\012sub alphapsili.sc by alphapsili.sc.ss06;\012sub alphadasia.sc by alphadasia.sc.ss06;\012sub alphapsilivaria.sc by alphapsilivaria.sc.ss06;\012sub alphadasiavaria.sc by alphadasiavaria.sc.ss06;\012sub alphapsilioxia.sc by alphapsilioxia.sc.ss06;\012sub alphadasiaoxia.sc by alphadasiaoxia.sc.ss06;\012sub alphapsiliperispomeni.sc by alphapsiliperispomeni.sc.ss06;\012sub alphadasiaperispomeni.sc by alphadasiaperispomeni.sc.ss06;\012sub alphavaria.sc by alphavaria.sc.ss06;\012sub alphaoxia.sc by alphaoxia.sc.ss06;\012sub alphaperispomeni.sc by alphaperispomeni.sc.ss06;\012sub alphavrachy.sc by alphavrachy.sc.ss06;\012sub alphamacron.sc by alphamacron.sc.ss06;\012sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ss06;\012sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ss06;\012sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ss06;\012sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ss06;\012sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ss06;\012sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ss06;\012sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ss06;\012sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ss06;\012sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ss06;\012sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ss06;\012sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ss06;\012sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ss06;\012sub epsilonpsili.sc by epsilonpsili.sc.ss06;\012sub epsilondasia.sc by epsilondasia.sc.ss06;\012sub epsilonpsilivaria.sc by epsilonpsilivaria.sc.ss06;\012sub epsilondasiavaria.sc by epsilondasiavaria.sc.ss06;\012sub epsilonpsilioxia.sc by epsilonpsilioxia.sc.ss06;\012sub epsilondasiaoxia.sc by epsilondasiaoxia.sc.ss06;\012sub epsilonvaria.sc by epsilonvaria.sc.ss06;\012sub epsilonoxia.sc by epsilonoxia.sc.ss06;\012sub etapsili.sc by etapsili.sc.ss06;\012sub etadasia.sc by etadasia.sc.ss06;\012sub etapsilivaria.sc by etapsilivaria.sc.ss06;\012sub etadasiavaria.sc by etadasiavaria.sc.ss06;\012sub etapsilioxia.sc by etapsilioxia.sc.ss06;\012sub etadasiaoxia.sc by etadasiaoxia.sc.ss06;\012sub etapsiliperispomeni.sc by etapsiliperispomeni.sc.ss06;\012sub etadasiaperispomeni.sc by etadasiaperispomeni.sc.ss06;\012sub etavaria.sc by etavaria.sc.ss06;\012sub etaoxia.sc by etaoxia.sc.ss06;\012sub etaperispomeni.sc by etaperispomeni.sc.ss06;\012sub etaypogegrammeni.sc by etaypogegrammeni.sc.ss06;\012sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ss06;\012sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ss06;\012sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ss06;\012sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ss06;\012sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ss06;\012sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ss06;\012sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ss06;\012sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ss06;\012sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ss06;\012sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ss06;\012sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ss06;\012sub iotapsili.sc by iotapsili.sc.ss06;\012sub iotadasia.sc by iotadasia.sc.ss06;\012sub iotapsilivaria.sc by iotapsilivaria.sc.ss06;\012sub iotadasiavaria.sc by iotadasiavaria.sc.ss06;\012sub iotapsilioxia.sc by iotapsilioxia.sc.ss06;\012sub iotadasiaoxia.sc by iotadasiaoxia.sc.ss06;\012sub iotapsiliperispomeni.sc by iotapsiliperispomeni.sc.ss06;\012sub iotadasiaperispomeni.sc by iotadasiaperispomeni.sc.ss06;\012sub iotavaria.sc by iotavaria.sc.ss06;\012sub iotaoxia.sc by iotaoxia.sc.ss06;\012sub iotaperispomeni.sc by iotaperispomeni.sc.ss06;\012sub iotavrachy.sc by iotavrachy.sc.ss06;\012sub iotamacron.sc by iotamacron.sc.ss06;\012sub iotadialytikavaria.sc by iotadialytikavaria.sc.ss06;\012sub iotadialytikaoxia.sc by iotadialytikaoxia.sc.ss06;\012sub iotadialytikaperispomeni.sc by iotadialytikaperispomeni.sc.ss06;\012sub omicronpsili.sc by omicronpsili.sc.ss06;\012sub omicrondasia.sc by omicrondasia.sc.ss06;\012sub omicronpsilivaria.sc by omicronpsilivaria.sc.ss06;\012sub omicrondasiavaria.sc by omicrondasiavaria.sc.ss06;\012sub omicronpsilioxia.sc by omicronpsilioxia.sc.ss06;\012sub omicrondasiaoxia.sc by omicrondasiaoxia.sc.ss06;\012sub omicronvaria.sc by omicronvaria.sc.ss06;\012sub omicronoxia.sc by omicronoxia.sc.ss06;\012sub rhopsili.sc by rhopsili.sc.ss06;\012sub rhodasia.sc by rhodasia.sc.ss06;\012sub upsilonpsili.sc by upsilonpsili.sc.ss06;\012sub upsilondasia.sc by upsilondasia.sc.ss06;\012sub upsilonpsilivaria.sc by upsilonpsilivaria.sc.ss06;\012sub upsilondasiavaria.sc by upsilondasiavaria.sc.ss06;\012sub upsilonpsilioxia.sc by upsilonpsilioxia.sc.ss06;\012sub upsilondasiaoxia.sc by upsilondasiaoxia.sc.ss06;\012sub upsilonpsiliperispomeni.sc by upsilonpsiliperispomeni.sc.ss06;\012sub upsilondasiaperispomeni.sc by upsilondasiaperispomeni.sc.ss06;\012sub upsilonvaria.sc by upsilonvaria.sc.ss06;\012sub upsilonoxia.sc by upsilonoxia.sc.ss06;\012sub upsilonperispomeni.sc by upsilonperispomeni.sc.ss06;\012sub upsilonvrachy.sc by upsilonvrachy.sc.ss06;\012sub upsilonmacron.sc by upsilonmacron.sc.ss06;\012sub upsilondialytikavaria.sc by upsilondialytikavaria.sc.ss06;\012sub upsilondialytikaoxia.sc by upsilondialytikaoxia.sc.ss06;\012sub upsilondialytikaperispomeni.sc by upsilondialytikaperispomeni.sc.ss06;\012sub omegapsili.sc by omegapsili.sc.ss06;\012sub omegadasia.sc by omegadasia.sc.ss06;\012sub omegapsilivaria.sc by omegapsilivaria.sc.ss06;\012sub omegadasiavaria.sc by omegadasiavaria.sc.ss06;\012sub omegapsilioxia.sc by omegapsilioxia.sc.ss06;\012sub omegadasiaoxia.sc by omegadasiaoxia.sc.ss06;\012sub omegapsiliperispomeni.sc by omegapsiliperispomeni.sc.ss06;\012sub omegadasiaperispomeni.sc by omegadasiaperispomeni.sc.ss06;\012sub omegavaria.sc by omegavaria.sc.ss06;\012sub omegaoxia.sc by omegaoxia.sc.ss06;\012sub omegaperispomeni.sc by omegaperispomeni.sc.ss06;\012sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ss06;\012sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ss06;\012sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ss06;\012sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ss06;\012sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ss06;\012sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ss06;\012sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ss06;\012sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ss06;\012sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ss06;\012sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ss06;\012sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ss06;\012sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ss06;\012";
 name = ss06;
 },
 {
-code = "featureNames {
-    name \"iota adscript\";
-    name 1 \"iota adscript\";
-};
-
-sub Alphaprosgegrammeni by Alphaprosgegrammeni.ad;
-sub Alphapsiliprosgegrammeni by Alphapsiliprosgegrammeni.ad;
-sub Alphadasiaprosgegrammeni by Alphadasiaprosgegrammeni.ad;
-sub Alphapsilivariaprosgegrammeni by Alphapsilivariaprosgegrammeni.ad;
-sub Alphadasiavariaprosgegrammeni by Alphadasiavariaprosgegrammeni.ad;
-sub Alphapsilioxiaprosgegrammeni by Alphapsilioxiaprosgegrammeni.ad;
-sub Alphadasiaoxiaprosgegrammeni by Alphadasiaoxiaprosgegrammeni.ad;
-sub Alphapsiliperispomeniprosgegrammeni by Alphapsiliperispomeniprosgegrammeni.ad;
-sub Alphadasiaperispomeniprosgegrammeni by Alphadasiaperispomeniprosgegrammeni.ad;
-sub Etaprosgegrammeni by Etaprosgegrammeni.ad;
-sub Etapsiliprosgegrammeni by Etapsiliprosgegrammeni.ad;
-sub Etadasiaprosgegrammeni by Etadasiaprosgegrammeni.ad;
-sub Etapsilivariaprosgegrammeni by Etapsilivariaprosgegrammeni.ad;
-sub Etadasiavariaprosgegrammeni by Etadasiavariaprosgegrammeni.ad;
-sub Etapsilioxiaprosgegrammeni by Etapsilioxiaprosgegrammeni.ad;
-sub Etadasiaoxiaprosgegrammeni by Etadasiaoxiaprosgegrammeni.ad;
-sub Etapsiliperispomeniprosgegrammeni by Etapsiliperispomeniprosgegrammeni.ad;
-sub Etadasiaperispomeniprosgegrammeni by Etadasiaperispomeniprosgegrammeni.ad;
-sub Omegaprosgegrammeni by Omegaprosgegrammeni.ad;
-sub Omegapsiliprosgegrammeni by Omegapsiliprosgegrammeni.ad;
-sub Omegadasiaprosgegrammeni by Omegadasiaprosgegrammeni.ad;
-sub Omegapsilivariaprosgegrammeni by Omegapsilivariaprosgegrammeni.ad;
-sub Omegadasiavariaprosgegrammeni by Omegadasiavariaprosgegrammeni.ad;
-sub Omegapsilioxiaprosgegrammeni by Omegapsilioxiaprosgegrammeni.ad;
-sub Omegadasiaoxiaprosgegrammeni by Omegadasiaoxiaprosgegrammeni.ad;
-sub Omegapsiliperispomeniprosgegrammeni by Omegapsiliperispomeniprosgegrammeni.ad;
-sub Omegadasiaperispomeniprosgegrammeni by Omegadasiaperispomeniprosgegrammeni.ad;
-sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ad;
-sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ad;
-sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ad;
-sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ad;
-sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ad;
-sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ad;
-sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ad;
-sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ad;
-sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ad;
-sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ad;
-sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ad;
-sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ad;
-sub etaypogegrammeni.sc by etaypogegrammeni.sc.ad;
-sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ad;
-sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ad;
-sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ad;
-sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ad;
-sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ad;
-sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ad;
-sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ad;
-sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ad;
-sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ad;
-sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ad;
-sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ad;
-sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ad;
-sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ad;
-sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ad;
-sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ad;
-sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ad;
-sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ad;
-sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ad;
-sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ad;
-sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ad;
-sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ad;
-sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ad;
-sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ad;
-sub alphaypogegrammeni.sc.ss06 by alphaypogegrammeni.sc.ad.ss06 ;
-sub alphavariaypogegrammeni.sc.ss06 by alphavariaypogegrammeni.sc.ad.ss06 ;
-sub alphaoxiaypogegrammeni.sc.ss06 by alphaoxiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsiliypogegrammeni.sc.ss06 by alphapsiliypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaypogegrammeni.sc.ss06 by alphadasiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsilivariaypogegrammeni.sc.ss06 by alphapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub alphadasiavariaypogegrammeni.sc.ss06 by alphadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub alphapsilioxiaypogegrammeni.sc.ss06 by alphapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaoxiaypogegrammeni.sc.ss06 by alphadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub alphapsiliperispomeniypogegrammeni.sc.ss06 by alphapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub alphadasiaperispomeniypogegrammeni.sc.ss06 by alphadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub alphaperispomeniypogegrammeni.sc.ss06 by alphaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etaypogegrammeni.sc.ss06 by etaypogegrammeni.sc.ad.ss06 ;
-sub etavariaypogegrammeni.sc.ss06 by etavariaypogegrammeni.sc.ad.ss06 ;
-sub etaoxiaypogegrammeni.sc.ss06 by etaoxiaypogegrammeni.sc.ad.ss06 ;
-sub etapsiliypogegrammeni.sc.ss06 by etapsiliypogegrammeni.sc.ad.ss06 ;
-sub etadasiaypogegrammeni.sc.ss06 by etadasiaypogegrammeni.sc.ad.ss06 ;
-sub etapsilivariaypogegrammeni.sc.ss06 by etapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub etadasiavariaypogegrammeni.sc.ss06 by etadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub etapsilioxiaypogegrammeni.sc.ss06 by etapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub etadasiaoxiaypogegrammeni.sc.ss06 by etadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub etapsiliperispomeniypogegrammeni.sc.ss06 by etapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etadasiaperispomeniypogegrammeni.sc.ss06 by etadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub etaperispomeniypogegrammeni.sc.ss06 by etaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegaypogegrammeni.sc.ss06 by omegaypogegrammeni.sc.ad.ss06 ;
-sub omegavariaypogegrammeni.sc.ss06 by omegavariaypogegrammeni.sc.ad.ss06 ;
-sub omegaoxiaypogegrammeni.sc.ss06 by omegaoxiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsiliypogegrammeni.sc.ss06 by omegapsiliypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaypogegrammeni.sc.ss06 by omegadasiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsilivariaypogegrammeni.sc.ss06 by omegapsilivariaypogegrammeni.sc.ad.ss06 ;
-sub omegadasiavariaypogegrammeni.sc.ss06 by omegadasiavariaypogegrammeni.sc.ad.ss06 ;
-sub omegapsilioxiaypogegrammeni.sc.ss06 by omegapsilioxiaypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaoxiaypogegrammeni.sc.ss06 by omegadasiaoxiaypogegrammeni.sc.ad.ss06 ;
-sub omegapsiliperispomeniypogegrammeni.sc.ss06 by omegapsiliperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegadasiaperispomeniypogegrammeni.sc.ss06 by omegadasiaperispomeniypogegrammeni.sc.ad.ss06 ;
-sub omegaperispomeniypogegrammeni.sc.ss06 by omegaperispomeniypogegrammeni.sc.ad.ss06 ;";
+code = "featureNames {\012    name \"iota adscript\";\012    name 1 \"iota adscript\";\012};\012\012sub Alphaprosgegrammeni by Alphaprosgegrammeni.ad;\012sub Alphapsiliprosgegrammeni by Alphapsiliprosgegrammeni.ad;\012sub Alphadasiaprosgegrammeni by Alphadasiaprosgegrammeni.ad;\012sub Alphapsilivariaprosgegrammeni by Alphapsilivariaprosgegrammeni.ad;\012sub Alphadasiavariaprosgegrammeni by Alphadasiavariaprosgegrammeni.ad;\012sub Alphapsilioxiaprosgegrammeni by Alphapsilioxiaprosgegrammeni.ad;\012sub Alphadasiaoxiaprosgegrammeni by Alphadasiaoxiaprosgegrammeni.ad;\012sub Alphapsiliperispomeniprosgegrammeni by Alphapsiliperispomeniprosgegrammeni.ad;\012sub Alphadasiaperispomeniprosgegrammeni by Alphadasiaperispomeniprosgegrammeni.ad;\012sub Etaprosgegrammeni by Etaprosgegrammeni.ad;\012sub Etapsiliprosgegrammeni by Etapsiliprosgegrammeni.ad;\012sub Etadasiaprosgegrammeni by Etadasiaprosgegrammeni.ad;\012sub Etapsilivariaprosgegrammeni by Etapsilivariaprosgegrammeni.ad;\012sub Etadasiavariaprosgegrammeni by Etadasiavariaprosgegrammeni.ad;\012sub Etapsilioxiaprosgegrammeni by Etapsilioxiaprosgegrammeni.ad;\012sub Etadasiaoxiaprosgegrammeni by Etadasiaoxiaprosgegrammeni.ad;\012sub Etapsiliperispomeniprosgegrammeni by Etapsiliperispomeniprosgegrammeni.ad;\012sub Etadasiaperispomeniprosgegrammeni by Etadasiaperispomeniprosgegrammeni.ad;\012sub Omegaprosgegrammeni by Omegaprosgegrammeni.ad;\012sub Omegapsiliprosgegrammeni by Omegapsiliprosgegrammeni.ad;\012sub Omegadasiaprosgegrammeni by Omegadasiaprosgegrammeni.ad;\012sub Omegapsilivariaprosgegrammeni by Omegapsilivariaprosgegrammeni.ad;\012sub Omegadasiavariaprosgegrammeni by Omegadasiavariaprosgegrammeni.ad;\012sub Omegapsilioxiaprosgegrammeni by Omegapsilioxiaprosgegrammeni.ad;\012sub Omegadasiaoxiaprosgegrammeni by Omegadasiaoxiaprosgegrammeni.ad;\012sub Omegapsiliperispomeniprosgegrammeni by Omegapsiliperispomeniprosgegrammeni.ad;\012sub Omegadasiaperispomeniprosgegrammeni by Omegadasiaperispomeniprosgegrammeni.ad;\012sub alphaypogegrammeni.sc by alphaypogegrammeni.sc.ad;\012sub alphavariaypogegrammeni.sc by alphavariaypogegrammeni.sc.ad;\012sub alphaoxiaypogegrammeni.sc by alphaoxiaypogegrammeni.sc.ad;\012sub alphapsiliypogegrammeni.sc by alphapsiliypogegrammeni.sc.ad;\012sub alphadasiaypogegrammeni.sc by alphadasiaypogegrammeni.sc.ad;\012sub alphapsilivariaypogegrammeni.sc by alphapsilivariaypogegrammeni.sc.ad;\012sub alphadasiavariaypogegrammeni.sc by alphadasiavariaypogegrammeni.sc.ad;\012sub alphapsilioxiaypogegrammeni.sc by alphapsilioxiaypogegrammeni.sc.ad;\012sub alphadasiaoxiaypogegrammeni.sc by alphadasiaoxiaypogegrammeni.sc.ad;\012sub alphapsiliperispomeniypogegrammeni.sc by alphapsiliperispomeniypogegrammeni.sc.ad;\012sub alphadasiaperispomeniypogegrammeni.sc by alphadasiaperispomeniypogegrammeni.sc.ad;\012sub alphaperispomeniypogegrammeni.sc by alphaperispomeniypogegrammeni.sc.ad;\012sub etaypogegrammeni.sc by etaypogegrammeni.sc.ad;\012sub etavariaypogegrammeni.sc by etavariaypogegrammeni.sc.ad;\012sub etaoxiaypogegrammeni.sc by etaoxiaypogegrammeni.sc.ad;\012sub etapsiliypogegrammeni.sc by etapsiliypogegrammeni.sc.ad;\012sub etadasiaypogegrammeni.sc by etadasiaypogegrammeni.sc.ad;\012sub etapsilivariaypogegrammeni.sc by etapsilivariaypogegrammeni.sc.ad;\012sub etadasiavariaypogegrammeni.sc by etadasiavariaypogegrammeni.sc.ad;\012sub etapsilioxiaypogegrammeni.sc by etapsilioxiaypogegrammeni.sc.ad;\012sub etadasiaoxiaypogegrammeni.sc by etadasiaoxiaypogegrammeni.sc.ad;\012sub etapsiliperispomeniypogegrammeni.sc by etapsiliperispomeniypogegrammeni.sc.ad;\012sub etadasiaperispomeniypogegrammeni.sc by etadasiaperispomeniypogegrammeni.sc.ad;\012sub etaperispomeniypogegrammeni.sc by etaperispomeniypogegrammeni.sc.ad;\012sub omegaypogegrammeni.sc by omegaypogegrammeni.sc.ad;\012sub omegavariaypogegrammeni.sc by omegavariaypogegrammeni.sc.ad;\012sub omegaoxiaypogegrammeni.sc by omegaoxiaypogegrammeni.sc.ad;\012sub omegapsiliypogegrammeni.sc by omegapsiliypogegrammeni.sc.ad;\012sub omegadasiaypogegrammeni.sc by omegadasiaypogegrammeni.sc.ad;\012sub omegapsilivariaypogegrammeni.sc by omegapsilivariaypogegrammeni.sc.ad;\012sub omegadasiavariaypogegrammeni.sc by omegadasiavariaypogegrammeni.sc.ad;\012sub omegapsilioxiaypogegrammeni.sc by omegapsilioxiaypogegrammeni.sc.ad;\012sub omegadasiaoxiaypogegrammeni.sc by omegadasiaoxiaypogegrammeni.sc.ad;\012sub omegapsiliperispomeniypogegrammeni.sc by omegapsiliperispomeniypogegrammeni.sc.ad;\012sub omegadasiaperispomeniypogegrammeni.sc by omegadasiaperispomeniypogegrammeni.sc.ad;\012sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ad;\012sub alphaypogegrammeni.sc.ss06 by alphaypogegrammeni.sc.ad.ss06 ;\012sub alphavariaypogegrammeni.sc.ss06 by alphavariaypogegrammeni.sc.ad.ss06 ;\012sub alphaoxiaypogegrammeni.sc.ss06 by alphaoxiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsiliypogegrammeni.sc.ss06 by alphapsiliypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaypogegrammeni.sc.ss06 by alphadasiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsilivariaypogegrammeni.sc.ss06 by alphapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub alphadasiavariaypogegrammeni.sc.ss06 by alphadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub alphapsilioxiaypogegrammeni.sc.ss06 by alphapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaoxiaypogegrammeni.sc.ss06 by alphadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub alphapsiliperispomeniypogegrammeni.sc.ss06 by alphapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub alphadasiaperispomeniypogegrammeni.sc.ss06 by alphadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub alphaperispomeniypogegrammeni.sc.ss06 by alphaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etaypogegrammeni.sc.ss06 by etaypogegrammeni.sc.ad.ss06 ;\012sub etavariaypogegrammeni.sc.ss06 by etavariaypogegrammeni.sc.ad.ss06 ;\012sub etaoxiaypogegrammeni.sc.ss06 by etaoxiaypogegrammeni.sc.ad.ss06 ;\012sub etapsiliypogegrammeni.sc.ss06 by etapsiliypogegrammeni.sc.ad.ss06 ;\012sub etadasiaypogegrammeni.sc.ss06 by etadasiaypogegrammeni.sc.ad.ss06 ;\012sub etapsilivariaypogegrammeni.sc.ss06 by etapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub etadasiavariaypogegrammeni.sc.ss06 by etadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub etapsilioxiaypogegrammeni.sc.ss06 by etapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub etadasiaoxiaypogegrammeni.sc.ss06 by etadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub etapsiliperispomeniypogegrammeni.sc.ss06 by etapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etadasiaperispomeniypogegrammeni.sc.ss06 by etadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub etaperispomeniypogegrammeni.sc.ss06 by etaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegaypogegrammeni.sc.ss06 by omegaypogegrammeni.sc.ad.ss06 ;\012sub omegavariaypogegrammeni.sc.ss06 by omegavariaypogegrammeni.sc.ad.ss06 ;\012sub omegaoxiaypogegrammeni.sc.ss06 by omegaoxiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsiliypogegrammeni.sc.ss06 by omegapsiliypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaypogegrammeni.sc.ss06 by omegadasiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsilivariaypogegrammeni.sc.ss06 by omegapsilivariaypogegrammeni.sc.ad.ss06 ;\012sub omegadasiavariaypogegrammeni.sc.ss06 by omegadasiavariaypogegrammeni.sc.ad.ss06 ;\012sub omegapsilioxiaypogegrammeni.sc.ss06 by omegapsilioxiaypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaoxiaypogegrammeni.sc.ss06 by omegadasiaoxiaypogegrammeni.sc.ad.ss06 ;\012sub omegapsiliperispomeniypogegrammeni.sc.ss06 by omegapsiliperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegadasiaperispomeniypogegrammeni.sc.ss06 by omegadasiaperispomeniypogegrammeni.sc.ad.ss06 ;\012sub omegaperispomeniypogegrammeni.sc.ss06 by omegaperispomeniypogegrammeni.sc.ad.ss06 ;";
 name = ss07;
 },
 {
-code = "featureNames {
-    name \"Bulgarian Locale\";
-    name 1 \"Bulgarian Locale\";
-};
-	
-script cyrl;
-sub De-cy by De-cy.loclBGR;
-sub El-cy by El-cy.loclBGR;
-sub Ef-cy by Ef-cy.loclBGR;
-sub ve-cy by ve-cy.loclBGR;
-sub ge-cy by ge-cy.loclBGR;
-sub de-cy by de-cy.loclBGR;
-sub zhe-cy by zhe-cy.loclBGR;
-sub ze-cy by ze-cy.loclBGR;
-sub ii-cy by ii-cy.loclBGR;
-sub iishort-cy by iishort-cy.loclBGR;
-sub iigrave-cy by iigrave-cy.loclBGR;
-sub ka-cy by ka-cy.loclBGR;
-sub el-cy by el-cy.loclBGR;
-sub ef-cy by ef-cy.loclBGR;
-sub pe-cy by pe-cy.loclBGR;
-sub te-cy by te-cy.loclBGR;
-sub tse-cy by tse-cy.loclBGR;
-sub sha-cy by sha-cy.loclBGR;
-sub shcha-cy by shcha-cy.loclBGR;
-sub softsign-cy by softsign-cy.loclBGR;
-sub hardsign-cy by hardsign-cy.loclBGR;
-sub iu-cy by iu-cy.loclBGR;
-sub yeru-cy by yeru-cy.loclBGR;
-sub de-cy.sc by de-cy.loclBGR.sc;
-sub el-cy.sc by el-cy.loclBGR.sc;
-sub ef-cy.sc by ef-cy.loclBGR.sc;
-";
+code = "featureNames {\012    name \"Bulgarian Locale\";\012    name 1 \"Bulgarian Locale\";\012};\012	\012script cyrl;\012sub De-cy by De-cy.loclBGR;\012sub El-cy by El-cy.loclBGR;\012sub Ef-cy by Ef-cy.loclBGR;\012sub ve-cy by ve-cy.loclBGR;\012sub ge-cy by ge-cy.loclBGR;\012sub de-cy by de-cy.loclBGR;\012sub zhe-cy by zhe-cy.loclBGR;\012sub ze-cy by ze-cy.loclBGR;\012sub ii-cy by ii-cy.loclBGR;\012sub iishort-cy by iishort-cy.loclBGR;\012sub iigrave-cy by iigrave-cy.loclBGR;\012sub ka-cy by ka-cy.loclBGR;\012sub el-cy by el-cy.loclBGR;\012sub ef-cy by ef-cy.loclBGR;\012sub pe-cy by pe-cy.loclBGR;\012sub te-cy by te-cy.loclBGR;\012sub tse-cy by tse-cy.loclBGR;\012sub sha-cy by sha-cy.loclBGR;\012sub shcha-cy by shcha-cy.loclBGR;\012sub softsign-cy by softsign-cy.loclBGR;\012sub hardsign-cy by hardsign-cy.loclBGR;\012sub iu-cy by iu-cy.loclBGR;\012sub yeru-cy by yeru-cy.loclBGR;\012sub de-cy.sc by de-cy.loclBGR.sc;\012sub el-cy.sc by el-cy.loclBGR.sc;\012sub ef-cy.sc by ef-cy.loclBGR.sc;\012";
 name = ss08;
 },
 {
-code = "# ===============
-# BEGIN HEBREW
-# ===============
-
-sub alef-hb by widealef-hb;
-sub he-hb by widehe-hb;
-sub lamed-hb by widelamed-hb;
-sub dalet-hb by widedalet-hb;
-sub kaf-hb by widekaf-hb;
-sub finalmem-hb by finalwidemem-hb;
-sub resh-hb by wideresh-hb;
-sub tav-hb by widetav-hb;
-
-# ===============
-# END HEBREW
-# ===============";
+code = "# ===============\012# BEGIN HEBREW\012# ===============\012\012sub alef-hb by widealef-hb;\012sub he-hb by widehe-hb;\012sub lamed-hb by widelamed-hb;\012sub dalet-hb by widedalet-hb;\012sub kaf-hb by widekaf-hb;\012sub finalmem-hb by finalwidemem-hb;\012sub resh-hb by wideresh-hb;\012sub tav-hb by widetav-hb;\012\012# ===============\012# END HEBREW\012# ===============";
 name = jalt;
 },
 {
-code = "# ==============
-# BEGIN HEBREW
-# ==============
-	lookupflag 0;
-	lookupflag RightToLeft;	
-	
-	# Kerning between narrow letters with wide marks			
-	pos [vav-hb yod-hb] @hb_wideMarks resh-hb' 60 @hb_wideMarks;
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_narrowHebrewLetters' 60 @hb_wideMarks;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks resh-hb' 30 @hb_wideMarks;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_narrowHebrewLetters' 30 @hb_wideMarks;
-	
-	# Make it work with cantillation marks (changed the second group to include all bottom diacritics)
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation resh-hb' 60 @hb_bottomDiacritics;
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 60 @hb_bottomDiacritics;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation resh-hb' 30 @hb_bottomDiacritics;
-	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 30 @hb_bottomDiacritics;
-			
-
-	# ---------- KERNING BETWEEN LAMED HOLAM AND SHINDOT
-	
-	pos [lamed_holam-hb lamed_dagesh_holam-hb] [shinshindot-hb shindageshshindot-hb ]' 60;
-	pos [lamed_holam-hb lamed_dagesh_holam-hb] @hb_allCantillation [shinshindot-hb shindageshshindot-hb ]' 60;
-	
-	
-	# ---------- KERNING BACK HOLAM IN BUSY PLACES
-	pos @hb_AllHebrewLetters holam-hb' < 50 0 0 0 > [shinshindot-hb shindageshshindot-hb vavholam-hb];
-	
-
-	# ---------- NARROW LETTER WITH HOLAM
-	
-	# Add kerning for holam after a wide cantillation sits on top of a narrow letter
-	pos @hb_narrowHebrewLetters [holam-hb holamhaser-hb] @hb_veryWideTopCantillation' < 50 0 0 0 >; 
-	pos @hb_narrowHebrewLetters [holam-hb holamhaser-hb]' < -30 0 0 0 > @hb_wideTopCantillation; 
-	
-	
-	# ---------- CANTILLATION GOES DOWN WHEN...		
-	
-	#1 between two wide diacritic marks
-	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] @hb_goesDown' < 50 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];	
-	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] siluqleft-hb' < 20 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];
-		
-	#2 between a wide mark and any letter with a very wide mark
-	pos [vav-hb yod-hb] @hb_wideMarks @hb_goesDown' < 120 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;	
-	pos [vav-hb yod-hb] @hb_wideMarks siluqleft-hb' < 80 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;
-					
-	#3 under the letter Qof
-	pos [qof-hb qofdagesh-hb] @hb_bottomDiacritics [@hb_goesDown siluqleft-hb]' < 50 -170 0 0 >;
-		
-	#4 before finalNun, finalKaf, finalPe
-	pos @hb_goesDown' < 0 -100 0 0 > [finalnun-hb finalpe-hb finalkaf-hb];
-
-# ==============
-# END HEBREW
-# ==============";
+code = "# ==============\012# BEGIN HEBREW\012# ==============\012	lookupflag 0;\012	lookupflag RightToLeft;	\012	\012	# Kerning between narrow letters with wide marks			\012	pos [vav-hb yod-hb] @hb_wideMarks resh-hb' 60 @hb_wideMarks;\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_narrowHebrewLetters' 60 @hb_wideMarks;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks resh-hb' 30 @hb_wideMarks;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_narrowHebrewLetters' 30 @hb_wideMarks;\012	\012	# Make it work with cantillation marks (changed the second group to include all bottom diacritics)\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation resh-hb' 60 @hb_bottomDiacritics;\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 60 @hb_bottomDiacritics;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation resh-hb' 30 @hb_bottomDiacritics;\012	pos [vavdagesh-hb yoddagesh-hb] @hb_wideMarks @hb_allCantillation @hb_narrowHebrewLetters' 30 @hb_bottomDiacritics;\012			\012\012	# ---------- KERNING BETWEEN LAMED HOLAM AND SHINDOT\012	\012	pos [lamed_holam-hb lamed_dagesh_holam-hb] [shinshindot-hb shindageshshindot-hb ]' 60;\012	pos [lamed_holam-hb lamed_dagesh_holam-hb] @hb_allCantillation [shinshindot-hb shindageshshindot-hb ]' 60;\012	\012	\012	# ---------- KERNING BACK HOLAM IN BUSY PLACES\012	pos @hb_AllHebrewLetters holam-hb' < 50 0 0 0 > [shinshindot-hb shindageshshindot-hb vavholam-hb];\012	\012\012	# ---------- NARROW LETTER WITH HOLAM\012	\012	# Add kerning for holam after a wide cantillation sits on top of a narrow letter\012	pos @hb_narrowHebrewLetters [holam-hb holamhaser-hb] @hb_veryWideTopCantillation' < 50 0 0 0 >; \012	pos @hb_narrowHebrewLetters [holam-hb holamhaser-hb]' < -30 0 0 0 > @hb_wideTopCantillation; \012	\012	\012	# ---------- CANTILLATION GOES DOWN WHEN...		\012	\012	#1 between two wide diacritic marks\012	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] @hb_goesDown' < 50 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];	\012	pos @hb_goesDownBefore [@hb_wideMarks hiriq-hb sheva-hb] siluqleft-hb' < 20 -160 0 0 > @hb_goesDownAfter [@hb_wideMarks sheva-hb hiriq-hb];\012		\012	#2 between a wide mark and any letter with a very wide mark\012	pos [vav-hb yod-hb] @hb_wideMarks @hb_goesDown' < 120 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;	\012	pos [vav-hb yod-hb] @hb_wideMarks siluqleft-hb' < 80 -160 0 0 > @hb_AllHebrewLetters @hb_veryWideMarks;\012					\012	#3 under the letter Qof\012	pos [qof-hb qofdagesh-hb] @hb_bottomDiacritics [@hb_goesDown siluqleft-hb]' < 50 -170 0 0 >;\012		\012	#4 before finalNun, finalKaf, finalPe\012	pos @hb_goesDown' < 0 -100 0 0 > [finalnun-hb finalpe-hb finalkaf-hb];\012\012# ==============\012# END HEBREW\012# ==============";
 name = kern;
 }
 );
@@ -6740,14 +3652,6 @@ leftKerningGroup = O;
 leftMetricsKey = O;
 rightKerningGroup = C;
 unicode = 0043;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = Cacute;
@@ -9849,14 +6753,6 @@ leftKerningGroup = O;
 leftMetricsKey = O;
 rightKerningGroup = G;
 unicode = 0047;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = Gbreve;
@@ -12124,14 +9020,6 @@ width = 575;
 leftKerningGroup = J;
 rightKerningGroup = J;
 unicode = 004A;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = Jcircumflex;
@@ -18030,14 +14918,6 @@ width = 631;
 leftKerningGroup = S;
 rightKerningGroup = S;
 unicode = 0053;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = Sacute;
@@ -24204,14 +21084,6 @@ width = 575;
 );
 leftKerningGroup = J;
 rightKerningGroup = J;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = K.alt;
@@ -27000,14 +23872,6 @@ width = 794;
 leftKerningGroup = O;
 leftMetricsKey = O;
 rightKerningGroup = G;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = a;
@@ -27305,14 +24169,6 @@ width = 594;
 leftKerningGroup = a;
 rightKerningGroup = a;
 unicode = 0061;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = aacute;
@@ -29069,17 +25925,6 @@ width = 594;
 leftKerningGroup = a;
 rightKerningGroup = a;
 unicode = 00E3;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 601;
-}
-);
-};
 },
 {
 glyphname = ae;
@@ -31847,14 +28692,6 @@ leftKerningGroup = o;
 leftMetricsKey = o;
 rightKerningGroup = e;
 unicode = 0065;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = eacute;
@@ -33676,14 +30513,6 @@ width = 404;
 leftKerningGroup = f;
 rightKerningGroup = f;
 unicode = 0066;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = g;
@@ -33969,14 +30798,6 @@ width = 612;
 leftKerningGroup = g;
 rightKerningGroup = g;
 unicode = 0067;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = gbreve;
@@ -34478,14 +31299,6 @@ width = 623;
 leftKerningGroup = l;
 rightKerningGroup = n;
 unicode = 0068;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = hbar;
@@ -37712,14 +34525,6 @@ leftMetricsKey = n;
 rightKerningGroup = n;
 rightMetricsKey = n;
 unicode = 006D;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = n;
@@ -37897,14 +34702,6 @@ width = 613;
 leftKerningGroup = lc_straight;
 rightKerningGroup = n;
 unicode = 006E;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = nacute;
@@ -38434,17 +35231,6 @@ width = 613;
 leftKerningGroup = lc_straight;
 rightKerningGroup = n;
 unicode = 00F1;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 601;
-}
-);
-};
 },
 {
 glyphname = o;
@@ -40675,17 +37461,6 @@ width = 614;
 leftKerningGroup = o;
 rightKerningGroup = o;
 unicode = 00F5;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 601;
-}
-);
-};
 },
 {
 glyphname = oe;
@@ -41933,14 +38708,6 @@ width = 422;
 leftKerningGroup = r;
 rightKerningGroup = r;
 unicode = 0072;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = racute;
@@ -42437,14 +39204,6 @@ width = 525;
 leftKerningGroup = s;
 rightKerningGroup = s;
 unicode = 0073;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = sacute;
@@ -43079,14 +39838,6 @@ width = 623;
 leftKerningGroup = l;
 rightKerningGroup = germandbs;
 unicode = 00DF;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = t;
@@ -43386,14 +40137,6 @@ width = 415;
 leftKerningGroup = t;
 rightKerningGroup = t;
 unicode = 0074;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = tbar;
@@ -50402,14 +47145,6 @@ leftKerningGroup = o;
 leftMetricsKey = a.alt;
 rightKerningGroup = e;
 rightMetricsKey = e;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = aeacute.alt;
@@ -51605,14 +48340,6 @@ width = 422;
 );
 leftKerningGroup = r;
 rightKerningGroup = r;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = racute.alt;
@@ -52118,14 +48845,6 @@ width = 405;
 );
 leftKerningGroup = t.alt;
 rightKerningGroup = t.alt;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = tbar.alt;
@@ -63556,14 +60275,6 @@ width = 827;
 leftKerningGroup = lc_straight;
 rightKerningGroup = t.alt;
 rightMetricsKey = t.alt;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = t_f.alt;
@@ -64417,11 +61128,6 @@ width = 598;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = a.sc;
-userData = {
-RMXScaler = {
-source = A;
-};
-};
 },
 {
 glyphname = aacute.sc;
@@ -66335,11 +63041,6 @@ width = 902;
 leftKerningGroup = a.sc;
 rightKerningGroup = e.sc;
 rightMetricsKey = e.sc;
-userData = {
-RMXScaler = {
-source = AE;
-};
-};
 },
 {
 glyphname = aeacute.sc;
@@ -82682,11 +79383,6 @@ width = 390;
 }
 );
 leftKerningGroup = o.sc.lc.ss04;
-userData = {
-RMXScaler = {
-source = q;
-};
-};
 },
 {
 glyphname = r.sc.lc.ss04;
@@ -85515,11 +82211,6 @@ width = 512;
 }
 );
 leftKerningGroup = o.sc.ss04;
-userData = {
-RMXScaler = {
-source = G;
-};
-};
 },
 {
 glyphname = h.sc.ss04;
@@ -88192,14 +84883,6 @@ width = 504;
 );
 leftKerningGroup = ords;
 unicode = 00AA;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = ordmasculine;
@@ -88829,14 +85512,6 @@ width = 550;
 leftKerningGroup = cyr_H;
 rightKerningGroup = cyr_G;
 unicode = 0403;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Gheupturn-cy";
@@ -89090,14 +85765,6 @@ leftKerningGroup = cyr_D;
 rightKerningGroup = cyr_Tse;
 rightMetricsKey = "Tse-cy";
 unicode = 0414;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Ie-cy";
@@ -89975,14 +86642,6 @@ width = 748;
 leftKerningGroup = cyr_H;
 rightKerningGroup = cyr_H;
 unicode = 0419;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Iigrave-cy";
@@ -90044,14 +86703,6 @@ width = 748;
 leftKerningGroup = cyr_H;
 rightKerningGroup = cyr_H;
 unicode = 040D;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 color = 4;
@@ -90357,14 +87008,6 @@ width = 668;
 leftKerningGroup = cyr_H;
 rightKerningGroup = cyr_K;
 unicode = 041A;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Kje-cy";
@@ -90426,14 +87069,6 @@ width = 668;
 leftKerningGroup = cyr_H;
 rightKerningGroup = cyr_K;
 unicode = 040C;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "El-cy";
@@ -91228,14 +87863,6 @@ width = 648;
 leftKerningGroup = cyr_Y;
 rightKerningGroup = cyr_Y;
 unicode = 0423;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Ushort-cy";
@@ -91297,14 +87924,6 @@ width = 648;
 leftKerningGroup = cyr_Y;
 rightKerningGroup = cyr_Y;
 unicode = 040E;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Ef-cy";
@@ -91559,14 +88178,6 @@ leftKerningGroup = cyr_F;
 rightKerningGroup = cyr_F;
 rightMetricsKey = "=|";
 unicode = 0424;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Ha-cy";
@@ -91802,14 +88413,6 @@ leftKerningGroup = cyr_Che;
 rightKerningGroup = cyr_H;
 rightMetricsKey = "En-cy";
 unicode = 0427;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Tse-cy";
@@ -91912,14 +88515,6 @@ leftKerningGroup = cyr_H;
 leftMetricsKey = H;
 rightKerningGroup = cyr_Tse;
 unicode = 0426;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "Sha-cy";
@@ -93656,14 +90251,6 @@ leftKerningGroup = cyr_E;
 rightKerningGroup = O;
 rightMetricsKey = "O-cy";
 unicode = 042D;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "I-cy";
@@ -103564,14 +100151,6 @@ leftKerningGroup = cyr_b;
 rightKerningGroup = cyr_b;
 rightMetricsKey = o;
 unicode = 0431;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "ve-cy";
@@ -104250,14 +100829,6 @@ leftKerningGroup = cyr_de;
 rightKerningGroup = cyr_tse;
 rightMetricsKey = "tse-cy";
 unicode = 0434;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "ie-cy";
@@ -105043,14 +101614,6 @@ leftMetricsKey = "en-cy";
 rightKerningGroup = lower_straight;
 rightMetricsKey = "=|";
 unicode = 0438;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "iishort-cy";
@@ -105173,14 +101736,6 @@ width = 632;
 leftKerningGroup = lc_straight;
 rightKerningGroup = lower_straight;
 unicode = 045D;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "iishorttail-cy";
@@ -105763,14 +102318,6 @@ leftMetricsKey = "en-cy";
 rightKerningGroup = lower_straight;
 rightMetricsKey = "=|";
 unicode = 043C;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "en-cy";
@@ -106094,14 +102641,6 @@ leftMetricsKey = "en-cy";
 rightKerningGroup = lower_straight;
 rightMetricsKey = "=|";
 unicode = 043F;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "er-cy";
@@ -106302,14 +102841,6 @@ leftKerningGroup = cyr_t;
 rightKerningGroup = cyr_t;
 rightMetricsKey = "=|";
 unicode = 0442;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "u-cy";
@@ -106675,14 +103206,6 @@ leftMetricsKey = "=o";
 rightKerningGroup = o;
 rightMetricsKey = "=|";
 unicode = 0444;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "ha-cy";
@@ -108534,14 +105057,6 @@ leftMetricsKey = c;
 rightKerningGroup = c;
 rightMetricsKey = c;
 unicode = 0454;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "ereversed-cy";
@@ -108737,14 +105252,6 @@ leftMetricsKey = "=|c";
 rightKerningGroup = o;
 rightMetricsKey = "o-cy";
 unicode = 044D;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "i-cy";
@@ -109669,14 +106176,6 @@ leftKerningGroup = cyr_ia;
 rightKerningGroup = lower_straight;
 rightMetricsKey = "en-cy";
 unicode = 044F;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "dje-cy";
@@ -113829,11 +110328,6 @@ leftKerningGroup = lc_straight;
 leftMetricsKey = "en-cy";
 rightKerningGroup = cyr_k;
 unicode = 04C4;
-userData = {
-RMXScaler = {
-source = "Kahook-cy";
-};
-};
 },
 {
 glyphname = "eltail-cy";
@@ -119281,14 +115775,6 @@ leftKerningGroup = o;
 leftMetricsKey = "=o";
 rightKerningGroup = o;
 rightMetricsKey = "=|";
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = "tse-cy.loclBGR";
@@ -121317,11 +117803,6 @@ width = 598;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = a.sc;
-userData = {
-RMXScaler = {
-source = "A-cy";
-};
-};
 },
 {
 glyphname = "be-cy.sc";
@@ -121514,11 +117995,6 @@ width = 570;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_b.sc;
-userData = {
-RMXScaler = {
-source = "Be-cy";
-};
-};
 },
 {
 glyphname = "ve-cy.sc";
@@ -121578,11 +118054,6 @@ width = 591;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = b.sc;
-userData = {
-RMXScaler = {
-source = "Ve-cy";
-};
-};
 },
 {
 glyphname = "ge-cy.sc";
@@ -121731,11 +118202,6 @@ width = 480;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
-userData = {
-RMXScaler = {
-source = "Ge-cy";
-};
-};
 },
 {
 glyphname = "gje-cy.sc";
@@ -121811,11 +118277,6 @@ width = 480;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_g.sc;
-userData = {
-RMXScaler = {
-source = "Gje-cy";
-};
-};
 },
 {
 glyphname = "gheupturn-cy.sc";
@@ -121933,11 +118394,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gheupturn-cy";
-};
-};
 },
 {
 glyphname = "de-cy.sc";
@@ -122146,11 +118602,6 @@ width = 664;
 leftKerningGroup = cyr_d.sc;
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "tse-cy.sc";
-userData = {
-RMXScaler = {
-source = "De-cy";
-};
-};
 },
 {
 glyphname = "ie-cy.sc";
@@ -122234,11 +118685,6 @@ width = 538;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = e.sc;
-userData = {
-RMXScaler = {
-source = "Ie-cy";
-};
-};
 },
 {
 glyphname = "iegrave-cy.sc";
@@ -122397,11 +118843,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = e.sc;
 rightMetricsKey = "e-cy.sc";
-userData = {
-RMXScaler = {
-source = "Io-cy";
-};
-};
 },
 {
 glyphname = "zhe-cy.sc";
@@ -122614,11 +119055,6 @@ width = 871;
 );
 leftKerningGroup = cyr_zhe.sc;
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Zhe-cy";
-};
-};
 },
 {
 glyphname = "ze-cy.sc";
@@ -122914,11 +119350,6 @@ width = 570;
 );
 leftKerningGroup = "cyr-ze.sc";
 rightKerningGroup = "cyr-ze.sc";
-userData = {
-RMXScaler = {
-source = "Ze-cy";
-};
-};
 },
 {
 glyphname = "ii-cy.sc";
@@ -123127,11 +119558,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ii-cy";
-};
-};
 },
 {
 glyphname = "iishort-cy.sc";
@@ -123207,11 +119633,6 @@ width = 649;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Iishort-cy";
-};
-};
 },
 {
 glyphname = "iigrave-cy.sc";
@@ -123741,11 +120162,6 @@ width = 593;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Ka-cy";
-};
-};
 },
 {
 glyphname = "kje-cy.sc";
@@ -123970,11 +120386,6 @@ width = 596;
 leftKerningGroup = cyr_l.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "El-cy";
-};
-};
 },
 {
 glyphname = "em-cy.sc";
@@ -124034,11 +120445,6 @@ width = 774;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Em-cy";
-};
-};
 },
 {
 glyphname = "en-cy.sc";
@@ -124098,11 +120504,6 @@ width = 616;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "En-cy";
-};
-};
 },
 {
 glyphname = "o-cy.sc";
@@ -124189,11 +120590,6 @@ width = 670;
 );
 leftKerningGroup = o.sc;
 rightKerningGroup = o.sc;
-userData = {
-RMXScaler = {
-source = "O-cy";
-};
-};
 },
 {
 glyphname = "pe-cy.sc";
@@ -124311,11 +120707,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Pe-cy";
-};
-};
 },
 {
 glyphname = "er-cy.sc";
@@ -124375,11 +120766,6 @@ width = 573;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = p.sc;
-userData = {
-RMXScaler = {
-source = "Er-cy";
-};
-};
 },
 {
 glyphname = "es-cy.sc";
@@ -124442,11 +120828,6 @@ width = 660;
 );
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
-userData = {
-RMXScaler = {
-source = "Es-cy";
-};
-};
 },
 {
 glyphname = "te-cy.sc";
@@ -124506,11 +120887,6 @@ width = 564;
 );
 leftKerningGroup = t.sc;
 rightKerningGroup = t.sc;
-userData = {
-RMXScaler = {
-source = "Te-cy";
-};
-};
 },
 {
 glyphname = "u-cy.sc";
@@ -124708,11 +121084,6 @@ width = 577;
 );
 leftKerningGroup = "u-cy.sc";
 rightKerningGroup = "u-cy.sc";
-userData = {
-RMXScaler = {
-source = "U-cy";
-};
-};
 },
 {
 glyphname = "ushort-cy.sc";
@@ -125060,11 +121431,6 @@ leftKerningGroup = cyr_f.sc;
 leftMetricsKey = "o-cy.sc";
 rightKerningGroup = cyr_f.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ef-cy";
-};
-};
 },
 {
 glyphname = "ha-cy.sc";
@@ -125124,11 +121490,6 @@ width = 632;
 );
 leftKerningGroup = x.sc;
 rightKerningGroup = x.sc;
-userData = {
-RMXScaler = {
-source = "Ha-cy";
-};
-};
 },
 {
 glyphname = "che-cy.sc";
@@ -125350,11 +121711,6 @@ width = 577;
 leftKerningGroup = cyr_che.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Che-cy";
-};
-};
 },
 {
 glyphname = "tse-cy.sc";
@@ -125487,11 +121843,6 @@ width = 630;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Tse-cy";
-};
-};
 },
 {
 glyphname = "sha-cy.sc";
@@ -125624,11 +121975,6 @@ width = 818;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Sha-cy";
-};
-};
 },
 {
 glyphname = "shcha-cy.sc";
@@ -125777,11 +122123,6 @@ width = 845;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Shcha-cy";
-};
-};
 },
 {
 glyphname = "dzhe-cy.sc";
@@ -125914,11 +122255,6 @@ width = 625;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
-userData = {
-RMXScaler = {
-source = "Dzhe-cy";
-};
-};
 },
 {
 glyphname = "softsign-cy.sc";
@@ -126103,11 +122439,6 @@ width = 576;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_soft.sc;
-userData = {
-RMXScaler = {
-source = "Softsign-cy";
-};
-};
 },
 {
 glyphname = "hardsign-cy.sc";
@@ -126300,11 +122631,6 @@ width = 689;
 leftKerningGroup = t.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Hardsign-cy";
-};
-};
 },
 {
 glyphname = "yeru-cy.sc";
@@ -126550,11 +122876,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Yeru-cy";
-};
-};
 },
 {
 glyphname = "lje-cy.sc";
@@ -126804,11 +123125,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Lje-cy";
-};
-};
 },
 {
 glyphname = "nje-cy.sc";
@@ -127031,11 +123347,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Nje-cy";
-};
-};
 },
 {
 glyphname = "dze-cy.sc";
@@ -127310,11 +123621,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = c.sc;
 rightKerningGroup = c.sc;
 rightMetricsKey = c.sc;
-userData = {
-RMXScaler = {
-source = "E-cy";
-};
-};
 },
 {
 glyphname = "ereversed-cy.sc";
@@ -127545,11 +123851,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = "=|c.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "o-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ereversed-cy";
-};
-};
 },
 {
 glyphname = "i-cy.sc";
@@ -128071,11 +124372,6 @@ width = 692;
 leftKerningGroup = t.sc;
 leftMetricsKey = t.sc;
 rightKerningGroup = cyr_dje.sc;
-userData = {
-RMXScaler = {
-source = "Tshe-cy";
-};
-};
 },
 {
 glyphname = "iu-cy.sc";
@@ -128316,11 +124612,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "o-cy.sc";
-userData = {
-RMXScaler = {
-source = "Iu-cy";
-};
-};
 },
 {
 glyphname = "ia-cy.sc";
@@ -128549,11 +124840,6 @@ width = 601;
 leftKerningGroup = cyr_ia.sc;
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ia-cy";
-};
-};
 },
 {
 glyphname = "dje-cy.sc";
@@ -128783,11 +125069,6 @@ width = 669;
 leftKerningGroup = t.sc;
 leftMetricsKey = t.sc;
 rightKerningGroup = cyr_dje.sc;
-userData = {
-RMXScaler = {
-source = "Dje-cy";
-};
-};
 },
 {
 glyphname = "yat-cy.sc";
@@ -129040,11 +125321,6 @@ leftKerningGroup = cyr_h.sc;
 leftMetricsKey = hbar.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Yat-cy";
-};
-};
 },
 {
 glyphname = "yusbig-cy.sc";
@@ -129284,11 +125560,6 @@ width = 682;
 );
 leftMetricsKey = "zhe-cy.sc";
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Yusbig-cy";
-};
-};
 },
 {
 glyphname = "fita-cy.sc";
@@ -129529,11 +125800,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Fita-cy";
-};
-};
 },
 {
 glyphname = "izhitsa-cy.sc";
@@ -129707,11 +125973,6 @@ width = 592;
 leftKerningGroup = v.sc;
 leftMetricsKey = v.sc;
 rightKerningGroup = cyr_v.sc;
-userData = {
-RMXScaler = {
-source = "Izhitsa-cy";
-};
-};
 },
 {
 glyphname = "ghestroke-cy.sc";
@@ -129852,11 +126113,6 @@ width = 493;
 leftKerningGroup = cyr_h.sc;
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ghestroke-cy";
-};
-};
 },
 {
 glyphname = "ghemiddlehook-cy.sc";
@@ -130070,11 +126326,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_dje.sc;
 rightMetricsKey = "dje-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ghemiddlehook-cy";
-};
-};
 },
 {
 glyphname = "zhedescender-cy.sc";
@@ -130260,11 +126511,6 @@ leftKerningGroup = cyr_zhe.sc;
 leftMetricsKey = "zhe-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "hadescender-cy.sc";
-userData = {
-RMXScaler = {
-source = "Zhedescender-cy";
-};
-};
 },
 {
 glyphname = "zedescender-cy.sc";
@@ -130377,11 +126623,6 @@ leftKerningGroup = "cyr-ze.sc";
 leftMetricsKey = "ze-cy.sc";
 rightKerningGroup = "cyr-ze.sc";
 rightMetricsKey = "ze-cy.sc";
-userData = {
-RMXScaler = {
-source = "Zedescender-cy";
-};
-};
 },
 {
 glyphname = "kadescender-cy.sc";
@@ -130522,11 +126763,6 @@ width = 596;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Kadescender-cy";
-};
-};
 },
 {
 glyphname = "kaverticalstroke-cy.sc";
@@ -130712,11 +126948,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kaverticalstroke-cy";
-};
-};
 },
 {
 glyphname = "kastroke-cy.sc";
@@ -130893,11 +127124,6 @@ width = 597;
 leftKerningGroup = cyr_h.sc;
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kastroke-cy";
-};
-};
 },
 {
 glyphname = "kabashkir-cy.sc";
@@ -131051,11 +127277,6 @@ leftKerningGroup = t.sc;
 leftMetricsKey = "hardsign-cy.sc";
 rightKerningGroup = cyr_k.sc;
 rightMetricsKey = "ka-cy.sc";
-userData = {
-RMXScaler = {
-source = "Kabashkir-cy";
-};
-};
 },
 {
 glyphname = "endescender-cy.sc";
@@ -131231,11 +127452,6 @@ width = 692;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Endescender-cy";
-};
-};
 },
 {
 glyphname = "enghe-cy.sc";
@@ -131362,11 +127578,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Enghe-cy";
-};
-};
 },
 {
 glyphname = "pedescender-cy.sc";
@@ -131807,11 +128018,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Haabkhasian-cy";
-};
-};
 },
 {
 glyphname = "esdescender-cy.sc";
@@ -131922,11 +128128,6 @@ width = 614;
 );
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
-userData = {
-RMXScaler = {
-source = "Esdescender-cy";
-};
-};
 },
 {
 glyphname = "tedescender-cy.sc";
@@ -132060,11 +128261,6 @@ leftKerningGroup = t.sc;
 leftMetricsKey = "te-cy.sc";
 rightKerningGroup = t.sc;
 rightMetricsKey = "te-cy.sc";
-userData = {
-RMXScaler = {
-source = "Tedescender-cy";
-};
-};
 },
 {
 glyphname = "hadescender-cy.sc";
@@ -132176,11 +128372,6 @@ width = 627;
 );
 leftKerningGroup = x.sc;
 rightKerningGroup = x.sc;
-userData = {
-RMXScaler = {
-source = "Hadescender-cy";
-};
-};
 },
 {
 glyphname = "chedescender-cy.sc";
@@ -132311,11 +128502,6 @@ width = 634;
 );
 leftKerningGroup = cyr_che.sc;
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Chedescender-cy";
-};
-};
 },
 {
 glyphname = "cheverticalstroke-cy.sc";
@@ -132518,11 +128704,6 @@ leftKerningGroup = cyr_che.sc;
 leftMetricsKey = "che-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Cheverticalstroke-cy";
-};
-};
 },
 {
 glyphname = "shha-cy.sc";
@@ -132671,11 +128852,6 @@ width = 577;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_shha.sc;
-userData = {
-RMXScaler = {
-source = "Shha-cy";
-};
-};
 },
 {
 glyphname = "shhadescender-cy.sc";
@@ -132856,11 +129032,6 @@ width = 605;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_shha.sc;
-userData = {
-RMXScaler = {
-source = "Shhadescender-cy";
-};
-};
 },
 {
 glyphname = "enlefthook-cy.sc";
@@ -133041,11 +129212,6 @@ width = 661;
 leftKerningGroup = "enlefthook-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = h.sc;
-userData = {
-RMXScaler = {
-source = "EnLeftHook-cy";
-};
-};
 },
 {
 glyphname = "eldescender-cy.sc";
@@ -133225,11 +129391,6 @@ width = 646;
 );
 leftKerningGroup = cyr_l.sc;
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Eldescender-cy";
-};
-};
 },
 {
 glyphname = "cheabkhasian-cy.sc";
@@ -133487,11 +129648,6 @@ width = 751;
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
 rightMetricsKey = "=|schwa-cy.sc";
-userData = {
-RMXScaler = {
-source = "Cheabkhasian-cy";
-};
-};
 },
 {
 glyphname = "chedescenderabkhasian-cy.sc";
@@ -133893,11 +130049,6 @@ width = 547;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_k.sc;
-userData = {
-RMXScaler = {
-source = "Kahook-cy";
-};
-};
 },
 {
 glyphname = "eltail-cy.sc";
@@ -134027,11 +130178,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "entail-cy.sc";
-userData = {
-RMXScaler = {
-source = "Eltail-cy";
-};
-};
 },
 {
 glyphname = "enhook-cy.sc";
@@ -134213,11 +130359,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Enhook-cy";
-};
-};
 },
 {
 glyphname = "entail-cy.sc";
@@ -134366,11 +130507,6 @@ width = 660;
 leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_tse.sc;
-userData = {
-RMXScaler = {
-source = "Entail-cy";
-};
-};
 },
 {
 glyphname = "chekhakassian-cy.sc";
@@ -134552,11 +130688,6 @@ leftKerningGroup = cyr_che.sc;
 leftMetricsKey = "che-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Chekhakassian-cy";
-};
-};
 },
 {
 glyphname = "emtail-cy.sc";
@@ -134758,11 +130889,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "em-cy.sc";
 rightKerningGroup = cyr_tse.sc;
 rightMetricsKey = "entail-cy.sc";
-userData = {
-RMXScaler = {
-source = "Emtail-cy";
-};
-};
 },
 {
 glyphname = "abreve-cy.sc";
@@ -134943,11 +131069,6 @@ width = 902;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = e.sc;
-userData = {
-RMXScaler = {
-source = "Aie-cy";
-};
-};
 },
 {
 glyphname = "iebreve-cy.sc";
@@ -135261,11 +131382,6 @@ width = 656;
 leftKerningGroup = o.sc;
 rightKerningGroup = o.sc;
 rightMetricsKey = o.sc;
-userData = {
-RMXScaler = {
-source = "Schwa-cy";
-};
-};
 },
 {
 glyphname = "schwadieresis-cy.sc";
@@ -135639,11 +131755,6 @@ leftKerningGroup = "cyr-ze.sc";
 leftMetricsKey = "ze-cy.sc";
 rightKerningGroup = "cyr-ze.sc";
 rightMetricsKey = "ze-cy.sc";
-userData = {
-RMXScaler = {
-source = "Dzeabkhasian-cy";
-};
-};
 },
 {
 glyphname = "imacron-cy.sc";
@@ -136063,11 +132174,6 @@ width = 577;
 );
 leftKerningGroup = "u-cy.sc";
 rightKerningGroup = "u-cy.sc";
-userData = {
-RMXScaler = {
-source = "Umacron-cy";
-};
-};
 },
 {
 glyphname = "udieresis-cy.sc";
@@ -136203,11 +132309,6 @@ width = 577;
 );
 leftKerningGroup = "u-cy.sc";
 rightKerningGroup = "u-cy.sc";
-userData = {
-RMXScaler = {
-source = "Uhungarumlaut-cy";
-};
-};
 },
 {
 glyphname = "chedieresis-cy.sc";
@@ -136393,11 +132494,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gedescender-cy";
-};
-};
 },
 {
 glyphname = "yerudieresis-cy.sc";
@@ -136614,11 +132710,6 @@ width = 458;
 leftKerningGroup = h.sc;
 rightKerningGroup = cyr_g.sc;
 rightMetricsKey = "ge-cy.sc";
-userData = {
-RMXScaler = {
-source = "Gestrokehook-cy";
-};
-};
 },
 {
 glyphname = "hahook-cy.sc";
@@ -136808,11 +132899,6 @@ leftKerningGroup = x.sc;
 leftMetricsKey = x.sc;
 widthMetricsKey = x.sc;
 rightKerningGroup = x.sc;
-userData = {
-RMXScaler = {
-source = "Hahook-cy";
-};
-};
 },
 {
 glyphname = "hastroke-cy.sc";
@@ -136990,11 +133076,6 @@ leftKerningGroup = x.sc;
 leftMetricsKey = "ha-cy.sc";
 rightKerningGroup = x.sc;
 rightMetricsKey = "ha-cy.sc";
-userData = {
-RMXScaler = {
-source = "Hastroke-cy";
-};
-};
 },
 {
 glyphname = "reversedze-cy.sc";
@@ -137251,11 +133332,6 @@ width = 487;
 );
 leftKerningGroup = o.sc;
 rightKerningGroup = c.sc;
-userData = {
-RMXScaler = {
-source = "Reversedze-cy";
-};
-};
 },
 {
 glyphname = "elhook-cy.sc";
@@ -137469,11 +133545,6 @@ leftKerningGroup = cyr_l.sc;
 leftMetricsKey = "el-cy.sc";
 rightKerningGroup = h.sc;
 rightMetricsKey = "en-cy.sc";
-userData = {
-RMXScaler = {
-source = "Elhook-cy";
-};
-};
 },
 {
 glyphname = "qa-cy.sc";
@@ -137779,11 +133850,6 @@ leftKerningGroup = cyr_h.sc;
 leftMetricsKey = hbar.sc;
 rightKerningGroup = cyr_soft.sc;
 rightMetricsKey = "softsign-cy.sc";
-userData = {
-RMXScaler = {
-source = "Semisoftsign-cy";
-};
-};
 },
 {
 glyphname = "ertick-cy.sc";
@@ -138005,11 +134071,6 @@ leftKerningGroup = h.sc;
 leftMetricsKey = "en-cy.sc";
 rightKerningGroup = p.sc;
 rightMetricsKey = "er-cy.sc";
-userData = {
-RMXScaler = {
-source = "Ertick-cy";
-};
-};
 },
 {
 glyphname = "de-cy.loclBGR.sc";
@@ -138185,11 +134246,6 @@ width = 641;
 );
 leftKerningGroup = a.sc;
 rightKerningGroup = a.sc;
-userData = {
-RMXScaler = {
-source = "De-cy.loclBGR";
-};
-};
 },
 {
 glyphname = "el-cy.loclBGR.sc";
@@ -138300,11 +134356,6 @@ leftKerningGroup = a.sc;
 leftMetricsKey = a.sc;
 rightKerningGroup = a.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "El-cy.loclBGR";
-};
-};
 },
 {
 glyphname = "ef-cy.loclBGR.sc";
@@ -138595,11 +134646,6 @@ leftKerningGroup = o.sc;
 leftMetricsKey = "ef-cy.sc";
 rightKerningGroup = o.sc;
 rightMetricsKey = "=|";
-userData = {
-RMXScaler = {
-source = "Ef-cy.loclBGR";
-};
-};
 },
 {
 glyphname = "ghestroke-cy.loclBSH.sc";
@@ -150528,14 +146574,6 @@ leftMetricsKey = "=p";
 rightKerningGroup = GRK_beta;
 rightMetricsKey = "=p";
 unicode = 03B2;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = gamma;
@@ -150631,14 +146669,6 @@ leftMetricsKey = "=v";
 rightKerningGroup = GRK_gamma;
 rightMetricsKey = "=v";
 unicode = 03B3;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = delta;
@@ -151272,14 +147302,6 @@ leftMetricsKey = "=o-10";
 rightKerningGroup = GRK_zeta;
 rightMetricsKey = "=c-20";
 unicode = 03B6;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = eta;
@@ -151972,14 +147994,6 @@ leftMetricsKey = "=k";
 rightKerningGroup = GRK_kappa;
 rightMetricsKey = "=k";
 unicode = 03BA;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = lambda;
@@ -153999,14 +150013,6 @@ leftMetricsKey = "=o";
 rightKerningGroup = GRK_omicron;
 rightMetricsKey = "=o";
 unicode = 03C6;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = chi;
@@ -154608,14 +150614,6 @@ leftMetricsKey = "=o+10";
 rightKerningGroup = GRK_omicron;
 rightMetricsKey = "=o+10";
 unicode = 03C9;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = iotatonos;
@@ -154982,17 +150980,6 @@ width = 608;
 leftKerningGroup = GRK_upsilon;
 rightKerningGroup = GRK_upsilon;
 unicode = 03B0;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 1018;
-}
-);
-};
 },
 {
 glyphname = omicrontonos;
@@ -155237,14 +151224,6 @@ width = 546;
 leftKerningGroup = GRK_epsilon;
 rightKerningGroup = GRK_epsilon;
 unicode = 03AD;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = etatonos;
@@ -191718,14 +187697,6 @@ width = 853;
 leftKerningGroup = circle;
 rightKerningGroup = circle;
 unicode = 278E;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = six.sansSerifBlackCircled;
@@ -192003,14 +187974,6 @@ width = 853;
 leftKerningGroup = circle;
 rightKerningGroup = circle;
 unicode = 278F;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = seven.sansSerifBlackCircled;
@@ -192176,14 +188139,6 @@ width = 853;
 leftKerningGroup = circle;
 rightKerningGroup = circle;
 unicode = 2790;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = eight.sansSerifBlackCircled;
@@ -192814,14 +188769,6 @@ width = 853;
 leftKerningGroup = circle;
 rightKerningGroup = circle;
 unicode = 2792;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = zero.alt;
@@ -193376,14 +189323,6 @@ nodes = (
 width = 576;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = seven.alt;
@@ -193718,14 +189657,6 @@ nodes = (
 width = 576;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = zero.alt.cap;
@@ -194363,14 +190294,6 @@ nodes = (
 width = 592;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = seven.alt.cap;
@@ -194705,14 +190628,6 @@ nodes = (
 width = 611;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = zero.cap;
@@ -195381,17 +191296,6 @@ nodes = (
 width = 569;
 }
 );
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = -247;
-y = 0;
-}
-);
-};
 },
 {
 glyphname = four.cap;
@@ -198066,14 +193970,6 @@ nodes = (
 width = 336;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = six.numerator;
@@ -198280,14 +194176,6 @@ nodes = (
 width = 340;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = seven.numerator;
@@ -198870,14 +194758,6 @@ nodes = (
 width = 340;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = zero.ss03;
@@ -206167,11 +202047,6 @@ width = 437;
 );
 leftKerningGroup = zero.sc;
 rightKerningGroup = zero.sc;
-userData = {
-RMXScaler = {
-source = zero.cap;
-};
-};
 },
 {
 glyphname = one.sc.ss04;
@@ -206250,11 +202125,6 @@ nodes = (
 width = 297;
 }
 );
-userData = {
-RMXScaler = {
-source = one.cap;
-};
-};
 },
 {
 glyphname = two.sc.ss04;
@@ -206421,11 +202291,6 @@ nodes = (
 width = 359;
 }
 );
-userData = {
-RMXScaler = {
-source = two.cap;
-};
-};
 },
 {
 glyphname = three.sc.ss04;
@@ -206695,11 +202560,6 @@ nodes = (
 width = 380;
 }
 );
-userData = {
-RMXScaler = {
-source = three.cap;
-};
-};
 },
 {
 glyphname = four.sc.ss04;
@@ -206830,11 +202690,6 @@ nodes = (
 width = 406;
 }
 );
-userData = {
-RMXScaler = {
-source = four;
-};
-};
 },
 {
 glyphname = five.sc.ss04;
@@ -207013,11 +202868,6 @@ nodes = (
 width = 379;
 }
 );
-userData = {
-RMXScaler = {
-source = five.cap;
-};
-};
 },
 {
 glyphname = six.sc.ss04;
@@ -207228,11 +203078,6 @@ nodes = (
 width = 370;
 }
 );
-userData = {
-RMXScaler = {
-source = six.cap;
-};
-};
 },
 {
 glyphname = seven.sc.ss04;
@@ -207327,11 +203172,6 @@ nodes = (
 width = 363;
 }
 );
-userData = {
-RMXScaler = {
-source = seven.cap;
-};
-};
 },
 {
 glyphname = eight.sc.ss04;
@@ -207622,11 +203462,6 @@ nodes = (
 width = 367;
 }
 );
-userData = {
-RMXScaler = {
-source = eight.cap;
-};
-};
 },
 {
 glyphname = nine.sc.ss04;
@@ -207837,11 +203672,6 @@ nodes = (
 width = 371;
 }
 );
-userData = {
-RMXScaler = {
-source = nine.cap;
-};
-};
 },
 {
 glyphname = "One-roman";
@@ -211924,14 +207754,6 @@ width = 294;
 leftKerningGroup = period;
 rightKerningGroup = period;
 unicode = 002C;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = colon;
@@ -214722,14 +210544,6 @@ width = 362;
 leftKerningGroup = slash;
 rightKerningGroup = slash;
 unicode = 002F;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = backslash;
@@ -214799,14 +210613,6 @@ width = 362;
 leftMetricsKey = "=|slash";
 rightMetricsKey = "=|slash";
 unicode = 005C;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = twoasterisksvertical;
@@ -219086,14 +214892,6 @@ width = 335;
 leftKerningGroup = quoteleft;
 rightKerningGroup = quoteleft;
 unicode = 2018;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = quoteright;
@@ -220007,14 +215805,6 @@ width = 582;
 );
 leftKerningGroup = quoteright;
 rightKerningGroup = quoteright;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = quoteleft.alt;
@@ -223177,14 +218967,6 @@ width = 606;
 }
 );
 unicode = 20A3;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = hryvnia;
@@ -230353,14 +226135,6 @@ layerId = "3E1A77A5-2AAF-4B97-842E-5802590C9619";
 width = 600;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = hryvnia.tf;
@@ -230725,14 +226499,6 @@ nodes = (
 width = 600;
 }
 );
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = ruble.tf;
@@ -233236,7 +229002,7 @@ width = 535;
 unicode = 005E;
 },
 {
-glyphname = infinity;
+glyphname = "infinity";
 lastChange = "2020-01-22 16:44:47 +0000";
 layers = (
 {
@@ -233693,14 +229459,6 @@ width = 784;
 leftKerningGroup = Omega;
 rightKerningGroup = Omega;
 unicode = 2126;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = increment;
@@ -240150,14 +235908,6 @@ width = 860;
 }
 );
 unicode = 25A1;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = upBlackTriangle;
@@ -240316,14 +236066,6 @@ width = 870;
 }
 );
 unicode = 25B3;
-userData = {
-com.typemytype.robofont.mark = (
-0.6,
-0.609,
-1,
-1
-);
-};
 },
 {
 glyphname = checkmark;
@@ -247708,14 +243450,6 @@ width = 559;
 }
 );
 leftKerningGroup = mark.mid;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = servicemark.alt2;
@@ -248011,14 +243745,6 @@ width = 498;
 }
 );
 leftKerningGroup = mark.mid;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = trademark.alt3;
@@ -248196,14 +243922,6 @@ width = 559;
 leftKerningGroup = mark.low;
 leftMetricsKey = trademark;
 rightMetricsKey = trademark;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = servicemark.alt3;
@@ -248501,14 +244219,6 @@ width = 548;
 leftKerningGroup = mark.low;
 leftMetricsKey = servicemark;
 rightMetricsKey = servicemark;
-userData = {
-com.typemytype.robofont.mark = (
-0.656,
-1,
-0.6,
-1
-);
-};
 },
 {
 glyphname = at.cap;
@@ -250966,24 +246676,6 @@ width = 280;
 }
 );
 unicode = 0307;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 642;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 118;
-y = 0;
-}
-);
-};
 },
 {
 glyphname = gravecomb;
@@ -251541,17 +247233,6 @@ width = 456;
 }
 );
 unicode = 0302;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 587;
-}
-);
-};
 },
 {
 glyphname = caroncomb;
@@ -254073,24 +249754,6 @@ width = 269;
 }
 );
 unicode = 02D9;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 642;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 118;
-y = 0;
-}
-);
-};
 },
 {
 glyphname = grave;
@@ -254263,17 +249926,6 @@ width = 456;
 }
 );
 unicode = 02C6;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 0;
-isGlobal = 0;
-magnetic = 5;
-x = 0;
-y = 587;
-}
-);
-};
 },
 {
 glyphname = caron;
@@ -268417,45 +264069,6 @@ width = 3284;
 }
 );
 unicode = E006;
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 861;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 1439;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2017;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2583;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2770;
-y = 0;
-}
-);
-};
 },
 {
 glyphname = uniE007;
@@ -269649,45 +265262,6 @@ nodes = (
 width = 3284;
 }
 );
-userData = {
-com.typemytype.robofont.guides = (
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 861;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 1439;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2017;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2583;
-y = 0;
-},
-{
-angle = 90;
-isGlobal = 0;
-magnetic = 5;
-x = 2770;
-y = 0;
-}
-);
-};
 },
 {
 export = 0;
@@ -293320,11 +288894,6 @@ width = 583;
 );
 leftKerningGroup = y.sc;
 rightKerningGroup = y.sc;
-userData = {
-RMXScaler = {
-source = "Ustraightstroke-cy";
-};
-};
 }
 );
 instances = (


### PR DESCRIPTION
Closes #86 

We have extraneous Robofont and RMXScaler user metadata in the source files.  I added a new glyphsLib based script to remove these unnecessary data from the source files as well as pass the sources through glyphsLib to achieve consistent source formatting for merges irrespective of the editor that designers elect to use with the upstream/downstream sources.

I consider this a WIP / experiment.  Requires testing to confirm that we do not alter the builds.  It removes 4000 lines from each of the sources and on initial inspection it appears that this includes: (1) the intentional removal of the glyph level Robofont / RMXScaler user library metadata; (2) reformatting of feature code newline characters to \012 octal literal

cc @alexeiva 