### PR TITLE
Add harfbuzz shaping regression tests: numr, sinf, subs, sups

### DIFF
--- a/qa/shaping/numr.json
+++ b/qa/shaping/numr.json
@@ -1,0 +1,170 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "numr": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789",
+      "12/34",
+      "12.34",
+      "01/23/34 01-23-34 01.23.34"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+      "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+      "one.numerator|two.numerator|period|three.numerator|four.numerator",
+      "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.numerator|one.numerator|two.numerator|three.numerator|four.numerator|five.numerator|six.numerator|seven.numerator|eight.numerator|nine.numerator",
+        "one.numerator|two.numerator|slash|three.numerator|four.numerator",
+        "one.numerator|two.numerator|period|three.numerator|four.numerator",
+        "zero.numerator|one.numerator|slash|two.numerator|three.numerator|slash|three.numerator|four.numerator|space|zero.numerator|one.numerator|hyphen|two.numerator|three.numerator|hyphen|three.numerator|four.numerator|space|zero.numerator|one.numerator|period|two.numerator|three.numerator|period|three.numerator|four.numerator"
+      ]
+    }
+  }
+}

--- a/qa/shaping/sinf.json
+++ b/qa/shaping/sinf.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "sinf": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ]
+    }
+  }
+}

--- a/qa/shaping/subs.json
+++ b/qa/shaping/subs.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "subs": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2080|uni2081|uni2082|uni2083|uni2084|uni2085|uni2086|uni2087|uni2088|uni2089"
+      ]
+    }
+  }
+}

--- a/qa/shaping/sups.json
+++ b/qa/shaping/sups.json
@@ -1,89 +1,95 @@
 {
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
   "input": {
-    "text": [
-      "01234567890"
-    ],
     "features": {
       "sups": true
     },
-    "comparison_mode": "glyphstream"
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "0123456789"
+    ]
   },
   "output": {
-    "GoogleSans-Italic[opsz,wght].ttf": {
-      "opsz=18.0,wght=400.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=18.0,wght=500.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=18.0,wght=700.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=400.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=500.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=700.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ]
-    },
-    "GoogleSans[opsz,wght].ttf": {
-      "opsz=18.0,wght=400.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=18.0,wght=500.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=18.0,wght=700.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=400.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=500.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ],
-      "opsz=17.0,wght=700.0": [
-        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-      ]
-    },
-    "GoogleSansText-Bold.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
-    "GoogleSansText-BoldItalic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
-    "GoogleSansText-Italic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
-    "GoogleSansText-Medium.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
-    "GoogleSansText-MediumItalic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
-    "GoogleSansText-Regular.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ],
     "GoogleSans-Bold.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
     ],
     "GoogleSans-BoldItalic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
     ],
     "GoogleSans-Italic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
     ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ]
+    },
     "GoogleSans-Medium.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
     ],
     "GoogleSans-MediumItalic.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
     ],
     "GoogleSans-Regular.ttf": [
-      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079|uni2070"
-    ]
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "uni2070|uni00B9|uni00B2|uni00B3|uni2074|uni2075|uni2076|uni2077|uni2078|uni2079"
+      ]
+    }
   }
 }

--- a/qa/shaping_input/numr.toml
+++ b/qa/shaping_input/numr.toml
@@ -1,0 +1,17 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+numr = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # replaced by numerator forms
+    "12/34", # fraction form includes all numerator and SOLIDUS without `frac` fea set
+    "12.34", # decimal form includes all numerator
+    "01/23/34 01-23-34 01.23.34", # date forms include all numerator
+]

--- a/qa/shaping_input/sinf.toml
+++ b/qa/shaping_input/sinf.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+sinf = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # inferior forms
+]

--- a/qa/shaping_input/subs.toml
+++ b/qa/shaping_input/subs.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+subs = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # inferior forms
+]

--- a/qa/shaping_input/sups.toml
+++ b/qa/shaping_input/sups.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+sups = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "0123456789", # superior forms
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the numr, sinf, subs, and sups features.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

Tracking: #161