### PR TITLE
Add harfbuzz shaping regression tests: jalt

### DIFF
--- a/qa/shaping/jalt_hebr_IWR.json
+++ b/qa/shaping/jalt_hebr_IWR.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "jalt": true
+    },
+    "script": "hebr",
+    "language": "IWR",
+    "direction": "rtl",
+    "comparison_mode": "full",
+    "text": [
+      "אהלדכםרת"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "uniFB28=7+1111,0|uniFB27=6+808,0|uniFB26=5+958,0|uniFB24=4+789,0|uniFB22=3+900,0|uniFB25=2+803,0|uniFB23=1+910,0|uniFB21=0+875,0"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "uniFB28=7+1115,0|uniFB27=6+808,0|uniFB26=5+958,0|uniFB24=4+788,0|uniFB22=3+900,0|uniFB25=2+803,0|uniFB23=1+909,0|uniFB21=0+875,0"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "uniFB28=7+1067,0|uniFB27=6+759,0|uniFB26=5+935,0|uniFB24=4+757,0|uniFB22=3+837,0|uniFB25=2+766,0|uniFB23=1+866,0|uniFB21=0+849,0"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uniFB28=7+1067,0|uniFB27=6+759,0|uniFB26=5+935,0|uniFB24=4+757,0|uniFB22=3+837,0|uniFB25=2+766,0|uniFB23=1+866,0|uniFB21=0+849,0"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uniFB28=7+1091,0|uniFB27=6+783,0|uniFB26=5+946,0|uniFB24=4+772,0|uniFB22=3+868,0|uniFB25=2+784,0|uniFB23=1+887,0|uniFB21=0+862,0"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uniFB28=7+1115,0|uniFB27=6+808,0|uniFB26=5+958,0|uniFB24=4+788,0|uniFB22=3+900,0|uniFB25=2+803,0|uniFB23=1+909,0|uniFB21=0+875,0"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uniFB28=7+1019,0|uniFB27=6+760,0|uniFB26=5+922,0|uniFB24=4+744,0|uniFB22=3+832,0|uniFB25=2+732,0|uniFB23=1+868,0|uniFB21=0+862,0"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uniFB28=7+1057,0|uniFB27=6+793,0|uniFB26=5+943,0|uniFB24=4+762,0|uniFB22=3+870,0|uniFB25=2+771,0|uniFB23=1+881,0|uniFB21=0+876,0"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uniFB28=7+1095,0|uniFB27=6+826,0|uniFB26=5+964,0|uniFB24=4+781,0|uniFB22=3+909,0|uniFB25=2+810,0|uniFB23=1+895,0|uniFB21=0+890,0"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "uniFB28=7+1083,0|uniFB27=6+783,0|uniFB26=5+946,0|uniFB24=4+770,0|uniFB22=3+868,0|uniFB25=2+784,0|uniFB23=1+887,0|uniFB21=0+862,0"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "uniFB28=7+1091,0|uniFB27=6+783,0|uniFB26=5+946,0|uniFB24=4+772,0|uniFB22=3+868,0|uniFB25=2+784,0|uniFB23=1+887,0|uniFB21=0+862,0"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "uniFB28=7+1056,0|uniFB27=6+759,0|uniFB26=5+935,0|uniFB24=4+752,0|uniFB22=3+837,0|uniFB25=2+766,0|uniFB23=1+865,0|uniFB21=0+849,0"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "uniFB28=7+1090,0|uniFB27=6+826,0|uniFB26=5+963,0|uniFB24=4+782,0|uniFB22=3+910,0|uniFB25=2+810,0|uniFB23=1+894,0|uniFB21=0+889,0"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "uniFB28=7+1095,0|uniFB27=6+826,0|uniFB26=5+964,0|uniFB24=4+781,0|uniFB22=3+909,0|uniFB25=2+810,0|uniFB23=1+895,0|uniFB21=0+890,0"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "uniFB28=7+1019,0|uniFB27=6+760,0|uniFB26=5+922,0|uniFB24=4+744,0|uniFB22=3+832,0|uniFB25=2+732,0|uniFB23=1+868,0|uniFB21=0+862,0"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "uniFB28=7+1053,0|uniFB27=6+793,0|uniFB26=5+942,0|uniFB24=4+762,0|uniFB22=3+871,0|uniFB25=2+771,0|uniFB23=1+880,0|uniFB21=0+875,0"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "uniFB28=7+1057,0|uniFB27=6+793,0|uniFB26=5+943,0|uniFB24=4+762,0|uniFB22=3+870,0|uniFB25=2+771,0|uniFB23=1+881,0|uniFB21=0+876,0"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "uniFB28=7+1016,0|uniFB27=6+760,0|uniFB26=5+921,0|uniFB24=4+743,0|uniFB22=3+832,0|uniFB25=2+732,0|uniFB23=1+867,0|uniFB21=0+861,0"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uniFB28=7+1056,0|uniFB27=6+759,0|uniFB26=5+935,0|uniFB24=4+752,0|uniFB22=3+837,0|uniFB25=2+766,0|uniFB23=1+865,0|uniFB21=0+849,0"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uniFB28=7+1083,0|uniFB27=6+783,0|uniFB26=5+946,0|uniFB24=4+770,0|uniFB22=3+868,0|uniFB25=2+784,0|uniFB23=1+887,0|uniFB21=0+862,0"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uniFB28=7+1111,0|uniFB27=6+808,0|uniFB26=5+958,0|uniFB24=4+789,0|uniFB22=3+900,0|uniFB25=2+803,0|uniFB23=1+910,0|uniFB21=0+875,0"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uniFB28=7+1016,0|uniFB27=6+760,0|uniFB26=5+921,0|uniFB24=4+743,0|uniFB22=3+832,0|uniFB25=2+732,0|uniFB23=1+867,0|uniFB21=0+861,0"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uniFB28=7+1053,0|uniFB27=6+793,0|uniFB26=5+942,0|uniFB24=4+762,0|uniFB22=3+871,0|uniFB25=2+771,0|uniFB23=1+880,0|uniFB21=0+875,0"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uniFB28=7+1090,0|uniFB27=6+826,0|uniFB26=5+963,0|uniFB24=4+782,0|uniFB22=3+910,0|uniFB25=2+810,0|uniFB23=1+894,0|uniFB21=0+889,0"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/jalt_hebr_IWR.toml
+++ b/qa/shaping_input/jalt_hebr_IWR.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+jalt = true
+
+[input]
+script = "hebr"
+language = "IWR"
+direction = "rtl"
+comparison_mode = "full"
+text = [ 
+    "אהלדכםרת", # justification alternate forms for Hebrew
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the `jalt` feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161