### PR TITLE
Add vendor documentation, style guidelines

### DIFF
--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -108,7 +108,7 @@ To make merges into the main source base as seamless as possible, vendors should
 
 #### Getting a List Of Glyphs and (Kerning) Groups
 
-Getting a list of glyph names usually involves selecting everything relevant in the editor and looking for the "copy glyph names" menu entry. The list should be saved to a text file with one line per glyph name and appended to the PR. Example file contents:
+Getting a list of glyph names usually involves selecting everything relevant in the editor and looking for the "copy glyph names" menu entry. The list should be saved to a text file (e.g. `import_glyphs.txt`) with one line per glyph name and appended to the PR. Example file contents:
 
 ```
 thai_koKai
@@ -119,7 +119,7 @@ thai_phoSamphao
 Getting a group list needs a script, as Glyphs.app and Fontlab name kerning groups differently, making retrieval tedious. For Glyphs.app files, use:
 
 ```
-$ python3 scripts/gs-print-kerning-groups.py source/GoogleSans/GoogleSansSomeScript.glyphs > import_groups.txt
+$ python3 scripts/gs-print-kerning-groups.py source/GoogleSans/GoogleSansSomeScript.glyphs --glyphs-list import_glyphs.txt > import_groups.txt
 ```
 
 Example file contents:
@@ -131,7 +131,9 @@ public.kern2.thai_boBaimai
 public.kern2.thai_khoKhuat
 ```
 
-The resulting list in the file `import_groups.txt` should be screened to contain only what should be imported and appended to the PR. The name prefix `public.kern1.` marks groups "to the left" (RTL: right) and `public.kern2.` marks groups "to the right" (RTL: left).
+The resulting list in the file `import_groups.txt` will only contain groups that contain at least one glyph that is going to be imported. If you want to include more groups, add them manually. The name prefix `public.kern1.` marks groups "to the left" (RTL: right) and `public.kern2.` marks groups "to the right" (RTL: left). Note that the import process will grab all kerning pairs that include either a listed kerning group name or a glyph inside that kerning group.
+
+Typically, you need to do both lists just once for your script and only change them if you actually add or remove a glyph or kerning group. If something needs to be remerged, the existing lists will work fine.
 
 ## Workflow
 

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -50,34 +50,41 @@ $ make sync-deps
 
 ## Source Conventions
 
+Our source code style guidance is documented in [STYLE.md](STYLE.md).
+
 The font sources we receive from vendors are scrubbed with custom scripts and stored as Designspaces and UFOs. The primary objective of the sources is to build the fonts and serve as a base for vendors to split off from to work on new scripts.
 
