### PR TITLE
Flatten components

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -43,8 +43,6 @@ excluded_check_ids = (
     "com.google.fonts/check/varfont/regular_opsz_coord",  # we do want our opsz definition
     # "com.google.fonts/check/os2_metrics_match_hhea",
     # "com.google.fonts/check/unwanted_tables",
-    # https://github.com/googlefonts/googlesans/issues/108:
-    "com.google.fonts/check/glyf_nested_components",
 )
 
 ATTRIBUTES = {

--- a/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
@@ -2487,7 +2487,6 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni0326.BRACKET.18

--- a/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
@@ -2487,7 +2487,6 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni0326.BRACKET.18

--- a/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
@@ -2487,7 +2487,6 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni0326.BRACKET.18

--- a/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
@@ -2487,6 +2487,5 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo

--- a/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
@@ -2487,6 +2487,5 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo

--- a/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
@@ -2487,6 +2487,5 @@ Gsuper
 Googlelogo
 uniE007
 brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo

--- a/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
@@ -2342,8 +2342,6 @@ elogo
 Gsuper
 Googlelogo
 uniE007
-brevecombcy.sc
-brevecombcy.cap
 brevecombcy
 Google.logo
 uni05F0

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -131,17 +131,10 @@ def scrub_ufo(ufo: ufoLib2.Font, skip_export_glyphs: Set[str]) -> None:
             ],
         },
         # Remove component nesting to work around broken TrueType rasterizers:
-        # https://github.com/googlefonts/googlesans/issues/108. First, decompose
-        # glyphs with mixed contours and components, because what to do
-        # with them is poorly defined for ufo2ft's flattenComponents filter.
-        {
-            "name": "decomposeComponents",
-            "pre": True,
-            "include": [
-                glyph.name for glyph in ufo if glyph.contours and glyph.components
-            ],
-        },
-        {"name": "flattenComponents", "pre": True},
+        # https://github.com/googlefonts/googlesans/issues/108. Flatten after
+        # decomposition, because what to do with mixed outline/component glyphs
+        # is poorly defined for ufo2ft's flattenComponents filter.
+        {"name": "flattenComponents", "pre": False},
     ]
 
     # Delete non-build-relevant layers.

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -130,7 +130,17 @@ def scrub_ufo(ufo: ufoLib2.Font, skip_export_glyphs: Set[str]) -> None:
                 "ytilde.BRACKET.18",
             ],
         },
-        # https://github.com/googlefonts/googlesans/issues/108
+        # Remove component nesting to work around broken TrueType rasterizers:
+        # https://github.com/googlefonts/googlesans/issues/108. First, decompose
+        # glyphs with mixed contours and components, because what to do
+        # with them is poorly defined for ufo2ft's flattenComponents filter.
+        {
+            "name": "decomposeComponents",
+            "pre": True,
+            "include": [
+                glyph.name for glyph in ufo if glyph.contours and glyph.components
+            ],
+        },
         {"name": "flattenComponents", "pre": True},
     ]
 

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -130,8 +130,8 @@ def scrub_ufo(ufo: ufoLib2.Font, skip_export_glyphs: Set[str]) -> None:
                 "ytilde.BRACKET.18",
             ],
         },
-        # Uncomment after attaining parity between Glyphs file and DS compilation.
-        # {"name": "flattenComponents", "pre": True},
+        # https://github.com/googlefonts/googlesans/issues/108
+        {"name": "flattenComponents", "pre": True},
     ]
 
     # Delete non-build-relevant layers.

