### PR TITLE
Add harfbuzz shaping regression tests: ordn

### DIFF
--- a/qa/shaping/ordn.json
+++ b/qa/shaping/ordn.json
@@ -1,0 +1,145 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "ordn": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "Aa",
+      "Oo",
+      "2.o"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "ordfeminine|ordfeminine",
+      "ordmasculine|ordmasculine",
+      "two|period|ordmasculine"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "ordfeminine|ordfeminine",
+        "ordmasculine|ordmasculine",
+        "two|period|ordmasculine"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/ordn.toml
+++ b/qa/shaping_input/ordn.toml
@@ -1,0 +1,16 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+ordn = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "Aa", # feminine
+    "Oo", # masculine
+    "2.o", # secundo
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the ordn feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161