### PR TITLE
Add harfbuzz shaping regression tests: ss03

### DIFF
--- a/qa/shaping/ss03.json
+++ b/qa/shaping/ss03.json
@@ -1,0 +1,120 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "ss03": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "01234567899",
+      "09:30 1:20pm"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+        "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "zero|one|two|three|four|five|six|seven|eight|nine|nine",
+      "zero|nine|colon.time|three|zero|space|one|colon.time|two|zero|p|m"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
+        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/ss03.toml
+++ b/qa/shaping_input/ss03.toml
@@ -1,0 +1,15 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+ss03 = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "01234567899",
+    "09:30 1:20pm",
+]


### PR DESCRIPTION
This PR adds harfbuzz shaping regression testing definition files for the ss03 feature.

The data have not been reviewed in detail to confirm that bugs do not exist in the production fonts. This intent is to add the production font data for regression testing and future bug hunt support.

### Issues

`ss03`:

```
sub colon by colon.ss03;
```

is trumped by the `calt`:

```
sub [zero one two three four five six seven eight nine] colon' [zero one two three four five six seven eight nine] by colon.time;
```

Tracking: #161

Required in: #158