### PR TITLE
Hebrew scaled dagesh

### DIFF
--- a/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-Italic[opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic[opsz,wght].ttf.glyphsetdef
@@ -2393,6 +2393,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
@@ -2392,6 +2392,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
@@ -2481,6 +2481,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/qa/definitions/GoogleSans[opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans[opsz,wght].ttf.glyphsetdef
@@ -2482,6 +2482,7 @@ uni05B9
 uni05BA
 uni05BB
 uni05BC
+uni05BC.alt
 uni05BD
 uni05BF
 uni05C2

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/contents.plist
@@ -1774,6 +1774,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="42" y="2" name="_center"/>
+  <outline>
+    <contour>
+      <point x="41" y="-50" type="curve" smooth="yes"/>
+      <point x="71" y="-50"/>
+      <point x="93" y="-27"/>
+      <point x="93" y="2" type="curve" smooth="yes"/>
+      <point x="93" y="31"/>
+      <point x="71" y="53"/>
+      <point x="41" y="53" type="curve" smooth="yes"/>
+      <point x="13" y="53"/>
+      <point x="-10" y="31"/>
+      <point x="-10" y="2" type="curve" smooth="yes"/>
+      <point x="-10" y="-27"/>
+      <point x="13" y="-50"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="699"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="313" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="363" yOffset="305"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="305" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="355" yOffset="305"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="667"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="294" yOffset="50"/>
+    <component base="dagesh-hb.alt" xOffset="344" yOffset="301"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="312" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="362" yOffset="305"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="430" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="480" yOffset="249"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="430" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="480" yOffset="249"/>
     <component base="shindot-hb" xOffset="613"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="430" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="480" yOffset="249"/>
     <component base="sindot-hb" xOffset="24" yOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Bold.ufo/lib.plist
@@ -2546,6 +2546,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3689,6 +3690,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/contents.plist
@@ -1770,6 +1770,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="-4" y="2" name="_center"/>
+  <outline>
+    <contour>
+      <point x="-7" y="-50" type="curve" smooth="yes"/>
+      <point x="24" y="-50"/>
+      <point x="47" y="-25"/>
+      <point x="47" y="4" type="curve" smooth="yes"/>
+      <point x="47" y="32"/>
+      <point x="27" y="53"/>
+      <point x="-3" y="53" type="curve" smooth="yes"/>
+      <point x="-30" y="53"/>
+      <point x="-55" y="31"/>
+      <point x="-55" y="-1" type="curve" smooth="yes"/>
+      <point x="-55" y="-29"/>
+      <point x="-34" y="-50"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="699"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="311" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="409" yOffset="305"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="303" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="401" yOffset="305"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="675"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="291" yOffset="50"/>
+    <component base="dagesh-hb.alt" xOffset="389" yOffset="301"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="310" yOffset="54"/>
+    <component base="dagesh-hb.alt" xOffset="408" yOffset="305"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="418" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="516" yOffset="249"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="418" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="516" yOffset="249"/>
     <component base="shindot-hb" xOffset="613"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="418" yOffset="-2"/>
+    <component base="dagesh-hb.alt" xOffset="516" yOffset="249"/>
     <component base="sindot-hb" xOffset="24" yOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-BoldItalic.ufo/lib.plist
@@ -2452,6 +2452,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3682,6 +3683,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/contents.plist
@@ -1770,6 +1770,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="-7" y="18" name="_center"/>
+  <outline>
+    <contour>
+      <point x="-10" y="-27" type="curve" smooth="yes"/>
+      <point x="17" y="-27"/>
+      <point x="38" y="-3"/>
+      <point x="38" y="21" type="curve" smooth="yes"/>
+      <point x="38" y="46"/>
+      <point x="22" y="63"/>
+      <point x="-4" y="63" type="curve" smooth="yes"/>
+      <point x="-29" y="63"/>
+      <point x="-52" y="44"/>
+      <point x="-52" y="17" type="curve" smooth="yes"/>
+      <point x="-52" y="-8"/>
+      <point x="-34" y="-27"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="675"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="330" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="429" yOffset="290"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="325" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="424" yOffset="290"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="646"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="292" yOffset="11"/>
+    <component base="dagesh-hb.alt" xOffset="391" yOffset="278"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="315" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="414" yOffset="290"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="450" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="549" yOffset="290"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="450" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="549" yOffset="290"/>
     <component base="shindot-hb" xOffset="607"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="450" yOffset="23"/>
+    <component base="dagesh-hb.alt" xOffset="549" yOffset="290"/>
     <component base="sindot-hb" xOffset="18" yOffset="-2"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Italic.ufo/lib.plist
@@ -2452,6 +2452,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3682,6 +3683,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/contents.plist
@@ -1774,6 +1774,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="50" y="50" name="_center"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="curve" smooth="yes"/>
+      <point x="79" y="0"/>
+      <point x="100" y="23"/>
+      <point x="100" y="50" type="curve" smooth="yes"/>
+      <point x="100" y="79"/>
+      <point x="79" y="100"/>
+      <point x="50" y="100" type="curve" smooth="yes"/>
+      <point x="23" y="100"/>
+      <point x="0" y="79"/>
+      <point x="0" y="50" type="curve" smooth="yes"/>
+      <point x="0" y="23"/>
+      <point x="23" y="0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="676"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xOffset="323" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="373" yOffset="258"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xOffset="317" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="367" yOffset="258"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="645"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xOffset="286" yOffset="-21"/>
+    <component base="dagesh-hb.alt" xOffset="336" yOffset="246"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xOffset="307" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="357" yOffset="258"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="442" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="492" yOffset="258"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="442" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="492" yOffset="258"/>
     <component base="shindot-hb" xOffset="607"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="442" yOffset="-9"/>
+    <component base="dagesh-hb.alt" xOffset="492" yOffset="258"/>
     <component base="sindot-hb" xOffset="18" yOffset="-2"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-Regular.ufo/lib.plist
@@ -2546,6 +2546,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3689,6 +3690,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/contents.plist
@@ -1774,6 +1774,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="42" y="2" name="_center"/>
+  <outline>
+    <contour>
+      <point x="41" y="-50" type="curve" smooth="yes"/>
+      <point x="71" y="-50"/>
+      <point x="93" y="-27"/>
+      <point x="93" y="2" type="curve" smooth="yes"/>
+      <point x="93" y="31"/>
+      <point x="71" y="53"/>
+      <point x="41" y="53" type="curve" smooth="yes"/>
+      <point x="13" y="53"/>
+      <point x="-10" y="31"/>
+      <point x="-10" y="2" type="curve" smooth="yes"/>
+      <point x="-10" y="-27"/>
+      <point x="13" y="-50"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="712"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="314" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="364" yOffset="315"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="307" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="357" yOffset="315"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="685"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="304" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="354" yOffset="315"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="304" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="354" yOffset="315"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="401" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="451" yOffset="243"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="401" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="451" yOffset="243"/>
     <component base="shindot-hb" xOffset="573"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="401" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="451" yOffset="243"/>
     <component base="sindot-hb" xOffset="33" yOffset="1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBold.ufo/lib.plist
@@ -2546,6 +2546,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3689,6 +3690,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/contents.plist
@@ -1770,6 +1770,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="-3" y="2" name="_center"/>
+  <outline>
+    <contour>
+      <point x="-5" y="-50" type="curve" smooth="yes"/>
+      <point x="24" y="-50"/>
+      <point x="47" y="-25"/>
+      <point x="47" y="5" type="curve" smooth="yes"/>
+      <point x="47" y="32"/>
+      <point x="27" y="53"/>
+      <point x="-2" y="53" type="curve" smooth="yes"/>
+      <point x="-29" y="53"/>
+      <point x="-54" y="30"/>
+      <point x="-54" y="-1" type="curve" smooth="yes"/>
+      <point x="-54" y="-29"/>
+      <point x="-34" y="-50"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="712"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="314" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="409" yOffset="315"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="307" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="402" yOffset="315"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="690"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="304" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="399" yOffset="315"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="304" yOffset="64"/>
+    <component base="dagesh-hb.alt" xOffset="399" yOffset="315"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="389" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="484" yOffset="243"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="389" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="484" yOffset="243"/>
     <component base="shindot-hb" xOffset="573"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.8" yScale="0.8" xOffset="389" yOffset="-8"/>
+    <component base="dagesh-hb.alt" xOffset="484" yOffset="243"/>
     <component base="sindot-hb" xOffset="34" yOffset="1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextBoldItalic.ufo/lib.plist
@@ -2452,6 +2452,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3682,6 +3683,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/contents.plist
@@ -1770,6 +1770,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="-8" y="18" name="_center"/>
+  <outline>
+    <contour>
+      <point x="-11" y="-27" type="curve" smooth="yes"/>
+      <point x="13" y="-27"/>
+      <point x="37" y="-7"/>
+      <point x="37" y="22" type="curve" smooth="yes"/>
+      <point x="37" y="46"/>
+      <point x="20" y="63"/>
+      <point x="-5" y="63" type="curve" smooth="yes"/>
+      <point x="-30" y="63"/>
+      <point x="-52" y="43"/>
+      <point x="-52" y="15" type="curve" smooth="yes"/>
+      <point x="-52" y="-9"/>
+      <point x="-35" y="-27"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="673"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="325" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="423" yOffset="298"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="315" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="413" yOffset="298"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="679"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="321" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="419" yOffset="298"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="321" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="419" yOffset="298"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="433" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="531" yOffset="298"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="433" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="531" yOffset="298"/>
     <component base="shindot-hb" xOffset="571"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xScale="0.9" yScale="0.9" xOffset="433" yOffset="31"/>
+    <component base="dagesh-hb.alt" xOffset="531" yOffset="298"/>
     <component base="sindot-hb" xOffset="32" yOffset="1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextItalic.ufo/lib.plist
@@ -2452,6 +2452,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3682,6 +3683,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/contents.plist
@@ -1774,6 +1774,8 @@
     <string>d.sc.ss04.glif</string>
     <key>dagesh-hb</key>
     <string>dagesh-hb.glif</string>
+    <key>dagesh-hb.alt</key>
+    <string>dagesh-hb.alt.glif</string>
     <key>dagger</key>
     <string>dagger.glif</string>
     <key>daggerdbl</key>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/dagesh-hb.alt.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/dagesh-hb.alt.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dagesh-hb.alt" format="2">
+  <anchor x="50" y="50" name="_center"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="curve" smooth="yes"/>
+      <point x="79" y="0"/>
+      <point x="100" y="23"/>
+      <point x="100" y="50" type="curve" smooth="yes"/>
+      <point x="100" y="79"/>
+      <point x="79" y="100"/>
+      <point x="50" y="100" type="curve" smooth="yes"/>
+      <point x="23" y="100"/>
+      <point x="0" y="79"/>
+      <point x="0" y="50" type="curve" smooth="yes"/>
+      <point x="0" y="23"/>
+      <point x="23" y="0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/finalpedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="672"/>
   <outline>
     <component base="finalpe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xOffset="314" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="364" yOffset="266"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/finalpedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/finalpedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB43"/>
   <outline>
     <component base="finalpe-hb"/>
-    <component base="dagesh-hb" xOffset="305" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="355" yOffset="266"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/pedagesh-hb.B_R_A_C_K_E_T_.18.glif
@@ -3,7 +3,7 @@
   <advance width="673"/>
   <outline>
     <component base="pe-hb.BRACKET.18"/>
-    <component base="dagesh-hb" xOffset="311" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="361" yOffset="266"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/pedagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/pedagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB44"/>
   <outline>
     <component base="pe-hb"/>
-    <component base="dagesh-hb" xOffset="311" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="361" yOffset="266"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindagesh-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindagesh-hb.glif
@@ -4,6 +4,6 @@
   <unicode hex="FB49"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="423" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="473" yOffset="266"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindageshshindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindageshshindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2C"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="423" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="473" yOffset="266"/>
     <component base="shindot-hb" xOffset="571"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindageshsindot-hb.glif
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/glyphs/shindageshsindot-hb.glif
@@ -4,7 +4,7 @@
   <unicode hex="FB2D"/>
   <outline>
     <component base="shin-hb"/>
-    <component base="dagesh-hb" xOffset="423" yOffset="-1"/>
+    <component base="dagesh-hb.alt" xOffset="473" yOffset="266"/>
     <component base="sindot-hb" xOffset="31" yOffset="1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-TextRegular.ufo/lib.plist
@@ -2546,6 +2546,7 @@
       <string>holamhaser-hb</string>
       <string>qubuts-hb</string>
       <string>dagesh-hb</string>
+      <string>dagesh-hb.alt</string>
       <string>siluqleft-hb</string>
       <string>rafe-hb</string>
       <string>sindot-hb</string>
@@ -3689,6 +3690,8 @@
       <string>uni0312.BRACKET.18</string>
       <key>dagesh-hb</key>
       <string>uni05BC</string>
+      <key>dagesh-hb.alt</key>
+      <string>uni05BC.alt</string>
       <key>dalet-hb</key>
       <string>uni05D3</string>
       <key>daletdagesh-hb</key>


### PR DESCRIPTION
The dagesh dot used in some glyphs has different scaling transformation than the default master in some masters.
This is problematic in variable fonts, since they can only use the scaling transformation from the default master.

- [x] Fix the variable fonts dagesh dot size in pedagesh-hb, pedagesh-hb.BRACKET.18, finalpedagesh-hb, finalpedagesh-hb.BRACKET.18, shindagedh-hb, shindagedhsintdot-hb, shindagedhshindot-hb
  - [x] Add a scaled dagesh-hb.alt with the transformation used in composite glyphs
  - [x] Update composite glyphs
  - [x] Add dagesh-hb.alt to glyhpsetdef

Split from #118 as this doesn't require to update the toolchain requirements.
