### PR TITLE
Add text shaping regression test suite

### DIFF
--- a/.github/workflows/static-artifact-ci.yml
+++ b/.github/workflows/static-artifact-ci.yml
@@ -29,11 +29,11 @@ jobs:
         with:
           python-version: ${{ steps.config.outputs.py-version }}
       - name: Python build dependency cache lookup
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           # Check for requirements file cache hit
-          key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
       - name: Install Python build dependencies
         uses: py-actions/py-dependency-install@v2
         with:

--- a/.github/workflows/static-artifact-ci.yml
+++ b/.github/workflows/static-artifact-ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           update-wheel: "true"
           update-setuptools: "true"
+          path: "requirements-dev.txt"
       - name: Build fonts
         run: ${{ steps.config.outputs.buildcommand }}
       - name: Font Bakery GS profile tests (Expert artifacts)

--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -29,11 +29,11 @@ jobs:
         with:
           python-version: ${{ steps.config.outputs.py-version }}
       - name: Python build dependency cache lookup
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           # Check for requirements file cache hit
-          key: ${{ runner.os }}-pip-${{ hashFiles('${{ steps.config.outputs.dependpath }}') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
       - name: Install Python build dependencies
         uses: py-actions/py-dependency-install@v2
         with:

--- a/.github/workflows/variable-artifact-ci.yml
+++ b/.github/workflows/variable-artifact-ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           update-wheel: "true"
           update-setuptools: "true"
+          path: "requirements-dev.txt"
       - name: Build fonts
         run: ${{ steps.config.outputs.buildcommand }}
       - name: Font Bakery GS profile tests (2-axis Expert)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ setup:
 	mkdir -p "$(VENV_DIR)"
 	python3 -m venv "$(VENV_DIR)"
 	"$(VENV_DIR)/bin/pip" install --upgrade pip wheel setuptools
-	"$(VENV_DIR)/bin/pip" install -r requirements.txt
+	"$(VENV_DIR)/bin/pip" install -r requirements-dev.txt
 	@echo "\n\nDependency versions installed in your venv are:\n"
 	@$(MAKE) list-deps
 	@echo "\n\nBuild fonts with 'make' or make targets for select font builds (see BUILD.md docs)."

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -248,3 +248,48 @@ The same as the [Glyphs.app workflow](#importing-a-glyphsapp-file), except we do
 Relies on testing material provided by vendors. Testing material should serve as a reference for how text should look and how features work. For testing, the vendor provided font is swapped with the merged font; if everything stays the same, the test is considered passed.
 
 ![Quality Assurance Workflow](assets/qa_process.png)
+
+### Adding and Updating Text Shaping Regression Test Files
+
+To ensure adding and changing feature code does not break existing font functionality, text shaping comparisons are run using HarfBuzz.
+
+The directory `qa/shaping/` contains `.json` files of the following format:
+
+```json
+{
+  "input": {
+    // Required, a list of strings to shape.
+    "text": [
+      "GS ĢȘ",
+      "ԵԳԶՋԷԾ,;"
+    ],
+    // Required, a dictionary of features to enable (true) or disable (false).
+    // Can be empty.
+    "features": {
+      "c2sc": true,
+      "ss04": true
+    },
+    // Optional, the ISO 15924 script tag for the text.
+    "script": "armn",
+    // Optional, the BCP 47 language tag for the text.
+    "language": "hy",
+    // Optional, the script direction, one of "ltr", "rtl", "ttb" or "btt".
+    "direction": "ltr",
+    // Optional, the shaping output. Either "full", which includes offsets and
+    // advance widths, or "glyphstream" for just the glyph names.
+    "comparison_mode": "full"
+  },
+  "output": {
+      // Per font file output goes here...
+  }
+}
+```
+
+The files currently have to be created by hand. Give them a descriptive name, ideally prefixed by the script they pertain to. To fill them with the shaping results of a list of fonts, essentially setting their output in stone, run:
+
+```
+$ python3 qa/update_shaping_test_data.py qa/shaping/my_file.json \
+    build/GoogleSans/variable/expert/*.ttf build/GoogleSans/static/expert/*.ttf
+```
+
+The FontBakery QA tests will pick up the file automatically.

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -255,7 +255,7 @@ To ensure adding and changing feature code does not break existing font function
 
 The directory `qa/shaping/` contains `.json` files of the following format:
 
-```json
+```json5
 {
   "input": {
     // Required, a list of strings to shape.

--- a/qa/check-fea.py
+++ b/qa/check-fea.py
@@ -12,10 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import sys
+import textwrap
+from pathlib import Path
 
-from fontbakery.checkrunner import Section, PASS, FAIL
+import uharfbuzz
 from fontbakery.callable import check, condition
+from fontbakery.checkrunner import FAIL, PASS, SKIP, Section
 from fontbakery.fonts_profile import profile_factory
+
+# Make FontBakery able to find the update_shaping_test_data package.
+sys.path.append(str(Path(__file__).parent.parent))
+
+from qa.update_shaping_test_data import (  # noqa: E402
+    ComparisonMode,
+    Direction,
+    shape_texts,
+)
+
 
 profile_imports = ()
 profile = profile_factory(
@@ -27,6 +42,7 @@ GOOGLESANS_PROFILE_CHECKS = [
     "com.google.fonts/check/googlesans/features/staticitalics",
     "com.google.fonts/check/googlesans/features/variableuprights",
     "com.google.fonts/check/googlesans/features/variableitalics",
+    "com.google.fonts/check/googlesans/features/regression",
 ]
 
 STATIC_UPRIGHT_FEA = [
@@ -192,6 +208,13 @@ def is_variable_font(ttFont):
     return "fvar" in ttFont.keys()
 
 
+@condition
+def hb_font(font):
+    with open(font, "rb") as fontfile:
+        hb_face = uharfbuzz.Face(fontfile.read())
+    return hb_face
+
+
 # ================================================
 # Feature support
 # ================================================
@@ -320,6 +343,96 @@ def com_google_fonts_check_googlesans_features_variable_italics(ttFont):
             f"{tt.reader.file.name} does not contain the expected feature tags.\n"
             f"Found:{sorted(fea_tags)}\nExpected:{VAR_ITALICS_FEA}",
         )
+
+
+@check(id="com.google.fonts/check/googlesans/features/regression")
+def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
+    """But does it shape?"""
+    tt = ttFont
+    filename = Path(tt.reader.file.name)
+
+    shaping_basedir = Path("qa", "shaping")
+    for shaping_file in shaping_basedir.glob("*.json"):
+        shaping_input_doc = json.loads(shaping_file.read_text())
+
+        try:
+            shaping_input = shaping_input_doc["input"]
+        except KeyError:
+            yield FAIL, (f"{shaping_file}: Must have an 'input' key dict.")
+            return
+        try:
+            shaping_texts = shaping_input["text"]
+            shaping_features = shaping_input["features"]
+        except KeyError as e:
+            yield FAIL, (f"{shaping_file}: 'input' key dict is missing {str(e)} key.")
+            return
+        shaping_script = shaping_input.get("script")
+        shaping_language = shaping_input.get("language")
+        shaping_comparison_mode = ComparisonMode(
+            shaping_input.get("comparison_mode", "full")
+        )
+        shaping_direction = Direction(shaping_input.get("direction", "ltr"))
+        try:
+            shaping_output = shaping_input_doc["output"]
+        except KeyError:
+            yield FAIL, (f"{shaping_file}: Must have an 'output' key dict.")
+            return
+        try:
+            shaped_texts_expected = shaping_output[filename.name]
+        except KeyError:
+            yield FAIL, f"{shaping_file}: No entry found for {filename.name}"
+            return
+
+        shaped_texts = shape_texts(
+            tt,
+            hb_font,
+            shaping_texts,
+            shaping_script,
+            shaping_language,
+            shaping_direction,
+            shaping_features,
+            shaping_comparison_mode,
+        )
+
+        if shaped_texts == shaped_texts_expected:
+            yield PASS, f"{shaping_file}: No regression detected"
+        else:
+            if "fvar" in tt:
+                assert isinstance(shaped_texts, dict)
+                assert isinstance(shaped_texts_expected, dict)
+
+                for key, shaped_text in shaped_texts.items():
+                    if shaped_text != shaped_texts_expected[key]:
+                        shaped_texts_str = textwrap.indent(
+                            "\n".join(shaped_text), "\t  "
+                        )
+                        shaped_texts_expected_str = textwrap.indent(
+                            "\n".join(shaped_texts_expected[key]), "\t  "
+                        )
+                        yield FAIL, (
+                            f"{shaping_file}: Expected and actual shaping not matching."
+                            f"\n\tExpected for {key}:\n"
+                            f"{shaped_texts_str}"
+                            "\n\tActual:\n"
+                            f"{shaped_texts_expected_str}"
+                        )
+            else:
+                assert isinstance(shaped_texts, list)
+                assert isinstance(shaped_texts_expected, list)
+
+                shaped_texts_str = textwrap.indent("\n".join(shaped_texts), "\t  ")
+                shaped_texts_expected_str = textwrap.indent(
+                    "\n".join(shaped_texts_expected), "\t  "
+                )
+                yield FAIL, (
+                    f"{shaping_file}: Expected and actual shaping not matching."
+                    "\n\tExpected:\n"
+                    f"{shaped_texts_str}"
+                    "\n\tActual:\n"
+                    f"{shaped_texts_expected_str}"
+                )
+    else:
+        yield SKIP, "No test files found."
 
 
 profile.auto_register(globals())

--- a/qa/update_shaping_test_data.py
+++ b/qa/update_shaping_test_data.py
@@ -1,0 +1,174 @@
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Update a regression test file with the shaping output of a list of fonts."""
+
+from __future__ import annotations
+
+import enum
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import uharfbuzz as hb
+from fontTools.ttLib import TTFont
+
+
+class ComparisonMode(enum.Enum):
+    FULL = "full"  # Record glyph names, offsets and advance widths.
+    GLYPHSTREAM = "glyphstream"  # Just glyph names.
+
+
+class Direction(enum.Enum):
+    LTR = "ltr"
+    RTL = "rtl"
+    TTB = "ttb"
+    BTT = "btt"
+
+
+def shape_run(
+    hb_face: hb.Face,
+    text: str,
+    script: Optional[str],
+    language: Optional[str],
+    direction: Direction,
+    features: Dict[str, bool],
+    shaping_comparison_mode: ComparisonMode,
+    variations: Optional[Dict[str, float]] = None,
+) -> str:
+    font = hb.Font(hb_face)
+    if variations is not None:
+        font.set_variations(variations)
+
+    buf = hb.Buffer()
+    buf.add_str(text)
+    if script is not None:
+        buf.script = script
+    buf.direction = direction.value
+    if language is not None:
+        buf.language = language
+    buf.guess_segment_properties()
+    hb.shape(font, buf, features)
+
+    infos = buf.glyph_infos
+    positions = buf.glyph_positions
+
+    if shaping_comparison_mode is ComparisonMode.FULL:
+        out = []
+        for info, pos in zip(infos, positions):
+            s = f"{font.get_glyph_name(info.codepoint)}={info.cluster}"
+            if pos.x_offset or pos.y_offset:
+                s += f"@{pos.x_offset},{pos.y_offset}"
+            if pos.x_advance or pos.y_advance:
+                s += f"+{pos.x_advance},{pos.y_advance}"
+            out.append(s)
+        return "|".join(out)
+    elif shaping_comparison_mode is ComparisonMode.GLYPHSTREAM:
+        return "|".join(font.get_glyph_name(info.codepoint) for info in infos)
+    else:
+        raise ValueError(f"Unknown comparison mode {shaping_comparison_mode}.")
+
+
+def shape_texts(
+    font: TTFont,
+    hb_face: hb.Face,
+    texts: List[str],
+    script: Optional[str],
+    language: Optional[str],
+    direction: Direction,
+    features: Dict[str, bool],
+    shaping_comparison_mode: ComparisonMode,
+) -> Union[Dict[str, List[str]], List[str]]:
+    if "fvar" in font:
+        result = {}
+        for instance in font["fvar"].instances:
+            coordinate_str = ",".join(
+                f"{k}={v}" for k, v in instance.coordinates.items()
+            )
+            result[coordinate_str] = [
+                shape_run(
+                    hb_face,
+                    text,
+                    script,
+                    language,
+                    direction,
+                    features,
+                    shaping_comparison_mode,
+                    instance.coordinates,
+                )
+                for text in texts
+            ]
+        return result
+    else:
+        return [
+            shape_run(
+                hb_face,
+                text,
+                script,
+                language,
+                direction,
+                features,
+                shaping_comparison_mode,
+            )
+            for text in texts
+        ]
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "shaping_file", type=Path, help="The testing .json file to update."
+    )
+    parser.add_argument(
+        "fonts",
+        nargs="+",
+        type=TTFont,
+        help="The fonts to update the testing file with.",
+    )
+    parsed_args = parser.parse_args()
+
+    shaping_file: Path = parsed_args.shaping_file
+    shaping_input_doc = json.loads(shaping_file.read_text())
+    shaping_input = shaping_input_doc["input"]
+    shaping_texts = shaping_input["text"]
+    shaping_features = shaping_input["features"]
+    shaping_script = shaping_input.get("script")
+    shaping_language = shaping_input.get("language")
+    shaping_comparison_mode = ComparisonMode(
+        shaping_input.get("comparison_mode", "full")
+    )
+    shaping_direction = Direction(shaping_input.get("direction", "ltr"))
+
+    if "output" not in shaping_input_doc:
+        shaping_input_doc["output"] = {}
+
+    font: TTFont
+    for font in parsed_args.fonts:
+        filename = Path(font.reader.file.name)
+        with open(filename, "rb") as fontfile:
+            hb_face = hb.Face(fontfile.read())
+        shaping_input_doc["output"][filename.name] = shape_texts(
+            font,
+            hb_face,
+            shaping_texts,
+            shaping_script,
+            shaping_language,
+            shaping_direction,
+            shaping_features,
+            shaping_comparison_mode,
+        )
+
+    shaping_file.write_text(json.dumps(shaping_input_doc, indent=2, ensure_ascii=False))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+uharfbuzz


### PR DESCRIPTION
Split off from https://github.com/googlefonts/googlesans/pull/137. Contains no tests yet.

This is meant to be a good-enough-for-now implementation that should later be streamlined for upstreaming into FontBakery.