### PR TITLE
[qa] Remove custom fontbakery conditions from fontbakery check profile

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -14,7 +14,7 @@
 
 
 from fontbakery.checkrunner import Section, PASS, FAIL
-from fontbakery.callable import check, condition
+from fontbakery.callable import check
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.profiles.universal import UNIVERSAL_PROFILE_CHECKS
 
@@ -69,9 +69,8 @@ ATTRIBUTES = {
 # ================================================
 
 
-@condition
-def is_not_variable_font(ttFont):
-    return "fvar" not in ttFont.keys()
+# removed custom conditions that duplicated upstream fontbakery
+# condition names
 
 
 # ================================================

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -43,6 +43,8 @@ excluded_check_ids = (
     "com.google.fonts/check/varfont/regular_opsz_coord",  # we do want our opsz definition
     # "com.google.fonts/check/os2_metrics_match_hhea",
     # "com.google.fonts/check/unwanted_tables",
+    # https://github.com/googlefonts/googlesans/issues/108:
+    "com.google.fonts/check/glyf_nested_components",
 )
 
 ATTRIBUTES = {

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -70,16 +70,6 @@ ATTRIBUTES = {
 
 
 @condition
-def is_italic(ttFont):
-    return "Italic" in ttFont.reader.file.name
-
-
-@condition
-def is_not_italic(ttFont):
-    return "Italic" not in ttFont.reader.file.name
-
-
-@condition
 def is_not_variable_font(ttFont):
     return "fvar" not in ttFont.keys()
 


### PR DESCRIPTION
Attempt to fix CI fail issue documented in #106

Fixes #106

---

### TODO

- [ ] reimplement nested components check that was removed in https://github.com/googlefonts/googlesans/pull/107/commits/a097840bee579d3198b1ad79bdefd4682953fa3d (this was added as a new issue report so that we can track the replacement of this test, this will allow us to have a functional CI while the UFO transition takes place and before we implement the nested component removal in the build workflow)