--- a/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
@@ -47,74 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Yi-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aogonek.sc</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>eight.sansSerifCircled</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>eltail-cy.sc</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>five.sansSerifCircled</string>
-          <string>four.sansSerifCircled</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hadescender-cy.sc</string>
-          <string>hbar.sc</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>nine.sansSerifCircled</string>
-          <string>one.sansSerifCircled</string>
-          <string>oslash.sc</string>
-          <string>questiongreek.BRACKET.18</string>
-          <string>semicolon</string>
-          <string>semicolon.BRACKET.18</string>
-          <string>seven.sansSerifCircled</string>
-          <string>six.sansSerifCircled</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>tcedilla</string>
-          <string>three.sansSerifCircled</string>
-          <string>two.sansSerifCircled</string>
-          <string>yi-cy</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
@@ -47,6 +47,70 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Yi-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aogonek.sc</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>eight.sansSerifCircled</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>eltail-cy.sc</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>five.sansSerifCircled</string>
+          <string>four.sansSerifCircled</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hadescender-cy.sc</string>
+          <string>hbar.sc</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>nine.sansSerifCircled</string>
+          <string>one.sansSerifCircled</string>
+          <string>oslash.sc</string>
+          <string>questiongreek.BRACKET.18</string>
+          <string>semicolon</string>
+          <string>semicolon.BRACKET.18</string>
+          <string>seven.sansSerifCircled</string>
+          <string>six.sansSerifCircled</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>tcedilla</string>
+          <string>three.sansSerifCircled</string>
+          <string>two.sansSerifCircled</string>
+          <string>yi-cy</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
@@ -47,6 +47,58 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Aringacute</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Emtail-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Idieresis</string>
+          <string>Iishorttail-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hbar.sc</string>
+          <string>idieresis</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>oslash.sc</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>theta.sc</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
@@ -47,62 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Aringacute</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Emtail-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Idieresis</string>
-          <string>Iishorttail-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hbar.sc</string>
-          <string>idieresis</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>oslash.sc</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>theta.sc</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
@@ -47,6 +47,58 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Aringacute</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Emtail-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Idieresis</string>
+          <string>Iishorttail-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hbar.sc</string>
+          <string>idieresis</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>oslash.sc</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>theta.sc</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
@@ -47,62 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Aringacute</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Emtail-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Idieresis</string>
-          <string>Iishorttail-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hbar.sc</string>
-          <string>idieresis</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>oslash.sc</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>theta.sc</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
@@ -47,74 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Yi-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aogonek.sc</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>eight.sansSerifCircled</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>eltail-cy.sc</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>five.sansSerifCircled</string>
-          <string>four.sansSerifCircled</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hadescender-cy.sc</string>
-          <string>hbar.sc</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>nine.sansSerifCircled</string>
-          <string>one.sansSerifCircled</string>
-          <string>oslash.sc</string>
-          <string>questiongreek.BRACKET.18</string>
-          <string>semicolon</string>
-          <string>semicolon.BRACKET.18</string>
-          <string>seven.sansSerifCircled</string>
-          <string>six.sansSerifCircled</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>tcedilla</string>
-          <string>three.sansSerifCircled</string>
-          <string>two.sansSerifCircled</string>
-          <string>yi-cy</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
@@ -47,6 +47,70 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Yi-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aogonek.sc</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>eight.sansSerifCircled</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>eltail-cy.sc</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>five.sansSerifCircled</string>
+          <string>four.sansSerifCircled</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hadescender-cy.sc</string>
+          <string>hbar.sc</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>nine.sansSerifCircled</string>
+          <string>one.sansSerifCircled</string>
+          <string>oslash.sc</string>
+          <string>questiongreek.BRACKET.18</string>
+          <string>semicolon</string>
+          <string>semicolon.BRACKET.18</string>
+          <string>seven.sansSerifCircled</string>
+          <string>six.sansSerifCircled</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>tcedilla</string>
+          <string>three.sansSerifCircled</string>
+          <string>two.sansSerifCircled</string>
+          <string>yi-cy</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
@@ -47,74 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Yi-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aogonek.sc</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>eight.sansSerifCircled</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>eltail-cy.sc</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>five.sansSerifCircled</string>
-          <string>four.sansSerifCircled</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hadescender-cy.sc</string>
-          <string>hbar.sc</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>nine.sansSerifCircled</string>
-          <string>one.sansSerifCircled</string>
-          <string>oslash.sc</string>
-          <string>questiongreek.BRACKET.18</string>
-          <string>semicolon</string>
-          <string>semicolon.BRACKET.18</string>
-          <string>seven.sansSerifCircled</string>
-          <string>six.sansSerifCircled</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>tcedilla</string>
-          <string>three.sansSerifCircled</string>
-          <string>two.sansSerifCircled</string>
-          <string>yi-cy</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
@@ -47,6 +47,70 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Yi-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aogonek.sc</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>eight.sansSerifCircled</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>eltail-cy.sc</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>five.sansSerifCircled</string>
+          <string>four.sansSerifCircled</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hadescender-cy.sc</string>
+          <string>hbar.sc</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>nine.sansSerifCircled</string>
+          <string>one.sansSerifCircled</string>
+          <string>oslash.sc</string>
+          <string>questiongreek.BRACKET.18</string>
+          <string>semicolon</string>
+          <string>semicolon.BRACKET.18</string>
+          <string>seven.sansSerifCircled</string>
+          <string>six.sansSerifCircled</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>tcedilla</string>
+          <string>three.sansSerifCircled</string>
+          <string>two.sansSerifCircled</string>
+          <string>yi-cy</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
@@ -47,6 +47,58 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Aringacute</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Emtail-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Idieresis</string>
+          <string>Iishorttail-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hbar.sc</string>
+          <string>idieresis</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>oslash.sc</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>theta.sc</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
@@ -47,62 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Aringacute</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Emtail-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Idieresis</string>
-          <string>Iishorttail-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hbar.sc</string>
-          <string>idieresis</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>oslash.sc</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>theta.sc</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
@@ -47,6 +47,58 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Aringacute</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Emtail-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Idieresis</string>
+          <string>Iishorttail-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hbar.sc</string>
+          <string>idieresis</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>oslash.sc</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>theta.sc</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
@@ -47,62 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Aringacute</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Emtail-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Idieresis</string>
-          <string>Iishorttail-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hbar.sc</string>
-          <string>idieresis</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>oslash.sc</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>theta.sc</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
@@ -47,74 +47,10 @@
         <true/>
       </dict>
       <dict>
