### PR TITLE
Add harfbuzz shaping regression tests: calt

### DIFF
--- a/qa/shaping/calt.json
+++ b/qa/shaping/calt.json
@@ -1,0 +1,295 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "calt": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "Google_logo google_logo",
+      "google_G google_g",
+      "super_G_logo super_g_logo",
+      "G_logo",
+      "e_logo",
+      "g_logo",
+      "l_logo",
+      "o_logo",
+      "09:30 1:20pm"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "Google.logo|space|Google.logo",
+      "G.logo|space|G.logo",
+      "G.super|space|G.super",
+      "G.logo",
+      "e.logo",
+      "g.logo",
+      "l.logo",
+      "o.logo",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "G.BRACKET.18|o|o|g|l|e.logo|space|Google.logo",
+        "g|o|o|g|l|e|underscore|G.BRACKET.18|space|G.logo",
+        "s|u|p|e|r|underscore|G.BRACKET.18|underscore|l|o|g|o|space|G.super",
+        "G.BRACKET.18|underscore|l|o|g|o",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "Google.logo|space|Google.logo",
+        "G.logo|space|G.logo",
+        "G.super|space|G.super",
+        "G.logo",
+        "e.logo",
+        "g.logo",
+        "l.logo",
+        "o.logo",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/calt.toml
+++ b/qa/shaping_input/calt.toml
@@ -1,0 +1,22 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+calt = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "Google_logo google_logo", # logo
+    "google_G google_g", # G logo
+    "super_G_logo super_g_logo", # Super G logo
+    "G_logo", # G logo
+    "e_logo", # e logo
+    "g_logo", # g logo
+    "l_logo", # l logo
+    "o_logo", # o logo
+    "09:30 1:20pm", # colon time used between figures in calt feature
+]


### PR DESCRIPTION
This PR adds harfbuzz regression testing definition files for the `calt` feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

### Issues

- I wonder if we want to *remove* support for replacement of the tabular colon with the colon.time (a figure centered design intended for NN:NN times), or better yet make a figure height centered design with the same tabular width.  If you are setting values with tabular figures, you likely want a tabular width colon too?

### Notes

- etatonos.sc sub is not currently included. We will need a separate definition file with SS06 and smcp set to true.  I haven't prioritized any of the smcp / stylistic set testing at this stage.

Tracking: https://github.com/googlefonts/googlesans/issues/161