-Specifically, the sources are normalized to be formatted in the way ufoLib formats sources and contain only:
+<details>
+<summary><strong>Source Normalization Details (click to open)</strong></summary>
+
+The sources are normalized according to [fontTools.ufoLib](https://fonttools.readthedocs.io/en/latest/ufoLib/) formatting and contain only:
 
 * Foreground, intermediate (brace) and conditional (bracket) glyphs, no draft or background layers
-    * whose metadata (lib keys) contains only semantically relevant data like Glyphs.app's metrics keys, but not color marks.
+  * whose metadata (lib keys) contains only semantically relevant data like Glyphs.app's metrics keys, but not color marks.
 * Groups and kerning
 * Manually merged and arranged features
 * Manually maintained font info data
-* Automatically managed UFO lib.plist files, that contain:
-    * `public.glyphOrder` for determining the order of glyphs in the final fonts
-    * `public.postscriptNames` for determining the production glyph names in the final fonts
-    * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
-    * `com.github.googlei18n.ufo2ft.filters` for listing filters and their options for compile-time font processing
-        * `propagateAnchors`: inherits anchors of base glyphs to their composites automatically to help with building the `mark` and `mkmk` features.
-    * `com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check` for telling Glyphs.app to always run compatibility checks, not relevant for the build
-    * `com.schriftgestaltung.customParameter.GSFont.disablesLastChange` for telling Glyphs.app to not put "last changed" markers into glyphs, which we don't need in the UFO format
-    * `com.schriftgestaltung.fontMasterID` for making it easier to match vendor Glyphs.app files to be imported to the target UFOs
-* Automatically managed UFO layer layerinfo.plist files, that contain:
-    * `com.schriftgestaltung.layerId` for hopefully helping exchange with Glyphs.app.
+* Automatically managed UFO [lib.plist files](https://unifiedfontobject.org/versions/ufo3/lib.plist/), that contain:
+  * `public.glyphOrder` for determining the order of glyphs in the final fonts
+  * `public.postscriptNames` for determining the production glyph names in the final fonts
+  * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+  * `com.github.googlei18n.ufo2ft.filters` for listing filters and their options for compile-time font processing
+    * `propagateAnchors`: inherits anchors of base glyphs to their composites automatically to help with building the `mark` and `mkmk` features.
+  * `com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check` for telling Glyphs.app to always run compatibility checks, not relevant for the build
+  * `com.schriftgestaltung.customParameter.GSFont.disablesLastChange` for telling Glyphs.app to not put "last changed" markers into glyphs, which we don't need in the UFO format
+  * `com.schriftgestaltung.fontMasterID` for making it easier to match vendor Glyphs.app files to be imported to the target UFOs
+* Automatically managed UFO layer [layerinfo.plist files](https://unifiedfontobject.org/versions/ufo3/glyphs/layerinfo.plist/), that contain:
+  * `com.schriftgestaltung.layerId` for hopefully helping exchange with Glyphs.app.
 * Manually managed Designspace `<rules>` for describing conditional (bracket) glyphs
 * Automatically managed Designspace instance and global libs, that contain:
-    * Instances:
-        * `com.schriftgestaltung.customParameters` for carrying build-relevant metadata like PANOSE values
-    * Global:
-        * `GSDimensionPlugin.Dimensions` for storing Glyphs.app's metadata for stem thicknesses
-        * `com.github.googlei18n.ufo2ft.featureWriters` for build-relevant options on how to generate OpenType layout data
-        * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+  * Instances:
+    * `com.schriftgestaltung.customParameters` for carrying build-relevant metadata like PANOSE values
+  * Global:
+    * `GSDimensionPlugin.Dimensions` for storing Glyphs.app's metadata for stem thicknesses
+    * `com.github.googlei18n.ufo2ft.featureWriters` for build-relevant options on how to generate OpenType layout data
+    * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+
+</details>
 
 ### Normalizing Sources and Updating GDEF
 
@@ -98,77 +105,6 @@ To make merges into the main source base as seamless as possible, vendors should
 * Provide a list of glyph names and group names to import into the base sources ([see below](#getting-a-list-of-glyphs-and-kerning-groups)).
 * Notify us if they want to change something in the base sources with their sources, as we will screen the changes out otherwise. This includes the names or contents of existing kerning groups or OpenType classes.
 * Bundle up test documents for checking the correct shaping of text and application of features, to have tests for functionality after merging.
-
-Additionally, some conventions should be followed for kerning group names and feature code:
-
-* Below, script tags refer to codes in [OpenType Script Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags) and language tags to [OpenType Language System Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags).
-* Generally, all names should be lowercase (as seen in the examples), separated by underscores, except for what refers to glyph names. E.g. `Omega` should stay as is if it refers to the glyph name.
-* OpenType class naming uses the following format:
-    * A_B_C_D
-    * A - Context-dependent Script system tag - only for Non-Latin scripts
-    * B - Context-dependent language system tag
-    * C - Context-dependent feature tag
-    * D - Class Description string
-    * E.g.:
-        * C: `pnum`
-        * C_D: `pnum_currencies`
-        * C_D: `frac_precomposed`
-        * A_B_C: `cyrl_bgr_locl`
-        * A_C_D_D: `grek_calt_marks_context`
-
-    Lookup naming should use the following format:
-
-    * A_B_C_D
-    * A - Context-dependent Script system tag - only for Non-Latin scripts
-    * B - Context-dependent language system tag
-    * C - Feature tag
-    * D - Lookup description string
-    * E.g.:
-        * B_C_D_D: `rom_locl_cedilla_substitution`
-        * A_C_D_D: `grek_ccmp_recompose_dieresistonos`
-        * A_B_C_D: `cyrl_bgr_locl_alternates`
-        * C_D: `frac_precomposed`
-
-    In general:
-
-    * When a lookup/class is used by several scripts, list all scripts in the name.
-    * When a lookup/class is used by several languages, list all languages in the name.
-    * When a lookup/class is used in several features, list all feature tags in its name.
-    * Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the lookup/class definition, to explain which scripts/languages/features are concerned
-* Kerning groups should contain the name of the script they pertain to. This avoids name clashes. The format is script_key_glyph_or_description, examples: `grek_Omega`, `armn_uc_topround_bottomstraight`, `thai_phoSamphao`.
-* Feature code should be organized so that:
-    * feature blocks and lookups are declared separately. This makes merging much easier.
-    * lookups should have descriptive names and should include, where it makes sense, the language and feature tag where they are used. Example: `nld_locl_ij_substitution` for a netherlandish lookup that replaces `i' j'` by `ij`. See https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags for ISO 639 language tags.
-
-Feature file example:
-
-```
-languagesystem DFLT dflt;
-languagesystem latn dflt;
-languagesystem latn NLD;
-
-@pnum_fig_dflt = [zero one two three four five six seven eight nine];
-@pnum_fig_alt = [zero.alt one.alt two.alt three.alt four.alt five.alt six.alt seven.alt eight.alt nine.alt];
-
-lookup pnum_text {
-    sub @fig_dflt by @fig_alt;
-} pnum_text;
-
-lookup nld_locl_ij_substitution {
-    sub i' j' by ij;
-    sub I' J' by IJ;
-} nld_locl_ij_substitution;
-
-feature pnum {
-    lookup pnum_text;
-} pnum;
-
-feature locl {
-    script latn;
-    language NLD;
-    lookup nld_locl_ij_substitution;
-} locl;
-```
 
 #### Getting a List Of Glyphs and (Kerning) Groups
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -48,7 +48,7 @@ This document details the source style guidelines for the Google Sans project.
 - All names should be lowercase, separated by underscores, except for the string that refers to glyph names. E.g. `Omega` should stay as is if it refers to the upper case glyph name
 - Kerning groups should contain the name of the script they pertain to. This avoids name clashes. The format is script_key_glyph_or_description
 
-#### Adobe feature code lookup names
+#### Adobe OpenType feature file lookup names
 
 - Adobe feature code lookup names should use the following format:
 
@@ -62,7 +62,7 @@ This document details the source style guidelines for the Google Sans project.
 - When a lookup is used in several features, list all feature tags in its name
 - Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the lookup definition, to explain which scripts/languages/features are concerned
 
-### Adobe feature file source
+### Adobe OpenType feature file source
 
 - feature blocks and lookups should be declared separately
 - lookups should have descriptive names and include, where appropriate, the language and feature tag where they are used. Example: `nld_locl_ij_substitution` for a Netherlandish lookup that replaces `i' j'` by `ij`
@@ -100,7 +100,7 @@ This document details the source style guidelines for the Google Sans project.
 - A_B_C_D: `cyrl_bgr_locl_alternates`
 - C_D: `frac_precomposed`
   
-### Adobe feature file examples
+### Adobe OpenType feature file examples
 
 ```fea
 languagesystem DFLT dflt;

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -12,11 +12,11 @@ This document details the source style guidelines for the Google Sans project.
 
 ### Script Tags
 
-"Script tags" in this document refer to the script tag strings defined in [OpenType Script Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags).
+"Script tags" refer to the script tag strings defined in [OpenType Script Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags).
 
 ### Language Tags
 
-"Language tags" in this document refer to the language tag strings defined in [OpenType Language System Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags).
+"Language tags" refer to the language tag strings defined in [OpenType Language System Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags).
 
 ## Style
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,131 @@
+# Google Sans Style Guidelines
+
+This document details the source style guidelines for the Google Sans project.
+
+## Contents
+
+- [Definitions](#definitions)
+- [Style](#style)
+- [Examples](#examples)
+
+## Definitions
+
+### Script Tags
+
+"Script tags" in this document refer to the script tag strings defined in [OpenType Script Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags).
+
+### Language Tags
+
+"Language tags" in this document refer to the language tag strings defined in [OpenType Language System Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags).
+
+## Style
+
+### Names
+
+#### Glyph names
+
+- Name all glyphs according to the naming standard used by the Glyphs.app GlyphData.xml database
+- Use underscores to separate glyph names in ligature glyph forms
+- Name localized glyph forms with the glyph name, a period, the string `locl`, followed by an all caps localized language tag suffix
+- In scripts that support upper case forms, please use title case glyph names for upper case glyph forms
+- Please do not change glyph names after they have been imported into the upstream source files
+
+#### OpenType class names
+
+- OpenType class naming should use the following format:
+  - A_B_C_D
+    - A - Context-dependent script system tag (only for Non-Latin scripts)
+    - B - Context-dependent language system tag
+    - C - Context-dependent feature tag
+    - D - Class description string
+- When a class is used by several scripts, list all scripts in the name
+- When a class is used by several languages, list all languages in the name
+- When a class is used in several features, list all feature tags in its name
+- Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the class definition, to explain which scripts/languages/features are concerned
+
+#### Kerning group names
+
+- All names should be lowercase, separated by underscores, except for the string that refers to glyph names. E.g. `Omega` should stay as is if it refers to the upper case glyph name
+- Kerning groups should contain the name of the script they pertain to. This avoids name clashes. The format is script_key_glyph_or_description
+
+#### Adobe feature code lookup names
+
+- Adobe feature code lookup names should use the following format:
+
+- A_B_C_D
+  - A - Context-dependent Script system tag - only for Non-Latin scripts
+  - B - Context-dependent language system tag
+  - C - Feature tag
+  - D - Lookup description string
+- When a lookup is used by several scripts, list all scripts in the name
+- When a lookup is used by several languages, list all languages in the name
+- When a lookup is used in several features, list all feature tags in its name
+- Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the lookup definition, to explain which scripts/languages/features are concerned
+
+### Adobe feature file source
+
+- feature blocks and lookups should be declared separately
+- lookups should have descriptive names and include, where appropriate, the language and feature tag where they are used. Example: `nld_locl_ij_substitution` for a Netherlandish lookup that replaces `i' j'` by `ij`
+- Use four space indentation for source contained in `{` and `}` delimiters
+- do not include empty lines between the opening `{` delimiter and the first line of contained source
+- do not include empty lines between the final line of contained source and the closing `}` delimiter
+
+## Examples
+
+### Glyph name examples
+
+- `amacron`: lower case form has lower case name
+- `Amacron`: upper case form has title case name
+- `f_f_i`: a `ffi` ligature
+- `Ef-cy.loclBGR`: a localized form uses the string `locl` followed by an all caps language tag
+
+### OpenType class name examples
+
+- C: `pnum`
+- C_D: `pnum_currencies`
+- C_D: `frac_precomposed`
+- A_B_C: `cyrl_bgr_locl`
+- A_C_D_D: `grek_calt_marks_context`
+
+### Kerning group name examples
+
+- `grek_Omega`
+- `thai_phoSamphao`
+- `armn_uc_topround_bottomstraight`
+
+### Adobe feature code lookup name examples
+
+- B_C_D_D: `rom_locl_cedilla_substitution`
+- A_C_D_D: `grek_ccmp_recompose_dieresistonos`
+- A_B_C_D: `cyrl_bgr_locl_alternates`
+- C_D: `frac_precomposed`
+  
+### Adobe feature file examples
+
+```fea
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+languagesystem latn NLD;
+
+@pnum_fig_dflt = [zero one two three four five six seven eight nine];
+@pnum_fig_alt = [zero.alt one.alt two.alt three.alt four.alt five.alt six.alt seven.alt eight.alt nine.alt];
+
+lookup pnum_text {
+    sub @fig_dflt by @fig_alt;
+} pnum_text;
+
+lookup nld_locl_ij_substitution {
+    sub i' j' by ij;
+    sub I' J' by IJ;
+} nld_locl_ij_substitution;
+
+feature pnum {
+    lookup pnum_text;
+} pnum;
+
+feature locl {
+    script latn;
+    language NLD;
+    lookup nld_locl_ij_substitution;
+} locl;
+```

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -30,6 +30,10 @@ This document details the source style guidelines for the Google Sans project.
 - In scripts that support upper case forms, please use title case glyph names for upper case glyph forms
 - Please do not change glyph names after they have been imported into the upstream source files
 
+Notes:
+- If your script, such as Burmese, already has conventions for localized forms in `glyphsData.xml`, then prefer the existing conventions.
+- If your script behaves in such a way that it's impractical to list all languages after the `.locl` suffix of the glyph name, then you don't have to list all the languages there; instead please use only `.locl` as a suffix and write a comment somewhere to explain which languages are concerned.
+
 #### OpenType class names
 
 - OpenType class naming should use the following format:
@@ -41,7 +45,7 @@ This document details the source style guidelines for the Google Sans project.
 - When a class is used by several scripts, list all scripts in the name
 - When a class is used by several languages, list all languages in the name
 - When a class is used in several features, list all feature tags in its name
-- Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the class definition, to explain which scripts/languages/features are concerned
+- Except if listing everything is too cumbersome and counterproductive, then drop that part of the name but leave a comment instead, just above the class definition, to explain which scripts/languages/features are concerned
 
 #### Kerning group names
 
@@ -60,7 +64,7 @@ This document details the source style guidelines for the Google Sans project.
 - When a lookup is used by several scripts, list all scripts in the name
 - When a lookup is used by several languages, list all languages in the name
 - When a lookup is used in several features, list all feature tags in its name
-- Except if listing everything is too cumbersome and counterproductive, then drop that part of name but leave a comment instead, just above the lookup definition, to explain which scripts/languages/features are concerned
+- Except if listing everything is too cumbersome and counterproductive, then drop that part of the name but leave a comment instead, just above the lookup definition, to explain which scripts/languages/features are concerned
 
 ### Adobe OpenType feature file source
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -1,0 +1,63 @@
+# Google Sans Vendor Documentation
+
+ These docs summarize how vendors contribute changes to the Google Sans project.  Detailed [maintainer documentation](MAINTAINER.md) is available if you would like to review additional details about build dependency installation, virtual environment management, and the fontmake compiler based build approach.
+
+## Source Format
+
+The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs or UFO formatted source files.  Scripts are provided to facilitate transformations between glyphs and UFO source file formats.
+
+## UFO Source Conventions
+
+The font sources we receive from vendors are scrubbed with custom scripts and stored as Designspaces and UFOs. The primary objective of the upstream UFO sources is to build the production fonts and serve as a base for vendors to split off from to make project changes.
+
+Specifically, the sources are normalized to be formatted in the way ufoLib formats sources and contain only:
+
+* Foreground, intermediate (brace) and conditional (bracket) glyphs, no draft or background layers
+  * whose metadata (lib keys) contains only semantically relevant data like Glyphs.app's metrics keys, but not color marks.
+* Groups and kerning
+* Manually merged and arranged features
+* Manually maintained font info data
+* Automatically managed UFO [lib.plist files](https://unifiedfontobject.org/versions/ufo3/lib.plist/), that contain:
+  * `public.glyphOrder` for determining the order of glyphs in the final fonts
+  * `public.postscriptNames` for determining the production glyph names in the final fonts
+  * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+  * `com.github.googlei18n.ufo2ft.filters` for listing filters and their options for compile-time font processing
+    * `propagateAnchors`: inherits anchors of base glyphs to their composites automatically to help with building the `mark` and `mkmk` features.
+  * `com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check` for telling Glyphs.app to always run compatibility checks, not relevant for the build
+  * `com.schriftgestaltung.customParameter.GSFont.disablesLastChange` for telling Glyphs.app to not put "last changed" markers into glyphs, which we don't need in the UFO format
+  * `com.schriftgestaltung.fontMasterID` for making it easier to match vendor Glyphs.app files to be imported to the target UFOs
+* Automatically managed UFO layer [layerinfo.plist files](https://unifiedfontobject.org/versions/ufo3/glyphs/layerinfo.plist/), that contain:
+  * `com.schriftgestaltung.layerId` for hopefully helping exchange with Glyphs.app.
+* Manually managed Designspace `<rules>` for describing conditional (bracket) glyphs
+* Automatically managed Designspace instance and global libs, that contain:
+  * Instances:
+    * `com.schriftgestaltung.customParameters` for carrying build-relevant metadata like PANOSE values
+  * Global:
+    * `GSDimensionPlugin.Dimensions` for storing Glyphs.app's metadata for stem thicknesses
+    * `com.github.googlei18n.ufo2ft.featureWriters` for build-relevant options on how to generate OpenType layout data
+    * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+
+## Font Format
+
+We compile to OpenType variable and static instance fonts with quadratic outlines (*.ttf).
+
+## Hinting
+
+We do not use TrueType instruction sets.
+
+## Requirements for Vendors
+
+We ask the following from vendors who contribute to the Google Sans project:
+
+* Follow type design conventions
+* Use a required directory and file path structure
+* Name glyphs, glyph classes, kerning groups, and lookups with the required format
+* Develop and submit test documentation that allows us to perform initial and regression testing of shaping, new feature code, and feature code changes that are included in your updates
+
+## Contributing to the Google Sans Project
+
+### How to Submit Updates
+
+1. Open a new issue with the title `[YOUR SCRIPT] merge: [OPTIONAL BRIEF DESCRIPTION]` on our [issue tracker](https://github.com/googlefonts/googlesans/issues).
+2. Prepare a zip archive with your source files and associated test strings, documentation, and quality assurance testing tools.
+3. Drag and drop the zip archive into the GitHub issue post that you opened in #1 above

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -4,11 +4,12 @@
 
 ## Source Format
 
-The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs version 2 or UFO version 3 formatted source files.  Scripts are provided to facilitate transformations between glyphs and UFO source file formats.
+The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs format version 2 or UFO format version 3 source files.  Scripts are provided in this repository to facilitate transformations between glyphs and UFO source file formats.
 
 ## UFO Source Conventions
 
-The font sources we receive from vendors are scrubbed with custom scripts and stored as Designspaces and UFOs. The primary objective of the upstream UFO sources is to build the production fonts and serve as a base for vendors to split off from to make project changes.
+The font sources that we receive from vendors are cleaned with custom scripts and stored as Designspaces and UFOs. The primary objective of the upstream UFO sources is to build the production fonts and serve as a basis for future updates.
+
 <details>
 <summary><strong>Source Normalization Details (click to open)</strong></summary>
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -1,46 +1,16 @@
 # Google Sans Vendor Documentation
 
- These docs summarize how vendors contribute changes to the Google Sans project.  Detailed [maintainer documentation](MAINTAINER.md) is available if you would like to review additional details about build dependency installation, virtual environment management, and the fontmake compiler based build approach for local font testing.
+This document summarizes how vendors contribute changes to the Google Sans project.  Detailed [maintainer documentation](MAINTAINER.md) is available if you would like to review additional details about build dependency installation, virtual environment management, and the fontmake compiler based build approach.
 
 ## Source Format
 
-The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs format version 2 or UFO format version 3 source files.  Scripts are provided in this repository to facilitate transformations between glyphs and UFO source file formats.
+The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs format version 2 or UFO format version 3 source files. Scripts are provided in this repository to facilitate transformations between glyphs and UFO source file formats.
 
 ## UFO Source Conventions
 
-The font sources that we receive from vendors are cleaned with custom scripts and stored as Designspaces and UFOs. The primary objective of the upstream UFO sources is to build the production fonts and serve as a basis for future updates.
+The font sources that we receive from vendors are cleaned with custom scripts and stored as Designspaces and UFOs to create our production source files. The primary objective of the upstream UFO sources is to build the production fonts and serve as a basis for future development of the type software.
 
-<details>
-<summary><strong>Source Normalization Details (click to open)</strong></summary>
-
-The sources are normalized to be formatted in the way [fontTools.ufoLib](https://fonttools.readthedocs.io/en/latest/ufoLib/) formats sources and contain only:
-
-* Foreground, intermediate (brace) and conditional (bracket) glyphs, no draft or background layers
-  * whose metadata (lib keys) contains only semantically relevant data like Glyphs.app's metrics keys, but not color marks.
-* Groups and kerning
-* Manually merged and arranged features
-* Manually maintained font info data
-* Automatically managed UFO [lib.plist files](https://unifiedfontobject.org/versions/ufo3/lib.plist/), that contain:
-  * `public.glyphOrder` for determining the order of glyphs in the final fonts
-  * `public.postscriptNames` for determining the production glyph names in the final fonts
-  * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
-  * `com.github.googlei18n.ufo2ft.filters` for listing filters and their options for compile-time font processing
-    * `propagateAnchors`: inherits anchors of base glyphs to their composites automatically to help with building the `mark` and `mkmk` features.
-  * `com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check` for telling Glyphs.app to always run compatibility checks, not relevant for the build
-  * `com.schriftgestaltung.customParameter.GSFont.disablesLastChange` for telling Glyphs.app to not put "last changed" markers into glyphs, which we don't need in the UFO format
-  * `com.schriftgestaltung.fontMasterID` for making it easier to match vendor Glyphs.app files to be imported to the target UFOs
-* Automatically managed UFO layer [layerinfo.plist files](https://unifiedfontobject.org/versions/ufo3/glyphs/layerinfo.plist/), that contain:
-  * `com.schriftgestaltung.layerId` for hopefully helping exchange with Glyphs.app.
-* Manually managed Designspace `<rules>` for describing conditional (bracket) glyphs
-* Automatically managed Designspace instance and global libs, that contain:
-  * Instances:
-    * `com.schriftgestaltung.customParameters` for carrying build-relevant metadata like PANOSE values
-  * Global:
-    * `GSDimensionPlugin.Dimensions` for storing Glyphs.app's metadata for stem thicknesses
-    * `com.github.googlei18n.ufo2ft.featureWriters` for build-relevant options on how to generate OpenType layout data
-    * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
-
-</details>
+Please refer to the [Source Normalization Details section of the MAINTAINER.md document](MAINTAINER.md#source-conventions) for additional information about the source normalization process.
 
 ## Font Format
 
@@ -49,6 +19,10 @@ We compile to OpenType variable and static instance fonts with quadratic outline
 ## Hinting
 
 We do not use TrueType instruction sets.
+
+## Style
+
+Please refer to [STYLE.md](STYLE.md) for source style guidelines.  The document includes information on how to format your source files in order to contribute to this project.
 
 ## Requirements for Vendors
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -4,7 +4,7 @@
 
 ## Source Format
 
-The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs or UFO formatted source files.  Scripts are provided to facilitate transformations between glyphs and UFO source file formats.
+The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org/) (UFO) version 3 formatted source files to build production fonts. Vendors may develop in glyphs version 2 or UFO version 3 formatted source files.  Scripts are provided to facilitate transformations between glyphs and UFO source file formats.
 
 ## UFO Source Conventions
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -1,6 +1,6 @@
 # Google Sans Vendor Documentation
 
- These docs summarize how vendors contribute changes to the Google Sans project.  Detailed [maintainer documentation](MAINTAINER.md) is available if you would like to review additional details about build dependency installation, virtual environment management, and the fontmake compiler based build approach.
+ These docs summarize how vendors contribute changes to the Google Sans project.  Detailed [maintainer documentation](MAINTAINER.md) is available if you would like to review additional details about build dependency installation, virtual environment management, and the fontmake compiler based build approach for local font testing.
 
 ## Source Format
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -9,8 +9,10 @@ The Google Sans project uses [Unified Font Object](https://unifiedfontobject.org
 ## UFO Source Conventions
 
 The font sources we receive from vendors are scrubbed with custom scripts and stored as Designspaces and UFOs. The primary objective of the upstream UFO sources is to build the production fonts and serve as a base for vendors to split off from to make project changes.
+<details>
+<summary><strong>Source Normalization Details (click to open)</strong></summary>
 
-Specifically, the sources are normalized to be formatted in the way ufoLib formats sources and contain only:
+The sources are normalized to be formatted in the way [fontTools.ufoLib](https://fonttools.readthedocs.io/en/latest/ufoLib/) formats sources and contain only:
 
 * Foreground, intermediate (brace) and conditional (bracket) glyphs, no draft or background layers
   * whose metadata (lib keys) contains only semantically relevant data like Glyphs.app's metrics keys, but not color marks.
@@ -36,6 +38,8 @@ Specifically, the sources are normalized to be formatted in the way ufoLib forma
     * `GSDimensionPlugin.Dimensions` for storing Glyphs.app's metadata for stem thicknesses
     * `com.github.googlei18n.ufo2ft.featureWriters` for build-relevant options on how to generate OpenType layout data
     * `public.skipExportGlyphs` for listing glyph names that should not be exported to the final fonts
+
+</details>
 
 ## Font Format
 

--- a/docs/VENDOR.md
+++ b/docs/VENDOR.md
@@ -35,6 +35,20 @@ We ask the following from vendors who contribute to the Google Sans project:
 
 ## Contributing to the Google Sans Project
 
+### Generating Glpyhs.app Source Files
+
+If you work in Glyphs.app and want to generate sources for modification, skip using Glyphs.app's built-in im- and exporter functionality. Instead, run:
+
+```
+$ python3 scripts/gs-ufo2glyphs.py source/GoogleSans/GoogleSans.designspace
+
+$ python3 scripts/gs-ufo2glyphs.py source/GoogleSans/GoogleSans-Italic.designspace
+```
+
+It's best to rename the files to include the script you're working on, e.g. "GoogleSans_Devanagari.glyphs".
+
+You can post those source files directly to us, no back-conversion necessary, see below.
+
 ### How to Submit Updates
 
 1. Open a new issue with the title `[YOUR SCRIPT] merge: [OPTIONAL BRIEF DESCRIPTION]` on our [issue tracker](https://github.com/googlefonts/googlesans/issues).

--- a/scripts/gs-print-kerning-groups.py
+++ b/scripts/gs-print-kerning-groups.py
@@ -21,12 +21,16 @@ the base sources.
 """
 
 import argparse
+from pathlib import Path
 
 import glyphsLib
 import glyphsLib.builder
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input", type=glyphsLib.GSFont, help="Path to source .glyphs file.")
+parser.add_argument(
+    "--glyphs-list", type=Path, help="Only list groups with glyphs listed in this file."
+)
 parsed_args = parser.parse_args()
 
 builder = glyphsLib.builder.UFOBuilder(
@@ -39,4 +43,12 @@ builder = glyphsLib.builder.UFOBuilder(
 
 first_master = next(builder.masters)
 
-print("\n".join(sorted(first_master.groups)))
+if parsed_args.glyphs_list is not None:
+    import_glyphs = {
+        name.strip() for name in parsed_args.glyphs_list.read_text().split("\n") if name
+    }
+    for name, glyphs in sorted(first_master.groups.items()):
+        if any(g in import_glyphs for g in glyphs):
+            print(name)
+else:
+    print("\n".join(sorted(first_master.groups)))


### PR DESCRIPTION
Adds vendor docs (`docs/VENDOR.md`) on how to contribute to the project with the new UFO source format and contribution workflow added in #105 