### PR TITLE
Add harfbuzz shaping regression tests: dnom

### DIFF
--- a/qa/shaping/dnom.json
+++ b/qa/shaping/dnom.json
@@ -1,0 +1,170 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "dnom": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789",
+      "12/34",
+      "12.34",
+      "01/23/34 01-23-34 01.23.34"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+      "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+      "one.denominator|two.denominator|period|three.denominator|four.denominator",
+      "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.denominator|one.denominator|two.denominator|three.denominator|four.denominator|five.denominator|six.denominator|seven.denominator|eight.denominator|nine.denominator",
+        "one.denominator|two.denominator|slash|three.denominator|four.denominator",
+        "one.denominator|two.denominator|period|three.denominator|four.denominator",
+        "zero.denominator|one.denominator|slash|two.denominator|three.denominator|slash|three.denominator|four.denominator|space|zero.denominator|one.denominator|hyphen|two.denominator|three.denominator|hyphen|three.denominator|four.denominator|space|zero.denominator|one.denominator|period|two.denominator|three.denominator|period|three.denominator|four.denominator"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/dnom.toml
+++ b/qa/shaping_input/dnom.toml
@@ -1,0 +1,17 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+dnom = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # replaced by denominator forms
+    "12/34", # fraction form includes all denominator and SOLIDUS without `frac` fea set
+    "12.34", # decimal form includes all denominator
+    "01/23/34 01-23-34 01.23.34", # date forms include all denominator
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the `dnom` feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161 