### PR TITLE
Add harfbuzz shaping regression tests: ss05

### DIFF
--- a/qa/shaping/ss05.json
+++ b/qa/shaping/ss05.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "617d313bb59de7969f34439975febc98f7378403"
+  },
+  "input": {
+    "features": {
+      "ss05": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "↑↗→↘↓↙←↖"
+    ]
+  },
+  "output": {
+    "GoogleSans-Bold.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ]
+    },
+    "GoogleSans-Medium.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+    ],
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "arrowup.ss05|uni2197.ss05|arrowright.ss05|uni2198.ss05|arrowdown.ss05|uni2199.ss05|arrowleft.ss05|uni2196.ss05"
+      ]
+    }
+  }
+}

--- a/qa/shaping_input/ss05.toml
+++ b/qa/shaping_input/ss05.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+ss05 = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "↑↗→↘↓↙←↖", # arrows
+]


### PR DESCRIPTION
Adds new harfbuzz shaping test definition files for the ss05 feature.

Tracking #161 