-        <key>include</key>
-        <array>
-          <string>Aring</string>
-          <string>Chedescenderabkhasian-cy</string>
-          <string>Esdescender-cy</string>
-          <string>Hadescender-cy</string>
-          <string>Imacron</string>
-          <string>Kadescender-cy</string>
-          <string>Obarred-cy</string>
-          <string>Shhadescender-cy</string>
-          <string>Yi-cy</string>
-          <string>Zedescender-cy</string>
-          <string>Zhedescender-cy</string>
-          <string>aogonek.sc</string>
-          <string>aring.sc</string>
-          <string>aringacute</string>
-          <string>aringacute.alt</string>
-          <string>centigrade</string>
-          <string>chedescender-cy.sc</string>
-          <string>chedescenderabkhasian-cy</string>
-          <string>chedescenderabkhasian-cy.sc</string>
-          <string>eight.sansSerifCircled</string>
-          <string>elhook-cy</string>
-          <string>eltail-cy</string>
-          <string>eltail-cy.sc</string>
-          <string>ertick-cy</string>
-          <string>esdescender-cy</string>
-          <string>esdescender-cy.sc</string>
-          <string>eth.sc</string>
-          <string>fahrenheit</string>
-          <string>five.sansSerifCircled</string>
-          <string>four.sansSerifCircled</string>
-          <string>gestrokehook-cy</string>
-          <string>hadescender-cy</string>
-          <string>hadescender-cy.sc</string>
-          <string>hbar.sc</string>
-          <string>iishorttail-cy</string>
-          <string>kadescender-cy</string>
-          <string>lslash.sc</string>
-          <string>nine.sansSerifCircled</string>
-          <string>one.sansSerifCircled</string>
-          <string>oslash.sc</string>
-          <string>questiongreek.BRACKET.18</string>
-          <string>semicolon</string>
-          <string>semicolon.BRACKET.18</string>
-          <string>seven.sansSerifCircled</string>
-          <string>six.sansSerifCircled</string>
-          <string>tbar.sc</string>
-          <string>tcaron</string>
-          <string>tcaron.alt</string>
-          <string>tcedilla</string>
-          <string>three.sansSerifCircled</string>
-          <string>two.sansSerifCircled</string>
-          <string>yi-cy</string>
-          <string>zedescender-cy</string>
-          <string>zedescender-cy.sc</string>
-          <string>zhedescender-cy</string>
-        </array>
-        <key>name</key>
-        <string>decomposeComponents</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>
-        <true/>
+        <false/>
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
@@ -46,6 +46,12 @@
         <key>pre</key>
         <true/>
       </dict>
