### PR TITLE
Add harfbuzz shaping regression tests: pnum, tnum

### DIFF
--- a/qa/shaping/pnum.json
+++ b/qa/shaping/pnum.json
@@ -1,0 +1,271 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "tnum": true,
+      "pnum": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789",
+      "12/34",
+      "12.34",
+      "01/23/34 01-23-34 01.23.34",
+      " .:;,",
+      "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€",
+      "§¬#%",
+      "+−×÷±<=>≈≠≤≥"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine",
+      "one|two|slash|three|four",
+      "one|two|period|three|four",
+      "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+      "space|period|colon|semicolon|comma",
+      "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+      "section|logicalnot|numbersign|percent",
+      "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine",
+        "one|two|slash|three|four",
+        "one|two|period|three|four",
+        "zero|one|slash|two|three|slash|three|four|space|zero|one|hyphen|two|three|hyphen|three|four|space|zero|one|period|two|three|period|three|four",
+        "space|period|colon|semicolon|comma",
+        "cent|dollar|franc|sterling|currency|yen|lira|uni20A9|dong|uni20AE|uni20B8|uni20B9|uni20BA|uni20BD|uni20B1|uni20B4.tf|uni20AA.tf|florin|Euro",
+        "section|logicalnot|numbersign|percent",
+        "plus|minus|multiply|divide|plusminus|less|equal|greater|approxequal|notequal|lessequal|greaterequal"
+      ]
+    }
+  }
+}

--- a/qa/shaping/tnum.json
+++ b/qa/shaping/tnum.json
@@ -1,0 +1,295 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "tnum": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789",
+      "12/34",
+      "12.34",
+      "09:30 1:20pm",
+      "01/23/34 01-23-34 01.23.34",
+      " .:;,",
+      "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€",
+      "§¬#%",
+      "+−×÷±<=>≈≠≤≥"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+      "one.tf|two.tf|slash|three.tf|four.tf",
+      "one.tf|two.tf|period.tf|three.tf|four.tf",
+      "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+      "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+      "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+      "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+      "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+      "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.BRACKET.18|comma.BRACKET.18",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.tf|one.tf|two.tf|three.tf|four.tf|five.tf|six.tf|seven.tf|eight.tf|nine.tf",
+        "one.tf|two.tf|slash|three.tf|four.tf",
+        "one.tf|two.tf|period.tf|three.tf|four.tf",
+        "zero.tf|nine.tf|colon.time|three.tf|zero.tf|space.tf|one.tf|colon.time|two.tf|zero.tf|p|m",
+        "zero.tf|one.tf|slash|two.tf|three.tf|slash|three.tf|four.tf|space.tf|zero.tf|one.tf|hyphen|two.tf|three.tf|hyphen|three.tf|four.tf|space.tf|zero.tf|one.tf|period.tf|two.tf|three.tf|period.tf|three.tf|four.tf",
+        "space.tf|period.tf|colon.tf|semicolon.tf|comma.tf",
+        "cent.tf|dollar.tf|franc.tf|sterling.tf|currency.tf|yen.tf|lira.tf|uni20A9.tf|dong.tf|uni20AE.tf|uni20B8.tf|uni20B9.tf|uni20BA.tf|uni20BD.tf|uni20B1.tf|uni20B4.tf|uni20AA.tf|florin.tf|Euro.tf",
+        "section.tf|logicalnot.tf|numbersign.tf|percent.tf",
+        "plus.tf|minus.tf|multiply.tf|divide.tf|plusminus.tf|less.tf|equal.tf|greater.tf|approxequal.tf|notequal.tf|lessequal.tf|greaterequal.tf"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/pnum.toml
+++ b/qa/shaping_input/pnum.toml
@@ -1,0 +1,22 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+tnum = true
+pnum = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # figures: should not be tabular forms
+    "12/34", # figures: should not be tabular forms
+    "12.34", # figures: should not be tabular forms
+    "01/23/34 01-23-34 01.23.34", # figures: should not be tabular forms
+    " .:;,",  # punctuation: should not be tabular forms
+    "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€", # currency symbols: should not be tabular forms
+    "§¬#%",  # symbols: should not be tabular forms
+    "+−×÷±<=>≈≠≤≥", # math symbols: should not be tabular forms
+]

--- a/qa/shaping_input/tnum.toml
+++ b/qa/shaping_input/tnum.toml
@@ -1,0 +1,22 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+tnum = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # figures: replaced by tabular forms
+    "12/34", # figures: fraction form includes all tabular and SOLIDUS without `frac` fea set
+    "12.34", # figures: decimal form includes all tabular
+    "09:30 1:20pm", # figures: should use colon.time form with calt off
+    "01/23/34 01-23-34 01.23.34", # figures: date forms include all tabular
+    " .:;,",  # punctuation tab forms (note includes lead space glyph)
+    "¢$₣£¤¥₤₩₫₮₸₹₺₽₱₴₪ƒ€", # currency symbols: tab forms
+    "§¬#%",  # symbols: tab forms
+    "+−×÷±<=>≈≠≤≥", # math symbols: tab forms
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the `pnum` and `tnum` features.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161