### PR TITLE
Update fontTools and glyphsLib dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ compreffor==0.5.0         # via ufo2ft
 cu2qu==1.6.7              # via fontmake, ufo2ft
 fontmake==2.2.0           # via -r requirements.in
 fontmath==0.6.0           # via fontmake
-fonttools[lxml,ufo,unicode]==4.14.0  # via booleanoperations, cffsubr, compreffor, cu2qu, fontmake, fontmath, glyphslib, ufo2ft, ufolib2
+fonttools[lxml,ufo,unicode]==4.19.1  # via booleanoperations, cffsubr, compreffor, cu2qu, fontmake, fontmath, glyphslib, ufo2ft, ufolib2
 fs==2.4.11                # via fonttools
 lxml==4.6.2               # via fonttools
-glyphslib==5.3.1         # via fontmake
+glyphslib==5.3.2         # via fontmake
 pyclipper==1.2.0          # via booleanoperations
 pytz==2020.1              # via fs
 six==1.15.0               # via fs

--- a/scripts/gs-merge-designspace.py
+++ b/scripts/gs-merge-designspace.py
@@ -147,15 +147,48 @@ for import_source in designspace_import.sources:
     import_font: ufoLib2.Font = import_source.font
     target_font: ufoLib2.Font = target_source.font
 
+    # Snatch up any bracket glyphs for glyphs without them being explicitly
+    # listed in the import file. ".BRACKET." is a glyphsLib convention.
+    for name in import_font.keys():
+        if ".BRACKET." not in name:
+            continue
+        base = name.split(".BRACKET.")[0]
+        if base in import_glyphs:
+            import_glyphs.add(name)
+            logging.warning(
+                "Added bracket glyph '%s', manually add to the Designspace rules.", name
+            )
+
     for glyph_name in import_glyphs:
-        target_font[glyph_name] = import_font[glyph_name]
+        try:
+            target_font[glyph_name] = import_font[glyph_name]
+        except KeyError as e:
+            logging.error(
+                "Glyph '%s' does not exist in the source UFO %s, aborting.",
+                str(e),
+                str(import_source.filename),
+            )
+            sys.exit(1)
 
     for group_name in import_groups:
-        target_font.groups[group_name] = import_font.groups[group_name]
+        try:
+            target_font.groups[group_name] = import_font.groups[group_name]
+        except KeyError as e:
+            logging.warning(
+                "Kerning group %s does not exist in the source UFO %s, skipping.",
+                str(e),
+                str(import_source.filename),
+            )
+            continue
 
     # Import kerning where either side of a pair is an imported glyph or group:
     for key, value in import_font.kerning.items():
         first, second = key
+        if (first not in import_font and first not in import_font.groups) or (
+            second not in import_font and second not in import_font.groups
+        ):
+            # Skip spurious pairs.
+            continue
         if (
             first in import_groups
             or first in import_glyphs

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -1,14 +1,16 @@
 import copy
 from pathlib import Path
-from typing import Set
+from typing import List, Set
 
 import ufo2ft
 import ufoLib2
 from fontTools.designspaceLib import (
     DesignSpaceDocument,
     InstanceDescriptor,
+    RuleDescriptor,
     SourceDescriptor,
 )
+from glyphsLib.builder.builders import _expand_kerning_to_brackets
 
 from . import gdef
 
@@ -16,9 +18,10 @@ from . import gdef
 def scrub_designspace(designspace: DesignSpaceDocument, project_root: Path) -> None:
     designspace.loadSourceFonts(ufoLib2.Font.open)
     skip_export_glyphs = set(designspace.lib.get("public.skipExportGlyphs", []))
+    rules = designspace.rules
 
     for source in designspace.sources:
-        scrub_source(source, skip_export_glyphs)
+        scrub_source(source, skip_export_glyphs, rules)
 
     for instance in designspace.instances:
         scrub_instance(instance, project_root)
@@ -56,11 +59,15 @@ def scrub_instance(instance: InstanceDescriptor, project_root: Path) -> None:
     )
 
 
-def scrub_source(source: SourceDescriptor, skip_export_glyphs: Set[str]) -> None:
-    scrub_ufo(source.font, skip_export_glyphs)
+def scrub_source(
+    source: SourceDescriptor, skip_export_glyphs: Set[str], rules: List[RuleDescriptor]
+) -> None:
+    scrub_ufo(source.font, skip_export_glyphs, rules)
 
 
-def scrub_ufo(ufo: ufoLib2.Font, skip_export_glyphs: Set[str]) -> None:
+def scrub_ufo(
+    ufo: ufoLib2.Font, skip_export_glyphs: Set[str], rules: List[RuleDescriptor]
+) -> None:
     # Clean global lib.
     keys_to_keep = {
         # UFOs don't need lastChanged because glyphs are separate files, keep it disabled.
@@ -187,6 +194,12 @@ def scrub_ufo(ufo: ufoLib2.Font, skip_export_glyphs: Set[str]) -> None:
             new_kerning[key] = value
     ufo.kerning.clear()
     ufo.kerning.update(new_kerning)
+
+    # Bracket glyphs are a Glyphs.app construct that inherit the kerning from
+    # their parents.
+    for rule in rules:
+        for name, name_bracket in rule.subs:
+            _expand_kerning_to_brackets(name, name_bracket, ufo)
 
     # Update GDEF table. Anchors have to be propagated before we can construct
     # the GDEF table. Use the UFO copy so we can safely save the original with


### PR DESCRIPTION
Updates:

- fonttools to 4.19.1
- glyphsLib to 5.3.2
- gs-merge-designspace.py
- normalize.py

Cherry picked from Nikolaus's `build-armenian` branch @ commit 91a471deefeebb8e13f4be333a4e624fb15fe87b

These updates are required to proceed with work in open PR's.