+      <dict>
+        <key>name</key>
+        <string>flattenComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check</key>
     <integer>1</integer>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
@@ -47,6 +47,70 @@
         <true/>
       </dict>
       <dict>
+        <key>include</key>
+        <array>
+          <string>Aring</string>
+          <string>Chedescenderabkhasian-cy</string>
+          <string>Esdescender-cy</string>
+          <string>Hadescender-cy</string>
+          <string>Imacron</string>
+          <string>Kadescender-cy</string>
+          <string>Obarred-cy</string>
+          <string>Shhadescender-cy</string>
+          <string>Yi-cy</string>
+          <string>Zedescender-cy</string>
+          <string>Zhedescender-cy</string>
+          <string>aogonek.sc</string>
+          <string>aring.sc</string>
+          <string>aringacute</string>
+          <string>aringacute.alt</string>
+          <string>centigrade</string>
+          <string>chedescender-cy.sc</string>
+          <string>chedescenderabkhasian-cy</string>
+          <string>chedescenderabkhasian-cy.sc</string>
+          <string>eight.sansSerifCircled</string>
+          <string>elhook-cy</string>
+          <string>eltail-cy</string>
+          <string>eltail-cy.sc</string>
+          <string>ertick-cy</string>
+          <string>esdescender-cy</string>
+          <string>esdescender-cy.sc</string>
+          <string>eth.sc</string>
+          <string>fahrenheit</string>
+          <string>five.sansSerifCircled</string>
+          <string>four.sansSerifCircled</string>
+          <string>gestrokehook-cy</string>
+          <string>hadescender-cy</string>
+          <string>hadescender-cy.sc</string>
+          <string>hbar.sc</string>
+          <string>iishorttail-cy</string>
+          <string>kadescender-cy</string>
+          <string>lslash.sc</string>
+          <string>nine.sansSerifCircled</string>
+          <string>one.sansSerifCircled</string>
+          <string>oslash.sc</string>
+          <string>questiongreek.BRACKET.18</string>
+          <string>semicolon</string>
+          <string>semicolon.BRACKET.18</string>
+          <string>seven.sansSerifCircled</string>
+          <string>six.sansSerifCircled</string>
+          <string>tbar.sc</string>
+          <string>tcaron</string>
+          <string>tcaron.alt</string>
+          <string>tcedilla</string>
+          <string>three.sansSerifCircled</string>
+          <string>two.sansSerifCircled</string>
+          <string>yi-cy</string>
+          <string>zedescender-cy</string>
+          <string>zedescender-cy.sc</string>
+          <string>zhedescender-cy</string>
+        </array>
+        <key>name</key>
+        <string>decomposeComponents</string>
+        <key>pre</key>
+        <true/>
+      </dict>
+      <dict>
         <key>name</key>
         <string>flattenComponents</string>
         <key>pre</key>


### PR DESCRIPTION
Closes https://github.com/googlefonts/googlesans/issues/116
Closes https://github.com/googlefonts/googlesans/issues/108


---

@chrissimpkins edits below:

### TODO

- [x] calculate file size change in the production character set with these updates (https://github.com/googlefonts/googlesans/pull/124#issuecomment-761581545)
- [x] review and address inappropriate component edits initially documented in https://github.com/googlefonts/googlesans/pull/124#issuecomment-761576389 across all styles / build formats
- [x] review glyph order change after component flattening, why is this different across styles?
- [ ] further review and discuss glyph delta issue in https://github.com/googlefonts/googlesans/pull/124#issuecomment-763246768
- [ ] discuss mark delta issue in https://github.com/googlefonts/googlesans/pull/124#issuecomment-763246768 and https://github.com/googlefonts/googlesans/pull/124#issuecomment-763252993