### PR TITLE
Add harfbuzz shaping regression tests: case

### DIFF
--- a/qa/shaping/case.json
+++ b/qa/shaping/case.json
@@ -1,0 +1,220 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "case": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789",
+      "09:30 1:20pm",
+      "@[](){}¿¡-–—‹›«»·•",
+      "#%‰‱",
+      "°℉℃",
+      "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+      "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+      "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+      "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+      "degree.cap|uni2109.cap|uni2103.cap",
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
+        "zero.cap|nine.cap|colon.time|three.cap|zero.cap|space|one.cap|colon.time|two.cap|zero.cap|p|m",
+        "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
+        "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
+        "degree.cap|uni2109.cap|uni2103.cap",
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      ]
+    }
+  }
+}

--- a/qa/shaping/case.json
+++ b/qa/shaping/case.json
@@ -16,7 +16,9 @@
       "@[](){}¿¡-–—‹›«»·•",
       "#%‰‱",
       "°℉℃",
-      "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€"
+      "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€",
+      "Μήλα ή αχλάδια",
+      "ΜΗΛΑ Ή ΑΧΛΑΔΙΑ"
     ]
   },
   "output": {
@@ -26,7 +28,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans-BoldItalic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -34,7 +38,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans-Italic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -42,7 +48,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans-Italic[opsz,wght].ttf": {
       "opsz=18.0,wght=400.0": [
@@ -51,7 +59,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=18.0,wght=500.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -59,7 +69,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=18.0,wght=700.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -67,7 +79,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=400.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -75,7 +89,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=500.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -83,7 +99,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=700.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -91,7 +109,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ]
     },
     "GoogleSans-Medium.ttf": [
@@ -100,7 +120,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans-MediumItalic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -108,7 +130,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans-Regular.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -116,7 +140,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-Bold.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -124,7 +150,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-BoldItalic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -132,7 +160,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-Italic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -140,7 +170,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-Medium.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -148,7 +180,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-MediumItalic.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -156,7 +190,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSansText-Regular.ttf": [
       "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -164,7 +200,9 @@
       "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
       "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
       "degree.cap|uni2109.cap|uni2103.cap",
-      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+      "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+      "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+      "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
     ],
     "GoogleSans[opsz,wght].ttf": {
       "opsz=18.0,wght=400.0": [
@@ -173,7 +211,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=18.0,wght=500.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -181,7 +221,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=18.0,wght=700.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -189,7 +231,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=400.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -197,7 +241,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=500.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -205,7 +251,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ],
       "opsz=17.0,wght=700.0": [
         "zero.cap|one.cap|two.cap|three.cap|four.cap|five.cap|six.cap|seven.cap|eight.cap|nine.cap",
@@ -213,7 +261,9 @@
         "at.cap|bracketleft.cap|bracketright.cap|parenleft.cap|parenright.cap|braceleft.cap|braceright.cap|questiondown.cap|exclamdown.cap|hyphen.cap|endash.cap|emdash.cap|guilsinglleft.cap|guilsinglright.cap|guillemotleft.cap|guillemotright.cap|anoteleia.case|bullet.cap",
         "numbersign.cap|percent.cap|perthousand.cap|uni2031.cap",
         "degree.cap|uni2109.cap|uni2103.cap",
-        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap"
+        "cent.cap|dollar.cap|franc.cap|sterling.cap|currency.cap|yen.cap|lira.cap|uni20A9.cap|dong.cap|uni20AE.cap|uni20B8.cap|uni20B9.cap|uni20BA.cap|uni20BD.cap|uni20B1.cap|uni20B4.cap|uni20AA.cap|florin|Euro.cap",
+        "Mu|etatonos|lambda|alpha|space|Etatonos|space|alpha|chi|lambda|alphatonos|delta|iota|alpha",
+        "Mu|Eta|Lambda|Alpha|space|Etatonos|space|Alpha|Chi|Lambda|Alpha|uni0394|Iota|Alpha"
       ]
     }
   }

--- a/qa/shaping_input/case.toml
+++ b/qa/shaping_input/case.toml
@@ -16,4 +16,6 @@ text = [
     "#%‰‱",
     "°℉℃", # temperature symbols
     "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€", # currency
+    "Μήλα ή αχλάδια", # Greek string with lower case surrounding etatonos (see https://github.com/googlefonts/googlesans/issues/157)
+    "ΜΗΛΑ Ή ΑΧΛΑΔΙΑ", # Greek string with all caps including Etatonos (see https://github.com/googlefonts/googlesans/issues/157)
 ]

--- a/qa/shaping_input/case.toml
+++ b/qa/shaping_input/case.toml
@@ -1,0 +1,19 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+case = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # figures
+    "09:30 1:20pm", # time values with `case` active should use colon.time centered colon
+    "@[](){}¿¡-–—‹›«»·•", # punctuation
+    "#%‰‱",
+    "°℉℃", # temperature symbols
+    "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€", # currency
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression test definition files for the case feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161 