### PR TITLE
Add test for frac feature

### DIFF
--- a/qa/shaping/frac.json
+++ b/qa/shaping/frac.json
@@ -1,0 +1,189 @@
+{
+  "input": {
+    "text": [
+      "1/2 1/3 2/3 1/4 3/4 1/8 3/8 5/8 7/8",
+      "1234567890/1234567890123",
+      "11111111111/2222222222222",
+      "0/0/0 00/000/00000 0//0",
+      "2 1/2 222222222222 1/2"
+    ],
+    "features": {
+      "frac": true
+    },
+    "comparison_mode": "glyphstream"
+  },
+  "output": {
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ]
+    },
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+        "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+        "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+        "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+        "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+      ]
+    },
+    "GoogleSansText-Bold.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-Bold.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-Medium.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "one.numerator|fraction|two.denominator|space|one.numerator|fraction|three.denominator|space|two.numerator|fraction|three.denominator|space|one.numerator|fraction|four.denominator|space|three.numerator|fraction|four.denominator|space|one.numerator|fraction|eight.denominator|space|three.numerator|fraction|eight.denominator|space|five.numerator|fraction|eight.denominator|space|seven.numerator|fraction|eight.denominator",
+      "one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator|zero.numerator|fraction|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator|zero.denominator|one.denominator|two.denominator|three.denominator",
+      "one|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|one.numerator|fraction|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator|two.denominator",
+      "zero|slash|zero|slash|zero|space|zero|zero|slash|zero|zero|zero|slash|zero|zero|zero|zero|zero|space|zero|slash|slash|zero",
+      "two|uni2009|one.numerator|fraction|two.denominator|space|two|two|two|two|two|two|two|two|two|two|two|two|uni2009|one.numerator|fraction|two.denominator"
+    ]
+  }
+}


### PR DESCRIPTION
Seems to be based on http://opentypecookbook.com/common-techniques/#method-2-contextual, so I added some basic tests to exercise things mentioned there.

Random find: there's no feature code to turn any fractions into precomposed ones like `seveneighths`.