### PR TITLE
[fontbakery tests] Update expected feature tags for GSv4 builds

### DIFF
--- a/qa/check-fea.py
+++ b/qa/check-fea.py
@@ -46,7 +46,6 @@ GOOGLESANS_PROFILE_CHECKS = [
 ]
 
 STATIC_UPRIGHT_FEA = [
-    "aalt",
     "c2sc",
     "calt",
     "case",
@@ -73,14 +72,12 @@ STATIC_UPRIGHT_FEA = [
     "ss05",
     "ss06",
     "ss07",
-    "ss08",
     "subs",
     "sups",
     "tnum",
 ]
 
 STATIC_ITALICS_FEA = [
-    "aalt",
     "c2sc",
     "calt",
     "case",
@@ -106,14 +103,12 @@ STATIC_ITALICS_FEA = [
     "ss05",
     "ss06",
     "ss07",
-    "ss08",
     "subs",
     "sups",
     "tnum",
 ]
 
 VAR_UPRIGHT_FEA = [
-    "aalt",
     "c2sc",
     "calt",
     "case",
@@ -141,14 +136,12 @@ VAR_UPRIGHT_FEA = [
     "ss05",
     "ss06",
     "ss07",
-    "ss08",
     "subs",
     "sups",
     "tnum",
 ]
 
 VAR_ITALICS_FEA = [
-    "aalt",
     "c2sc",
     "calt",
     "case",
@@ -175,7 +168,6 @@ VAR_ITALICS_FEA = [
     "ss05",
     "ss06",
     "ss07",
-    "ss08",
     "subs",
     "sups",
     "tnum",
@@ -405,9 +397,7 @@ def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
 
                 for key, shaped_text in shaped_texts.items():
                     if shaped_text != shaped_texts_expected[key]:
-                        shaped_texts_str = textwrap.indent(
-                            "\n".join(shaped_text), "\t  "
-                        )
+                        shaped_texts_str = textwrap.indent("\n".join(shaped_text), "\t  ")
                         shaped_texts_expected_str = textwrap.indent(
                             "\n".join(shaped_texts_expected[key]), "\t  "
                         )


### PR DESCRIPTION
removes ss08 and aalt feature tags from the expected list.  These features will be removed in GSv4

This update should fail CI testing until the updated GSv4 source is merged (#240)