### PR TITLE
Add ss01 and ss02 harfbuzz shaping regression tests

### DIFF
--- a/qa/shaping/ss01.json
+++ b/qa/shaping/ss01.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "200664562b06329fa7d2dcb93b7934521346de0c"
+  },
+  "input": {
+    "features": {
+      "ss01": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      "*"
+    ]
+  },
+  "output": {
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "asterisk.num"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "asterisk.num"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "asterisk.num"
+      ]
+    },
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "asterisk.num"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "asterisk.num"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "asterisk.num"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "asterisk.num"
+      ]
+    },
+    "GoogleSans-Bold.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSans-Medium.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "asterisk.num"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "asterisk.num"
+    ]
+  }
+}

--- a/qa/shaping/ss02.json
+++ b/qa/shaping/ss02.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "build_commit": "200664562b06329fa7d2dcb93b7934521346de0c"
+  },
+  "input": {
+    "features": {
+      "ss02": true
+    },
+    "script": "DFLT",
+    "language": "dflt",
+    "direction": "ltr",
+    "comparison_mode": "glyphstream",
+    "text": [
+      ":"
+    ]
+  },
+  "output": {
+    "GoogleSans-Italic[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "colon.time"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "colon.time"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "colon.time"
+      ]
+    },
+    "GoogleSans[opsz,wght].ttf": {
+      "opsz=18.0,wght=400.0": [
+        "colon.time"
+      ],
+      "opsz=18.0,wght=500.0": [
+        "colon.time"
+      ],
+      "opsz=18.0,wght=700.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=400.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=500.0": [
+        "colon.time"
+      ],
+      "opsz=17.0,wght=700.0": [
+        "colon.time"
+      ]
+    },
+    "GoogleSans-Bold.ttf": [
+      "colon.time"
+    ],
+    "GoogleSans-BoldItalic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSans-Italic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSans-Medium.ttf": [
+      "colon.time"
+    ],
+    "GoogleSans-MediumItalic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSans-Regular.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-Bold.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-BoldItalic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-Italic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-Medium.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-MediumItalic.ttf": [
+      "colon.time"
+    ],
+    "GoogleSansText-Regular.ttf": [
+      "colon.time"
+    ]
+  }
+}

--- a/qa/shaping_input/ss01.toml
+++ b/qa/shaping_input/ss01.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+ss01 = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    "*", # replaced with number pad asterisk form
+]

--- a/qa/shaping_input/ss02.toml
+++ b/qa/shaping_input/ss02.toml
@@ -1,0 +1,14 @@
+[meta]
+build_commit  = ""
+
+[input.features]
+ss02 = true
+
+[input]
+script = "DFLT"
+language = "dflt"
+direction = "ltr"
+comparison_mode = "glyphstream"
+text = [ 
+    ":", # replaced with colon.time cap height centered form
+]


### PR DESCRIPTION
Adds toml and json definition files to support harfbuzz shaping regression tests of ss01 and ss02 

Tracking #161