### PR TITLE
Eliminate generate-glyphs-file.yml runs on master branch pushes

### DIFF
--- a/.github/workflows/generate-glyphs-file.yml
+++ b/.github/workflows/generate-glyphs-file.yml
@@ -2,42 +2,41 @@ name: Generate Glyphs.app File
 
 on:
   push:
-    # Sequence of patterns matched against refs/heads 
-    branches: 
-      - master # Push events on master branch 
-      - "build/**" # Push events to branches matching refs/heads/build/[ANYTHING] 
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - "build/**" # Push events to branches matching refs/heads/build/[ANYTHING]
       - "build-*" # Push events to branches matching refs/heads/build-[ANYTHING]
 
 jobs:
   build-glyphs:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out ${{ steps.config.outputs.projectname }} source repository
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Python build dependency cache lookup
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        # Check for requirements file cache hit
-        key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
-    - name: Install Python build dependencies
-      uses: py-actions/py-dependency-install@v2
-      with:
-        update-wheel: "true"
-        update-setuptools: "true"
-    - name: Generate Glyphs.app file
-      run: make gs-ufo2glyphs
-    - uses: actions/upload-artifact@v2
-      with:	
-        name: 'Glyphs.app upright file'	
-        path: 'source/GoogleSans/GoogleSans.glyphs'
-        retention-days: 1
-    - uses: actions/upload-artifact@v2
-      with:	
-        name: 'Glyphs.app italic file'	
-        path: 'source/GoogleSans/GoogleSans-Italic.glyphs'
-        retention-days: 1
+      - name: Check out ${{ steps.config.outputs.projectname }} source repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Python build dependency cache lookup
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          # Check for requirements file cache hit
+          key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
+      - name: Install Python build dependencies
+        uses: py-actions/py-dependency-install@v2
+        with:
+          update-wheel: "true"
+          update-setuptools: "true"
+      - name: Generate Glyphs.app file
+        run: make gs-ufo2glyphs
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "Glyphs.app upright file"
+          path: "source/GoogleSans/GoogleSans.glyphs"
+          retention-days: 1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "Glyphs.app italic file"
+          path: "source/GoogleSans/GoogleSans-Italic.glyphs"
+          retention-days: 1


### PR DESCRIPTION
This GH Action workflow builds vendor glyphs formatted source files to fonts.  This *should* be a temporary requirement during merges in non-master branches. We will not typically have vendor glyphs sources in the master branch to require execution and upload of build artifacts.

Closes #123 