### PR TITLE
Eliminate grade on logo forms, Roman only

### DIFF
--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -3,43 +3,43 @@
   <advance width="861"/>
   <outline>
     <contour>
-      <point x="460.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="580.0" y="-16.0"/>
-      <point x="670.0" y="25.0"/>
-      <point x="742.0" y="99.0" type="curve"/>
-      <point x="814.0" y="174.0"/>
-      <point x="836.0" y="277.0"/>
-      <point x="836.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="836.0" y="387.0"/>
-      <point x="834.0" y="411.0"/>
-      <point x="830.0" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="339.0" type="line"/>
-      <point x="739.0" y="339.0" type="line"/>
-      <point x="738.0" y="275.0"/>
-      <point x="715.0" y="204.0"/>
-      <point x="670.0" y="159.0" type="curve" smooth="yes"/>
-      <point x="625.0" y="114.0"/>
-      <point x="564.0" y="72.0"/>
-      <point x="458.0" y="72.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="72.0"/>
-      <point x="151.0" y="217.0"/>
-      <point x="151.0" y="391.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="566.0"/>
-      <point x="285.0" y="709.0"/>
-      <point x="458.0" y="709.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="709.0"/>
-      <point x="619.0" y="669.0"/>
-      <point x="669.0" y="621.0" type="curve"/>
-      <point x="738.0" y="690.0" type="line"/>
-      <point x="672.0" y="757.0"/>
-      <point x="582.0" y="804.0"/>
-      <point x="460.0" y="804.0" type="curve" smooth="yes"/>
-      <point x="236.0" y="804.0"/>
-      <point x="49.0" y="620.0"/>
-      <point x="49.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="49.0" y="168.0"/>
-      <point x="236.0" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -3,37 +3,37 @@
   <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499.0" y="-27.0" type="curve" smooth="yes"/>
-      <point x="733.0" y="-27.0"/>
-      <point x="879.0" y="137.0"/>
-      <point x="879.0" y="367.0" type="curve" smooth="yes"/>
-      <point x="879.0" y="390.0"/>
-      <point x="875.0" y="417.0"/>
-      <point x="873.0" y="436.0" type="curve"/>
-      <point x="499.0" y="436.0" type="line"/>
-      <point x="499.0" y="310.0" type="line"/>
-      <point x="752.0" y="310.0" type="line"/>
-      <point x="737.0" y="187.0"/>
-      <point x="650.0" y="101.0"/>
-      <point x="500.0" y="101.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="101.0"/>
-      <point x="233.0" y="227.0"/>
-      <point x="233.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="233.0" y="524.0"/>
-      <point x="352.0" y="648.0"/>
-      <point x="500.0" y="648.0" type="curve" smooth="yes"/>
-      <point x="566.0" y="648.0"/>
-      <point x="626.0" y="625.0"/>
-      <point x="673.0" y="580.0" type="curve"/>
-      <point x="770.0" y="675.0" type="line"/>
-      <point x="700.0" y="740.0"/>
-      <point x="608.0" y="780.0"/>
-      <point x="499.0" y="780.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="780.0"/>
-      <point x="95.0" y="600.0"/>
-      <point x="95.0" y="377.0" type="curve" smooth="yes"/>
-      <point x="95.0" y="154.0"/>
-      <point x="274.0" y="-27.0"/>
+      <point x="499" y="-41" type="curve" smooth="yes"/>
+      <point x="739" y="-41"/>
+      <point x="898" y="128"/>
+      <point x="898" y="365" type="curve" smooth="yes"/>
+      <point x="898" y="395"/>
+      <point x="896" y="423"/>
+      <point x="891" y="451" type="curve"/>
+      <point x="499" y="451" type="line"/>
+      <point x="499" y="290" type="line"/>
+      <point x="723" y="290" type="line"/>
+      <point x="705" y="194"/>
+      <point x="621" y="124"/>
+      <point x="499" y="124" type="curve" smooth="yes"/>
+      <point x="363" y="124"/>
+      <point x="253" y="239"/>
+      <point x="253" y="375" type="curve" smooth="yes"/>
+      <point x="253" y="511"/>
+      <point x="363" y="625"/>
+      <point x="499" y="625" type="curve" smooth="yes"/>
+      <point x="560" y="625"/>
+      <point x="615" y="604"/>
+      <point x="658" y="563" type="curve"/>
+      <point x="777" y="683" type="line"/>
+      <point x="705" y="750"/>
+      <point x="611" y="791"/>
+      <point x="499" y="791" type="curve" smooth="yes"/>
+      <point x="269" y="791"/>
+      <point x="83" y="605"/>
+      <point x="83" y="375" type="curve" smooth="yes"/>
+      <point x="83" y="145"/>
+      <point x="269" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -3,183 +3,183 @@
   <advance width="3284"/>
   <outline>
     <contour>
-      <point x="460.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="580.0" y="-16.0"/>
-      <point x="670.0" y="25.0"/>
-      <point x="742.0" y="99.0" type="curve"/>
-      <point x="814.0" y="174.0"/>
-      <point x="836.0" y="277.0"/>
-      <point x="836.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="836.0" y="387.0"/>
-      <point x="834.0" y="411.0"/>
-      <point x="830.0" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="339.0" type="line"/>
-      <point x="739.0" y="339.0" type="line"/>
-      <point x="738.0" y="275.0"/>
-      <point x="715.0" y="204.0"/>
-      <point x="670.0" y="159.0" type="curve" smooth="yes"/>
-      <point x="625.0" y="114.0"/>
-      <point x="564.0" y="77.0"/>
-      <point x="458.0" y="77.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="77.0"/>
-      <point x="151.0" y="217.0"/>
-      <point x="151.0" y="391.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="566.0"/>
-      <point x="285.0" y="706.0"/>
-      <point x="458.0" y="706.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="706.0"/>
-      <point x="619.0" y="669.0"/>
-      <point x="669.0" y="621.0" type="curve"/>
-      <point x="738.0" y="690.0" type="line"/>
-      <point x="672.0" y="757.0"/>
-      <point x="582.0" y="804.0"/>
-      <point x="460.0" y="804.0" type="curve" smooth="yes"/>
-      <point x="236.0" y="804.0"/>
-      <point x="49.0" y="620.0"/>
-      <point x="49.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="49.0" y="168.0"/>
-      <point x="236.0" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
     <contour>
-      <point x="1147.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="1289.0" y="-16.0"/>
-      <point x="1404.0" y="96.0"/>
-      <point x="1404.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1404.0" y="401.0"/>
-      <point x="1289.0" y="512.0"/>
-      <point x="1147.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="1005.0" y="512.0"/>
-      <point x="890.0" y="401.0"/>
-      <point x="890.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="890.0" y="96.0"/>
-      <point x="1005.0" y="-16.0"/>
+      <point x="1148" y="-16" type="curve" smooth="yes"/>
+      <point x="1294" y="-16"/>
+      <point x="1413" y="96"/>
+      <point x="1413" y="248" type="curve" smooth="yes"/>
+      <point x="1413" y="401"/>
+      <point x="1294" y="512"/>
+      <point x="1148" y="512" type="curve" smooth="yes"/>
+      <point x="1002" y="512"/>
+      <point x="883" y="401"/>
+      <point x="883" y="248" type="curve" smooth="yes"/>
+      <point x="883" y="96"/>
+      <point x="1002" y="-16"/>
     </contour>
     <contour>
-      <point x="1147.0" y="72.0" type="curve" smooth="yes"/>
-      <point x="1060.0" y="72.0"/>
-      <point x="985.0" y="144.0"/>
-      <point x="985.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="985.0" y="352.0"/>
-      <point x="1060.0" y="423.0"/>
-      <point x="1147.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="1233.0" y="423.0"/>
-      <point x="1309.0" y="352.0"/>
-      <point x="1309.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="1309.0" y="144.0"/>
-      <point x="1233.0" y="72.0"/>
+      <point x="1148" y="88" type="curve" smooth="yes"/>
+      <point x="1068" y="88"/>
+      <point x="999" y="154"/>
+      <point x="999" y="248" type="curve" smooth="yes"/>
+      <point x="999" y="343"/>
+      <point x="1068" y="408"/>
+      <point x="1148" y="408" type="curve" smooth="yes"/>
+      <point x="1228" y="408"/>
+      <point x="1297" y="343"/>
+      <point x="1297" y="248" type="curve" smooth="yes"/>
+      <point x="1297" y="154"/>
+      <point x="1228" y="88"/>
     </contour>
     <contour>
-      <point x="1727.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="1869.0" y="-16.0"/>
-      <point x="1984.0" y="96.0"/>
-      <point x="1984.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1984.0" y="401.0"/>
-      <point x="1869.0" y="512.0"/>
-      <point x="1727.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="1585.0" y="512.0"/>
-      <point x="1470.0" y="401.0"/>
-      <point x="1470.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1470.0" y="96.0"/>
-      <point x="1585.0" y="-16.0"/>
+      <point x="1726" y="-16" type="curve" smooth="yes"/>
+      <point x="1872" y="-16"/>
+      <point x="1991" y="96"/>
+      <point x="1991" y="248" type="curve" smooth="yes"/>
+      <point x="1991" y="401"/>
+      <point x="1872" y="512"/>
+      <point x="1726" y="512" type="curve" smooth="yes"/>
+      <point x="1580" y="512"/>
+      <point x="1461" y="401"/>
+      <point x="1461" y="248" type="curve" smooth="yes"/>
+      <point x="1461" y="96"/>
+      <point x="1580" y="-16"/>
     </contour>
     <contour>
-      <point x="1727.0" y="72.0" type="curve" smooth="yes"/>
-      <point x="1640.0" y="72.0"/>
-      <point x="1565.0" y="144.0"/>
-      <point x="1565.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="1565.0" y="352.0"/>
-      <point x="1640.0" y="423.0"/>
-      <point x="1727.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="1813.0" y="423.0"/>
-      <point x="1889.0" y="352.0"/>
-      <point x="1889.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="1889.0" y="144.0"/>
-      <point x="1813.0" y="72.0"/>
+      <point x="1726" y="88" type="curve" smooth="yes"/>
+      <point x="1646" y="88"/>
+      <point x="1577" y="154"/>
+      <point x="1577" y="248" type="curve" smooth="yes"/>
+      <point x="1577" y="343"/>
+      <point x="1646" y="408"/>
+      <point x="1726" y="408" type="curve" smooth="yes"/>
+      <point x="1806" y="408"/>
+      <point x="1875" y="343"/>
+      <point x="1875" y="248" type="curve" smooth="yes"/>
+      <point x="1875" y="154"/>
+      <point x="1806" y="88"/>
     </contour>
     <contour>
-      <point x="2295.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="2431.0" y="-253.0"/>
-      <point x="2539.0" y="-173.0"/>
-      <point x="2539.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="2539.0" y="496.0" type="line"/>
-      <point x="2444.0" y="496.0" type="line"/>
-      <point x="2444.0" y="445.0" type="line"/>
-      <point x="2440.0" y="445.0" type="line"/>
-      <point x="2420.0" y="469.0"/>
-      <point x="2369.0" y="512.0"/>
-      <point x="2296.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="2171.0" y="512.0"/>
-      <point x="2049.0" y="406.0"/>
-      <point x="2049.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="2049.0" y="86.0"/>
-      <point x="2171.0" y="-12.0"/>
-      <point x="2294.0" y="-12.0" type="curve" smooth="yes"/>
-      <point x="2361.0" y="-12.0"/>
-      <point x="2417.0" y="29.0"/>
-      <point x="2440.0" y="58.0" type="curve"/>
-      <point x="2444.0" y="58.0" type="line"/>
-      <point x="2444.0" y="-11.0" type="line" smooth="yes"/>
-      <point x="2444.0" y="-112.0"/>
-      <point x="2391.0" y="-170.0"/>
-      <point x="2304.0" y="-170.0" type="curve" smooth="yes"/>
-      <point x="2217.0" y="-170.0"/>
-      <point x="2167.0" y="-108.0"/>
-      <point x="2149.0" y="-60.0" type="curve"/>
-      <point x="2061.0" y="-97.0" type="line"/>
-      <point x="2090.0" y="-167.0"/>
-      <point x="2167.0" y="-253.0"/>
+      <point x="2294" y="-253" type="curve" smooth="yes"/>
+      <point x="2430" y="-253"/>
+      <point x="2545" y="-173"/>
+      <point x="2545" y="22" type="curve" smooth="yes"/>
+      <point x="2545" y="496" type="line"/>
+      <point x="2435" y="496" type="line"/>
+      <point x="2435" y="453" type="line"/>
+      <point x="2431" y="453" type="line"/>
+      <point x="2405" y="484"/>
+      <point x="2355" y="512"/>
+      <point x="2292" y="512" type="curve" smooth="yes"/>
+      <point x="2160" y="512"/>
+      <point x="2039" y="396"/>
+      <point x="2039" y="247" type="curve" smooth="yes"/>
+      <point x="2039" y="99"/>
+      <point x="2160" y="-16"/>
+      <point x="2292" y="-16" type="curve" smooth="yes"/>
+      <point x="2355" y="-16"/>
+      <point x="2405" y="12"/>
+      <point x="2431" y="44" type="curve"/>
+      <point x="2435" y="44" type="line"/>
+      <point x="2435" y="6" type="line" smooth="yes"/>
+      <point x="2435" y="-95"/>
+      <point x="2381" y="-149"/>
+      <point x="2294" y="-149" type="curve" smooth="yes"/>
+      <point x="2223" y="-149"/>
+      <point x="2179" y="-98"/>
+      <point x="2161" y="-55" type="curve"/>
+      <point x="2060" y="-97" type="line"/>
+      <point x="2089" y="-167"/>
+      <point x="2166" y="-253"/>
     </contour>
     <contour>
-      <point x="2302.0" y="71.0" type="curve" smooth="yes"/>
-      <point x="2213.0" y="71.0"/>
-      <point x="2143.0" y="145.0"/>
-      <point x="2143.0" y="246.0" type="curve" smooth="yes"/>
-      <point x="2143.0" y="348.0"/>
-      <point x="2213.0" y="423.0"/>
-      <point x="2297.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="2390.0" y="423.0"/>
-      <point x="2449.0" y="353.0"/>
-      <point x="2449.0" y="246.0" type="curve" smooth="yes"/>
-      <point x="2449.0" y="139.0"/>
-      <point x="2390.0" y="71.0"/>
+      <point x="2302" y="88" type="curve" smooth="yes"/>
+      <point x="2222" y="88"/>
+      <point x="2155" y="155"/>
+      <point x="2155" y="247" type="curve" smooth="yes"/>
+      <point x="2155" y="340"/>
+      <point x="2222" y="408"/>
+      <point x="2302" y="408" type="curve" smooth="yes"/>
+      <point x="2381" y="408"/>
+      <point x="2443" y="340"/>
+      <point x="2443" y="247" type="curve" smooth="yes"/>
+      <point x="2443" y="155"/>
+      <point x="2381" y="88"/>
     </contour>
     <contour>
-      <point x="2636.0" y="0.0" type="line"/>
-      <point x="2732.0" y="0.0" type="line"/>
-      <point x="2732.0" y="776.0" type="line"/>
-      <point x="2636.0" y="776.0" type="line"/>
+      <point x="2625" y="0" type="line"/>
+      <point x="2741" y="0" type="line"/>
+      <point x="2741" y="776" type="line"/>
+      <point x="2625" y="776" type="line"/>
     </contour>
     <contour>
-      <point x="2901.0" y="257.0" type="curve" smooth="yes"/>
-      <point x="2901.0" y="387.0"/>
-      <point x="2988.0" y="427.0"/>
-      <point x="3049.0" y="427.0" type="curve" smooth="yes"/>
-      <point x="3107.0" y="427.0"/>
-      <point x="3144.0" y="392.0"/>
-      <point x="3164.0" y="351.0" type="curve"/>
-      <point x="2882.0" y="226.0" type="line"/>
-      <point x="2895.0" y="152.0" type="line"/>
-      <point x="3284.0" y="316.0" type="line"/>
-      <point x="3273.0" y="344.0" type="line" smooth="yes"/>
-      <point x="3249.0" y="406.0"/>
-      <point x="3186.0" y="512.0"/>
-      <point x="3052.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="2919.0" y="512.0"/>
-      <point x="2809.0" y="405.0"/>
-      <point x="2809.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="2809.0" y="100.0"/>
-      <point x="2918.0" y="-16.0"/>
-      <point x="3065.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="3183.0" y="-16.0"/>
-      <point x="3251.0" y="58.0"/>
-      <point x="3279.0" y="101.0" type="curve"/>
-      <point x="3209.0" y="153.0" type="line"/>
-      <point x="3177.0" y="106.0"/>
-      <point x="3131.0" y="77.0"/>
-      <point x="3067.0" y="77.0" type="curve" smooth="yes"/>
-      <point x="2983.0" y="77.0"/>
-      <point x="2901.0" y="130.0"/>
+      <point x="2911.0" y="256" type="curve" smooth="yes"/>
+      <point x="2911" y="364"/>
+      <point x="2991" y="410"/>
+      <point x="3050" y="410" type="curve" smooth="yes"/>
+      <point x="3096" y="410"/>
+      <point x="3135" y="387"/>
+      <point x="3148" y="354" type="curve"/>
+      <point x="2864" y="236" type="line"/>
+      <point x="2883" y="148" type="line"/>
+      <point x="3284" y="314" type="line"/>
+      <point x="3272" y="344" type="line" smooth="yes"/>
+      <point x="3250" y="403"/>
+      <point x="3183" y="512"/>
+      <point x="3046" y="512" type="curve" smooth="yes"/>
+      <point x="2910" y="512"/>
+      <point x="2797" y="405"/>
+      <point x="2797" y="248" type="curve" smooth="yes"/>
+      <point x="2797" y="100"/>
+      <point x="2909" y="-16"/>
+      <point x="3059" y="-16" type="curve" smooth="yes"/>
+      <point x="3180" y="-16"/>
+      <point x="3250" y="58"/>
+      <point x="3279" y="101" type="curve"/>
+      <point x="3189" y="161" type="line"/>
+      <point x="3159" y="117"/>
+      <point x="3118" y="88"/>
+      <point x="3059" y="88" type="curve" smooth="yes"/>
+      <point x="2976.0" y="88.0"/>
+      <point x="2911.0" y="152.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -3,35 +3,35 @@
   <advance width="514"/>
   <outline>
     <contour>
-      <point x="128.0" y="255.0" type="curve" smooth="yes"/>
-      <point x="128.0" y="366.0"/>
-      <point x="201.0" y="427.0"/>
-      <point x="275.0" y="427.0" type="curve" smooth="yes"/>
-      <point x="333.0" y="427.0"/>
-      <point x="370.0" y="392.0"/>
-      <point x="390.0" y="351.0" type="curve"/>
-      <point x="96.0" y="222.0" type="line"/>
-      <point x="117.0" y="152.0" type="line"/>
-      <point x="510.0" y="316.0" type="line"/>
-      <point x="499.0" y="344.0" type="line" smooth="yes"/>
-      <point x="475.0" y="406.0"/>
-      <point x="412.0" y="512.0"/>
-      <point x="278.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="145.0" y="512.0"/>
-      <point x="35.0" y="405.0"/>
-      <point x="35.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="35.0" y="100.0"/>
-      <point x="144.0" y="-16.0"/>
-      <point x="291.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="409.0" y="-16.0"/>
-      <point x="477.0" y="58.0"/>
-      <point x="505.0" y="101.0" type="curve"/>
-      <point x="435.0" y="153.0" type="line"/>
-      <point x="403.0" y="106.0"/>
-      <point x="357.0" y="78.0"/>
-      <point x="293.0" y="77.0" type="curve" smooth="yes"/>
-      <point x="191.0" y="76.0"/>
-      <point x="128.0" y="161.0"/>
+      <point x="141.0" y="255" type="curve" smooth="yes"/>
+      <point x="141" y="358"/>
+      <point x="214" y="410"/>
+      <point x="280" y="410" type="curve" smooth="yes"/>
+      <point x="326" y="410"/>
+      <point x="365" y="387"/>
+      <point x="378" y="354" type="curve"/>
+      <point x="93" y="236" type="line"/>
+      <point x="112" y="148" type="line"/>
+      <point x="514" y="314" type="line"/>
+      <point x="502" y="344" type="line" smooth="yes"/>
+      <point x="480" y="403"/>
+      <point x="413" y="512"/>
+      <point x="276" y="512" type="curve" smooth="yes"/>
+      <point x="140" y="512"/>
+      <point x="27" y="405"/>
+      <point x="27" y="248" type="curve" smooth="yes"/>
+      <point x="27" y="100"/>
+      <point x="139" y="-16"/>
+      <point x="289" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="480" y="58"/>
+      <point x="509" y="101" type="curve"/>
+      <point x="419" y="161" type="line"/>
+      <point x="389" y="117"/>
+      <point x="348" y="89"/>
+      <point x="289" y="88" type="curve" smooth="yes"/>
+      <point x="196.0" y="87.0"/>
+      <point x="141" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -3,51 +3,51 @@
   <advance width="566"/>
   <outline>
     <contour>
-      <point x="277.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="413.0" y="-253.0"/>
-      <point x="521.0" y="-173.0"/>
-      <point x="521.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="521.0" y="496.0" type="line"/>
-      <point x="426.0" y="496.0" type="line"/>
-      <point x="426.0" y="445.0" type="line"/>
-      <point x="422.0" y="445.0" type="line"/>
-      <point x="402.0" y="469.0"/>
-      <point x="351.0" y="512.0"/>
-      <point x="278.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="153.0" y="512.0"/>
-      <point x="31.0" y="406.0"/>
-      <point x="31.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="31.0" y="86.0"/>
-      <point x="153.0" y="-12.0"/>
-      <point x="276.0" y="-12.0" type="curve" smooth="yes"/>
-      <point x="343.0" y="-12.0"/>
-      <point x="399.0" y="29.0"/>
-      <point x="422.0" y="58.0" type="curve"/>
-      <point x="426.0" y="58.0" type="line"/>
-      <point x="426.0" y="-11.0" type="line" smooth="yes"/>
-      <point x="426.0" y="-112.0"/>
-      <point x="373.0" y="-170.0"/>
-      <point x="286.0" y="-170.0" type="curve" smooth="yes"/>
-      <point x="199.0" y="-170.0"/>
-      <point x="149.0" y="-108.0"/>
-      <point x="131.0" y="-60.0" type="curve"/>
-      <point x="43.0" y="-97.0" type="line"/>
-      <point x="72.0" y="-167.0"/>
-      <point x="149.0" y="-253.0"/>
+      <point x="277" y="-253" type="curve" smooth="yes"/>
+      <point x="413" y="-253"/>
+      <point x="528" y="-173"/>
+      <point x="528" y="22" type="curve" smooth="yes"/>
+      <point x="528" y="496" type="line"/>
+      <point x="418" y="496" type="line"/>
+      <point x="418" y="453" type="line"/>
+      <point x="414" y="453" type="line"/>
+      <point x="388" y="484"/>
+      <point x="338" y="512"/>
+      <point x="275" y="512" type="curve" smooth="yes"/>
+      <point x="143" y="512"/>
+      <point x="22" y="396"/>
+      <point x="22" y="247" type="curve" smooth="yes"/>
+      <point x="22" y="99"/>
+      <point x="143" y="-16"/>
+      <point x="275" y="-16" type="curve" smooth="yes"/>
+      <point x="338" y="-16"/>
+      <point x="388" y="12"/>
+      <point x="414" y="44" type="curve"/>
+      <point x="418" y="44" type="line"/>
+      <point x="418" y="6" type="line" smooth="yes"/>
+      <point x="418" y="-95"/>
+      <point x="364" y="-149"/>
+      <point x="277" y="-149" type="curve" smooth="yes"/>
+      <point x="206" y="-149"/>
+      <point x="162" y="-98"/>
+      <point x="144" y="-55" type="curve"/>
+      <point x="43" y="-97" type="line"/>
+      <point x="72" y="-167"/>
+      <point x="149" y="-253"/>
     </contour>
     <contour>
-      <point x="284.0" y="71.0" type="curve" smooth="yes"/>
-      <point x="195.0" y="71.0"/>
-      <point x="125.0" y="145.0"/>
-      <point x="125.0" y="246.0" type="curve" smooth="yes"/>
-      <point x="125.0" y="348.0"/>
-      <point x="195.0" y="423.0"/>
-      <point x="279.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="372.0" y="423.0"/>
-      <point x="431.0" y="353.0"/>
-      <point x="431.0" y="246.0" type="curve" smooth="yes"/>
-      <point x="431.0" y="139.0"/>
-      <point x="372.0" y="71.0"/>
+      <point x="285" y="88" type="curve" smooth="yes"/>
+      <point x="205" y="88"/>
+      <point x="138" y="155"/>
+      <point x="138" y="247" type="curve" smooth="yes"/>
+      <point x="138" y="340"/>
+      <point x="205" y="408"/>
+      <point x="285" y="408" type="curve" smooth="yes"/>
+      <point x="364" y="408"/>
+      <point x="426" y="340"/>
+      <point x="426" y="247" type="curve" smooth="yes"/>
+      <point x="426" y="155"/>
+      <point x="364" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -3,10 +3,10 @@
   <advance width="187"/>
   <outline>
     <contour>
-      <point x="52.0" y="0.0" type="line"/>
-      <point x="148.0" y="0.0" type="line"/>
-      <point x="148.0" y="776.0" type="line"/>
-      <point x="52.0" y="776.0" type="line"/>
+      <point x="42" y="0" type="line"/>
+      <point x="158" y="0" type="line"/>
+      <point x="158" y="776" type="line"/>
+      <point x="42" y="776" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -3,32 +3,32 @@
   <advance width="578"/>
   <outline>
     <contour>
-      <point x="287.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="429.0" y="-16.0"/>
-      <point x="544.0" y="96.0"/>
-      <point x="544.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="544.0" y="401.0"/>
-      <point x="429.0" y="512.0"/>
-      <point x="287.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="145.0" y="512.0"/>
-      <point x="30.0" y="401.0"/>
-      <point x="30.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="96.0"/>
-      <point x="145.0" y="-16.0"/>
+      <point x="287" y="-16" type="curve" smooth="yes"/>
+      <point x="433" y="-16"/>
+      <point x="552" y="96"/>
+      <point x="552" y="248" type="curve" smooth="yes"/>
+      <point x="552" y="401"/>
+      <point x="433" y="512"/>
+      <point x="287" y="512" type="curve" smooth="yes"/>
+      <point x="141" y="512"/>
+      <point x="22" y="401"/>
+      <point x="22" y="248" type="curve" smooth="yes"/>
+      <point x="22" y="96"/>
+      <point x="141" y="-16"/>
     </contour>
     <contour>
-      <point x="287.0" y="72.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="72.0"/>
-      <point x="125.0" y="144.0"/>
-      <point x="125.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="125.0" y="352.0"/>
-      <point x="200.0" y="423.0"/>
-      <point x="287.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="373.0" y="423.0"/>
-      <point x="449.0" y="352.0"/>
-      <point x="449.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="449.0" y="144.0"/>
-      <point x="373.0" y="72.0"/>
+      <point x="287" y="88" type="curve" smooth="yes"/>
+      <point x="207" y="88"/>
+      <point x="138" y="154"/>
+      <point x="138" y="248" type="curve" smooth="yes"/>
+      <point x="138" y="343"/>
+      <point x="207" y="408"/>
+      <point x="287" y="408" type="curve" smooth="yes"/>
+      <point x="367" y="408"/>
+      <point x="436" y="343"/>
+      <point x="436" y="248" type="curve" smooth="yes"/>
+      <point x="436" y="154"/>
+      <point x="367" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -3,43 +3,43 @@
   <advance width="861"/>
   <outline>
     <contour>
-      <point x="460.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="582.0" y="-16.0"/>
-      <point x="674.0" y="24.0"/>
-      <point x="746.0" y="99.0" type="curve"/>
-      <point x="820.0" y="173.0"/>
-      <point x="843.0" y="277.0"/>
-      <point x="843.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="843.0" y="387.0"/>
-      <point x="841.0" y="411.0"/>
-      <point x="837.0" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="319.0" type="line"/>
-      <point x="728.0" y="319.0" type="line"/>
-      <point x="720.0" y="256.0"/>
-      <point x="699.0" y="210.0"/>
-      <point x="667.0" y="178.0" type="curve" smooth="yes"/>
-      <point x="628.0" y="139.0"/>
-      <point x="567.0" y="96.0"/>
-      <point x="460.0" y="96.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="96.0"/>
-      <point x="166.0" y="229.0"/>
-      <point x="166.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="166.0" y="559.0"/>
-      <point x="295.0" y="692.0"/>
-      <point x="460.0" y="692.0" type="curve" smooth="yes"/>
-      <point x="549.0" y="692.0"/>
-      <point x="614.0" y="657.0"/>
-      <point x="662.0" y="612.0" type="curve"/>
-      <point x="741.0" y="691.0" type="line"/>
-      <point x="674.0" y="755.0"/>
-      <point x="585.0" y="804.0"/>
-      <point x="460.0" y="804.0" type="curve" smooth="yes"/>
-      <point x="234.0" y="804.0"/>
-      <point x="44.0" y="620.0"/>
-      <point x="44.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="44.0" y="168.0"/>
-      <point x="234.0" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -3,37 +3,37 @@
   <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499.0" y="-41.0" type="curve" smooth="yes"/>
-      <point x="739.0" y="-41.0"/>
-      <point x="898.0" y="128.0"/>
-      <point x="898.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="898.0" y="395.0"/>
-      <point x="896.0" y="423.0"/>
-      <point x="891.0" y="451.0" type="curve"/>
-      <point x="499.0" y="451.0" type="line"/>
-      <point x="499.0" y="290.0" type="line"/>
-      <point x="723.0" y="290.0" type="line"/>
-      <point x="705.0" y="194.0"/>
-      <point x="621.0" y="124.0"/>
-      <point x="499.0" y="124.0" type="curve" smooth="yes"/>
-      <point x="363.0" y="124.0"/>
-      <point x="253.0" y="239.0"/>
-      <point x="253.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="511.0"/>
-      <point x="363.0" y="625.0"/>
-      <point x="499.0" y="625.0" type="curve" smooth="yes"/>
-      <point x="560.0" y="625.0"/>
-      <point x="615.0" y="604.0"/>
-      <point x="658.0" y="563.0" type="curve"/>
-      <point x="777.0" y="683.0" type="line"/>
-      <point x="705.0" y="750.0"/>
-      <point x="611.0" y="791.0"/>
-      <point x="499.0" y="791.0" type="curve" smooth="yes"/>
-      <point x="269.0" y="791.0"/>
-      <point x="83.0" y="605.0"/>
-      <point x="83.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="83.0" y="145.0"/>
-      <point x="269.0" y="-41.0"/>
+      <point x="499" y="-41" type="curve" smooth="yes"/>
+      <point x="739" y="-41"/>
+      <point x="898" y="128"/>
+      <point x="898" y="365" type="curve" smooth="yes"/>
+      <point x="898" y="395"/>
+      <point x="896" y="423"/>
+      <point x="891" y="451" type="curve"/>
+      <point x="499" y="451" type="line"/>
+      <point x="499" y="290" type="line"/>
+      <point x="723" y="290" type="line"/>
+      <point x="705" y="194"/>
+      <point x="621" y="124"/>
+      <point x="499" y="124" type="curve" smooth="yes"/>
+      <point x="363" y="124"/>
+      <point x="253" y="239"/>
+      <point x="253" y="375" type="curve" smooth="yes"/>
+      <point x="253" y="511"/>
+      <point x="363" y="625"/>
+      <point x="499" y="625" type="curve" smooth="yes"/>
+      <point x="560" y="625"/>
+      <point x="615" y="604"/>
+      <point x="658" y="563" type="curve"/>
+      <point x="777" y="683" type="line"/>
+      <point x="705" y="750"/>
+      <point x="611" y="791"/>
+      <point x="499" y="791" type="curve" smooth="yes"/>
+      <point x="269" y="791"/>
+      <point x="83" y="605"/>
+      <point x="83" y="375" type="curve" smooth="yes"/>
+      <point x="83" y="145"/>
+      <point x="269" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
@@ -3,181 +3,181 @@
   <advance width="3284"/>
   <outline>
     <contour>
-      <point x="460.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="582.0" y="-16.0"/>
-      <point x="674.0" y="24.0"/>
-      <point x="746.0" y="99.0" type="curve"/>
-      <point x="820.0" y="173.0"/>
-      <point x="843.0" y="277.0"/>
-      <point x="843.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="843.0" y="387.0"/>
-      <point x="841.0" y="411.0"/>
-      <point x="837.0" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="319.0" type="line"/>
-      <point x="728.0" y="319.0" type="line"/>
-      <point x="720.0" y="256.0"/>
-      <point x="699.0" y="210.0"/>
-      <point x="667.0" y="178.0" type="curve" smooth="yes"/>
-      <point x="628.0" y="139.0"/>
-      <point x="567.0" y="96.0"/>
-      <point x="460.0" y="96.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="96.0"/>
-      <point x="166.0" y="229.0"/>
-      <point x="166.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="166.0" y="559.0"/>
-      <point x="295.0" y="692.0"/>
-      <point x="460.0" y="692.0" type="curve" smooth="yes"/>
-      <point x="549.0" y="692.0"/>
-      <point x="614.0" y="657.0"/>
-      <point x="662.0" y="612.0" type="curve"/>
-      <point x="741.0" y="691.0" type="line"/>
-      <point x="674.0" y="755.0"/>
-      <point x="585.0" y="804.0"/>
-      <point x="460.0" y="804.0" type="curve" smooth="yes"/>
-      <point x="234.0" y="804.0"/>
-      <point x="44.0" y="620.0"/>
-      <point x="44.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="44.0" y="168.0"/>
-      <point x="234.0" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
     <contour>
-      <point x="1148.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="1294.0" y="-16.0"/>
-      <point x="1413.0" y="96.0"/>
-      <point x="1413.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1413.0" y="401.0"/>
-      <point x="1294.0" y="512.0"/>
-      <point x="1148.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="1002.0" y="512.0"/>
-      <point x="883.0" y="401.0"/>
-      <point x="883.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="883.0" y="96.0"/>
-      <point x="1002.0" y="-16.0"/>
+      <point x="1148" y="-16" type="curve" smooth="yes"/>
+      <point x="1294" y="-16"/>
+      <point x="1413" y="96"/>
+      <point x="1413" y="248" type="curve" smooth="yes"/>
+      <point x="1413" y="401"/>
+      <point x="1294" y="512"/>
+      <point x="1148" y="512" type="curve" smooth="yes"/>
+      <point x="1002" y="512"/>
+      <point x="883" y="401"/>
+      <point x="883" y="248" type="curve" smooth="yes"/>
+      <point x="883" y="96"/>
+      <point x="1002" y="-16"/>
     </contour>
     <contour>
-      <point x="1148.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="1068.0" y="88.0"/>
-      <point x="999.0" y="154.0"/>
-      <point x="999.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="999.0" y="343.0"/>
-      <point x="1068.0" y="408.0"/>
-      <point x="1148.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="1228.0" y="408.0"/>
-      <point x="1297.0" y="343.0"/>
-      <point x="1297.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1297.0" y="154.0"/>
-      <point x="1228.0" y="88.0"/>
+      <point x="1148" y="88" type="curve" smooth="yes"/>
+      <point x="1068" y="88"/>
+      <point x="999" y="154"/>
+      <point x="999" y="248" type="curve" smooth="yes"/>
+      <point x="999" y="343"/>
+      <point x="1068" y="408"/>
+      <point x="1148" y="408" type="curve" smooth="yes"/>
+      <point x="1228" y="408"/>
+      <point x="1297" y="343"/>
+      <point x="1297" y="248" type="curve" smooth="yes"/>
+      <point x="1297" y="154"/>
+      <point x="1228" y="88"/>
     </contour>
     <contour>
-      <point x="1726.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="1872.0" y="-16.0"/>
-      <point x="1991.0" y="96.0"/>
-      <point x="1991.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1991.0" y="401.0"/>
-      <point x="1872.0" y="512.0"/>
-      <point x="1726.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="1580.0" y="512.0"/>
-      <point x="1461.0" y="401.0"/>
-      <point x="1461.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1461.0" y="96.0"/>
-      <point x="1580.0" y="-16.0"/>
+      <point x="1726" y="-16" type="curve" smooth="yes"/>
+      <point x="1872" y="-16"/>
+      <point x="1991" y="96"/>
+      <point x="1991" y="248" type="curve" smooth="yes"/>
+      <point x="1991" y="401"/>
+      <point x="1872" y="512"/>
+      <point x="1726" y="512" type="curve" smooth="yes"/>
+      <point x="1580" y="512"/>
+      <point x="1461" y="401"/>
+      <point x="1461" y="248" type="curve" smooth="yes"/>
+      <point x="1461" y="96"/>
+      <point x="1580" y="-16"/>
     </contour>
     <contour>
-      <point x="1726.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="1646.0" y="88.0"/>
-      <point x="1577.0" y="154.0"/>
-      <point x="1577.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1577.0" y="343.0"/>
-      <point x="1646.0" y="408.0"/>
-      <point x="1726.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="1806.0" y="408.0"/>
-      <point x="1875.0" y="343.0"/>
-      <point x="1875.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="1875.0" y="154.0"/>
-      <point x="1806.0" y="88.0"/>
+      <point x="1726" y="88" type="curve" smooth="yes"/>
+      <point x="1646" y="88"/>
+      <point x="1577" y="154"/>
+      <point x="1577" y="248" type="curve" smooth="yes"/>
+      <point x="1577" y="343"/>
+      <point x="1646" y="408"/>
+      <point x="1726" y="408" type="curve" smooth="yes"/>
+      <point x="1806" y="408"/>
+      <point x="1875" y="343"/>
+      <point x="1875" y="248" type="curve" smooth="yes"/>
+      <point x="1875" y="154"/>
+      <point x="1806" y="88"/>
     </contour>
     <contour>
-      <point x="2294.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="2430.0" y="-253.0"/>
-      <point x="2545.0" y="-173.0"/>
-      <point x="2545.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="2545.0" y="496.0" type="line"/>
-      <point x="2435.0" y="496.0" type="line"/>
-      <point x="2435.0" y="453.0" type="line"/>
-      <point x="2431.0" y="453.0" type="line"/>
-      <point x="2405.0" y="484.0"/>
-      <point x="2355.0" y="512.0"/>
-      <point x="2292.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="2160.0" y="512.0"/>
-      <point x="2039.0" y="396.0"/>
-      <point x="2039.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="2039.0" y="99.0"/>
-      <point x="2160.0" y="-16.0"/>
-      <point x="2292.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="2355.0" y="-16.0"/>
-      <point x="2405.0" y="12.0"/>
-      <point x="2431.0" y="44.0" type="curve"/>
-      <point x="2435.0" y="44.0" type="line"/>
-      <point x="2435.0" y="6.0" type="line" smooth="yes"/>
-      <point x="2435.0" y="-95.0"/>
-      <point x="2381.0" y="-149.0"/>
-      <point x="2294.0" y="-149.0" type="curve" smooth="yes"/>
-      <point x="2223.0" y="-149.0"/>
-      <point x="2179.0" y="-98.0"/>
-      <point x="2161.0" y="-55.0" type="curve"/>
-      <point x="2060.0" y="-97.0" type="line"/>
-      <point x="2089.0" y="-167.0"/>
-      <point x="2166.0" y="-253.0"/>
+      <point x="2294" y="-253" type="curve" smooth="yes"/>
+      <point x="2430" y="-253"/>
+      <point x="2545" y="-173"/>
+      <point x="2545" y="22" type="curve" smooth="yes"/>
+      <point x="2545" y="496" type="line"/>
+      <point x="2435" y="496" type="line"/>
+      <point x="2435" y="453" type="line"/>
+      <point x="2431" y="453" type="line"/>
+      <point x="2405" y="484"/>
+      <point x="2355" y="512"/>
+      <point x="2292" y="512" type="curve" smooth="yes"/>
+      <point x="2160" y="512"/>
+      <point x="2039" y="396"/>
+      <point x="2039" y="247" type="curve" smooth="yes"/>
+      <point x="2039" y="99"/>
+      <point x="2160" y="-16"/>
+      <point x="2292" y="-16" type="curve" smooth="yes"/>
+      <point x="2355" y="-16"/>
+      <point x="2405" y="12"/>
+      <point x="2431" y="44" type="curve"/>
+      <point x="2435" y="44" type="line"/>
+      <point x="2435" y="6" type="line" smooth="yes"/>
+      <point x="2435" y="-95"/>
+      <point x="2381" y="-149"/>
+      <point x="2294" y="-149" type="curve" smooth="yes"/>
+      <point x="2223" y="-149"/>
+      <point x="2179" y="-98"/>
+      <point x="2161" y="-55" type="curve"/>
+      <point x="2060" y="-97" type="line"/>
+      <point x="2089" y="-167"/>
+      <point x="2166" y="-253"/>
     </contour>
     <contour>
-      <point x="2302.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="2222.0" y="88.0"/>
-      <point x="2155.0" y="155.0"/>
-      <point x="2155.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="2155.0" y="340.0"/>
-      <point x="2222.0" y="408.0"/>
-      <point x="2302.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="2381.0" y="408.0"/>
-      <point x="2443.0" y="340.0"/>
-      <point x="2443.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="2443.0" y="155.0"/>
-      <point x="2381.0" y="88.0"/>
+      <point x="2302" y="88" type="curve" smooth="yes"/>
+      <point x="2222" y="88"/>
+      <point x="2155" y="155"/>
+      <point x="2155" y="247" type="curve" smooth="yes"/>
+      <point x="2155" y="340"/>
+      <point x="2222" y="408"/>
+      <point x="2302" y="408" type="curve" smooth="yes"/>
+      <point x="2381" y="408"/>
+      <point x="2443" y="340"/>
+      <point x="2443" y="247" type="curve" smooth="yes"/>
+      <point x="2443" y="155"/>
+      <point x="2381" y="88"/>
     </contour>
     <contour>
-      <point x="2625.0" y="0.0" type="line"/>
-      <point x="2741.0" y="0.0" type="line"/>
-      <point x="2741.0" y="776.0" type="line"/>
-      <point x="2625.0" y="776.0" type="line"/>
+      <point x="2625" y="0" type="line"/>
+      <point x="2741" y="0" type="line"/>
+      <point x="2741" y="776" type="line"/>
+      <point x="2625" y="776" type="line"/>
     </contour>
     <contour>
-      <point x="2911.0" y="256.0" type="curve" smooth="yes"/>
-      <point x="2911.0" y="364.0"/>
-      <point x="2991.0" y="410.0"/>
-      <point x="3050.0" y="410.0" type="curve" smooth="yes"/>
-      <point x="3096.0" y="410.0"/>
-      <point x="3135.0" y="387.0"/>
-      <point x="3148.0" y="354.0" type="curve"/>
-      <point x="2864.0" y="236.0" type="line"/>
-      <point x="2883.0" y="148.0" type="line"/>
-      <point x="3284.0" y="314.0" type="line"/>
-      <point x="3272.0" y="344.0" type="line" smooth="yes"/>
-      <point x="3250.0" y="403.0"/>
-      <point x="3183.0" y="512.0"/>
-      <point x="3046.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="2910.0" y="512.0"/>
-      <point x="2797.0" y="405.0"/>
-      <point x="2797.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="2797.0" y="100.0"/>
-      <point x="2909.0" y="-16.0"/>
-      <point x="3059.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="3180.0" y="-16.0"/>
-      <point x="3250.0" y="58.0"/>
-      <point x="3279.0" y="101.0" type="curve"/>
-      <point x="3189.0" y="161.0" type="line"/>
-      <point x="3159.0" y="117.0"/>
-      <point x="3118.0" y="88.0"/>
-      <point x="3059.0" y="88.0" type="curve" smooth="yes"/>
+      <point x="2911.0" y="256" type="curve" smooth="yes"/>
+      <point x="2911" y="364"/>
+      <point x="2991" y="410"/>
+      <point x="3050" y="410" type="curve" smooth="yes"/>
+      <point x="3096" y="410"/>
+      <point x="3135" y="387"/>
+      <point x="3148" y="354" type="curve"/>
+      <point x="2864" y="236" type="line"/>
+      <point x="2883" y="148" type="line"/>
+      <point x="3284" y="314" type="line"/>
+      <point x="3272" y="344" type="line" smooth="yes"/>
+      <point x="3250" y="403"/>
+      <point x="3183" y="512"/>
+      <point x="3046" y="512" type="curve" smooth="yes"/>
+      <point x="2910" y="512"/>
+      <point x="2797" y="405"/>
+      <point x="2797" y="248" type="curve" smooth="yes"/>
+      <point x="2797" y="100"/>
+      <point x="2909" y="-16"/>
+      <point x="3059" y="-16" type="curve" smooth="yes"/>
+      <point x="3180" y="-16"/>
+      <point x="3250" y="58"/>
+      <point x="3279" y="101" type="curve"/>
+      <point x="3189" y="161" type="line"/>
+      <point x="3159" y="117"/>
+      <point x="3118" y="88"/>
+      <point x="3059" y="88" type="curve" smooth="yes"/>
       <point x="2976.0" y="88.0"/>
       <point x="2911.0" y="152.0"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -3,35 +3,35 @@
   <advance width="514"/>
   <outline>
     <contour>
-      <point x="141.0" y="255.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="358.0"/>
-      <point x="214.0" y="410.0"/>
-      <point x="280.0" y="410.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="410.0"/>
-      <point x="365.0" y="387.0"/>
-      <point x="378.0" y="354.0" type="curve"/>
-      <point x="93.0" y="236.0" type="line"/>
-      <point x="112.0" y="148.0" type="line"/>
-      <point x="514.0" y="314.0" type="line"/>
-      <point x="502.0" y="344.0" type="line" smooth="yes"/>
-      <point x="480.0" y="403.0"/>
-      <point x="413.0" y="512.0"/>
-      <point x="276.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="140.0" y="512.0"/>
-      <point x="27.0" y="405.0"/>
-      <point x="27.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="27.0" y="100.0"/>
-      <point x="139.0" y="-16.0"/>
-      <point x="289.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="410.0" y="-16.0"/>
-      <point x="480.0" y="58.0"/>
-      <point x="509.0" y="101.0" type="curve"/>
-      <point x="419.0" y="161.0" type="line"/>
-      <point x="389.0" y="117.0"/>
-      <point x="348.0" y="89.0"/>
-      <point x="289.0" y="88.0" type="curve" smooth="yes"/>
+      <point x="141.0" y="255" type="curve" smooth="yes"/>
+      <point x="141" y="358"/>
+      <point x="214" y="410"/>
+      <point x="280" y="410" type="curve" smooth="yes"/>
+      <point x="326" y="410"/>
+      <point x="365" y="387"/>
+      <point x="378" y="354" type="curve"/>
+      <point x="93" y="236" type="line"/>
+      <point x="112" y="148" type="line"/>
+      <point x="514" y="314" type="line"/>
+      <point x="502" y="344" type="line" smooth="yes"/>
+      <point x="480" y="403"/>
+      <point x="413" y="512"/>
+      <point x="276" y="512" type="curve" smooth="yes"/>
+      <point x="140" y="512"/>
+      <point x="27" y="405"/>
+      <point x="27" y="248" type="curve" smooth="yes"/>
+      <point x="27" y="100"/>
+      <point x="139" y="-16"/>
+      <point x="289" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="480" y="58"/>
+      <point x="509" y="101" type="curve"/>
+      <point x="419" y="161" type="line"/>
+      <point x="389" y="117"/>
+      <point x="348" y="89"/>
+      <point x="289" y="88" type="curve" smooth="yes"/>
       <point x="196.0" y="87.0"/>
-      <point x="141.0" y="169.0"/>
+      <point x="141" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -3,51 +3,51 @@
   <advance width="566"/>
   <outline>
     <contour>
-      <point x="277.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="413.0" y="-253.0"/>
-      <point x="528.0" y="-173.0"/>
-      <point x="528.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="528.0" y="496.0" type="line"/>
-      <point x="418.0" y="496.0" type="line"/>
-      <point x="418.0" y="453.0" type="line"/>
-      <point x="414.0" y="453.0" type="line"/>
-      <point x="388.0" y="484.0"/>
-      <point x="338.0" y="512.0"/>
-      <point x="275.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="512.0"/>
-      <point x="22.0" y="396.0"/>
-      <point x="22.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="22.0" y="99.0"/>
-      <point x="143.0" y="-16.0"/>
-      <point x="275.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="-16.0"/>
-      <point x="388.0" y="12.0"/>
-      <point x="414.0" y="44.0" type="curve"/>
-      <point x="418.0" y="44.0" type="line"/>
-      <point x="418.0" y="6.0" type="line" smooth="yes"/>
-      <point x="418.0" y="-95.0"/>
-      <point x="364.0" y="-149.0"/>
-      <point x="277.0" y="-149.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="-149.0"/>
-      <point x="162.0" y="-98.0"/>
-      <point x="144.0" y="-55.0" type="curve"/>
-      <point x="43.0" y="-97.0" type="line"/>
-      <point x="72.0" y="-167.0"/>
-      <point x="149.0" y="-253.0"/>
+      <point x="277" y="-253" type="curve" smooth="yes"/>
+      <point x="413" y="-253"/>
+      <point x="528" y="-173"/>
+      <point x="528" y="22" type="curve" smooth="yes"/>
+      <point x="528" y="496" type="line"/>
+      <point x="418" y="496" type="line"/>
+      <point x="418" y="453" type="line"/>
+      <point x="414" y="453" type="line"/>
+      <point x="388" y="484"/>
+      <point x="338" y="512"/>
+      <point x="275" y="512" type="curve" smooth="yes"/>
+      <point x="143" y="512"/>
+      <point x="22" y="396"/>
+      <point x="22" y="247" type="curve" smooth="yes"/>
+      <point x="22" y="99"/>
+      <point x="143" y="-16"/>
+      <point x="275" y="-16" type="curve" smooth="yes"/>
+      <point x="338" y="-16"/>
+      <point x="388" y="12"/>
+      <point x="414" y="44" type="curve"/>
+      <point x="418" y="44" type="line"/>
+      <point x="418" y="6" type="line" smooth="yes"/>
+      <point x="418" y="-95"/>
+      <point x="364" y="-149"/>
+      <point x="277" y="-149" type="curve" smooth="yes"/>
+      <point x="206" y="-149"/>
+      <point x="162" y="-98"/>
+      <point x="144" y="-55" type="curve"/>
+      <point x="43" y="-97" type="line"/>
+      <point x="72" y="-167"/>
+      <point x="149" y="-253"/>
     </contour>
     <contour>
-      <point x="285.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="205.0" y="88.0"/>
-      <point x="138.0" y="155.0"/>
-      <point x="138.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="340.0"/>
-      <point x="205.0" y="408.0"/>
-      <point x="285.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="364.0" y="408.0"/>
-      <point x="426.0" y="340.0"/>
-      <point x="426.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="426.0" y="155.0"/>
-      <point x="364.0" y="88.0"/>
+      <point x="285" y="88" type="curve" smooth="yes"/>
+      <point x="205" y="88"/>
+      <point x="138" y="155"/>
+      <point x="138" y="247" type="curve" smooth="yes"/>
+      <point x="138" y="340"/>
+      <point x="205" y="408"/>
+      <point x="285" y="408" type="curve" smooth="yes"/>
+      <point x="364" y="408"/>
+      <point x="426" y="340"/>
+      <point x="426" y="247" type="curve" smooth="yes"/>
+      <point x="426" y="155"/>
+      <point x="364" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -3,10 +3,10 @@
   <advance width="187"/>
   <outline>
     <contour>
-      <point x="42.0" y="0.0" type="line"/>
-      <point x="158.0" y="0.0" type="line"/>
-      <point x="158.0" y="776.0" type="line"/>
-      <point x="42.0" y="776.0" type="line"/>
+      <point x="42" y="0" type="line"/>
+      <point x="158" y="0" type="line"/>
+      <point x="158" y="776" type="line"/>
+      <point x="42" y="776" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -3,32 +3,32 @@
   <advance width="578"/>
   <outline>
     <contour>
-      <point x="287.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="433.0" y="-16.0"/>
-      <point x="552.0" y="96.0"/>
-      <point x="552.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="552.0" y="401.0"/>
-      <point x="433.0" y="512.0"/>
-      <point x="287.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="512.0"/>
-      <point x="22.0" y="401.0"/>
-      <point x="22.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="22.0" y="96.0"/>
-      <point x="141.0" y="-16.0"/>
+      <point x="287" y="-16" type="curve" smooth="yes"/>
+      <point x="433" y="-16"/>
+      <point x="552" y="96"/>
+      <point x="552" y="248" type="curve" smooth="yes"/>
+      <point x="552" y="401"/>
+      <point x="433" y="512"/>
+      <point x="287" y="512" type="curve" smooth="yes"/>
+      <point x="141" y="512"/>
+      <point x="22" y="401"/>
+      <point x="22" y="248" type="curve" smooth="yes"/>
+      <point x="22" y="96"/>
+      <point x="141" y="-16"/>
     </contour>
     <contour>
-      <point x="287.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="207.0" y="88.0"/>
-      <point x="138.0" y="154.0"/>
-      <point x="138.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="343.0"/>
-      <point x="207.0" y="408.0"/>
-      <point x="287.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="367.0" y="408.0"/>
-      <point x="436.0" y="343.0"/>
-      <point x="436.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="436.0" y="154.0"/>
-      <point x="367.0" y="88.0"/>
+      <point x="287" y="88" type="curve" smooth="yes"/>
+      <point x="207" y="88"/>
+      <point x="138" y="154"/>
+      <point x="138" y="248" type="curve" smooth="yes"/>
+      <point x="138" y="343"/>
+      <point x="207" y="408"/>
+      <point x="287" y="408" type="curve" smooth="yes"/>
+      <point x="367" y="408"/>
+      <point x="436" y="343"/>
+      <point x="436" y="248" type="curve" smooth="yes"/>
+      <point x="436" y="154"/>
+      <point x="367" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -3,43 +3,43 @@
   <advance width="861"/>
   <outline>
     <contour>
-      <point x="460" y="-16.0" type="curve" smooth="yes"/>
-      <point x="580" y="-16.0"/>
-      <point x="670" y="25"/>
-      <point x="742" y="99.0" type="curve" smooth="yes"/>
-      <point x="814" y="174"/>
-      <point x="836" y="277.0"/>
-      <point x="836" y="361.0" type="curve" smooth="yes"/>
-      <point x="836" y="387.0"/>
-      <point x="834" y="411.0"/>
-      <point x="830" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="339.0" type="line"/>
-      <point x="739" y="339.0" type="line"/>
-      <point x="738" y="275.0"/>
-      <point x="715" y="204"/>
-      <point x="670" y="159" type="curve" smooth="yes"/>
-      <point x="625" y="114"/>
-      <point x="564.0" y="72.0"/>
-      <point x="458" y="72.0" type="curve" smooth="yes"/>
-      <point x="285" y="72"/>
-      <point x="151" y="217.0"/>
-      <point x="151" y="391.0" type="curve" smooth="yes"/>
-      <point x="151" y="566.0"/>
-      <point x="285" y="709.0"/>
-      <point x="458" y="709.0" type="curve" smooth="yes"/>
-      <point x="551" y="709.0"/>
-      <point x="619" y="669.0"/>
-      <point x="669" y="621.0" type="curve"/>
-      <point x="738" y="690.0" type="line"/>
-      <point x="672" y="757.0"/>
-      <point x="582" y="804.0"/>
-      <point x="460" y="804.0" type="curve" smooth="yes"/>
-      <point x="236" y="804.0"/>
-      <point x="49" y="620.0"/>
-      <point x="49" y="394.0" type="curve" smooth="yes"/>
-      <point x="49" y="168.0"/>
-      <point x="236" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -3,37 +3,37 @@
   <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499.0" y="-27" type="curve" smooth="yes"/>
-      <point x="733.0" y="-27"/>
-      <point x="879" y="137"/>
-      <point x="879.0" y="367" type="curve" smooth="yes"/>
-      <point x="879.0" y="390"/>
-      <point x="875.0" y="417"/>
-      <point x="873.0" y="436" type="curve"/>
-      <point x="499.0" y="436.0" type="line"/>
-      <point x="499.0" y="310.0" type="line"/>
-      <point x="752" y="310" type="line"/>
-      <point x="737" y="187"/>
-      <point x="650" y="101"/>
-      <point x="500" y="101" type="curve" smooth="yes"/>
-      <point x="352" y="101"/>
-      <point x="233" y="227"/>
-      <point x="233" y="375" type="curve" smooth="yes"/>
-      <point x="233" y="524"/>
-      <point x="352" y="648"/>
-      <point x="500" y="648" type="curve" smooth="yes"/>
-      <point x="566" y="648"/>
-      <point x="626" y="625"/>
-      <point x="673" y="580" type="curve"/>
-      <point x="770.0" y="675" type="line"/>
-      <point x="700.0" y="740"/>
-      <point x="608.0" y="780"/>
-      <point x="499.0" y="780" type="curve" smooth="yes"/>
-      <point x="274.0" y="780"/>
-      <point x="95.0" y="600"/>
-      <point x="95.0" y="377" type="curve" smooth="yes"/>
-      <point x="95.0" y="154"/>
-      <point x="274.0" y="-27"/>
+      <point x="499" y="-41" type="curve" smooth="yes"/>
+      <point x="739" y="-41"/>
+      <point x="898" y="128"/>
+      <point x="898" y="365" type="curve" smooth="yes"/>
+      <point x="898" y="395"/>
+      <point x="896" y="423"/>
+      <point x="891" y="451" type="curve"/>
+      <point x="499" y="451" type="line"/>
+      <point x="499" y="290" type="line"/>
+      <point x="723" y="290" type="line"/>
+      <point x="705" y="194"/>
+      <point x="621" y="124"/>
+      <point x="499" y="124" type="curve" smooth="yes"/>
+      <point x="363" y="124"/>
+      <point x="253" y="239"/>
+      <point x="253" y="375" type="curve" smooth="yes"/>
+      <point x="253" y="511"/>
+      <point x="363" y="625"/>
+      <point x="499" y="625" type="curve" smooth="yes"/>
+      <point x="560" y="625"/>
+      <point x="615" y="604"/>
+      <point x="658" y="563" type="curve"/>
+      <point x="777" y="683" type="line"/>
+      <point x="705" y="750"/>
+      <point x="611" y="791"/>
+      <point x="499" y="791" type="curve" smooth="yes"/>
+      <point x="269" y="791"/>
+      <point x="83" y="605"/>
+      <point x="83" y="375" type="curve" smooth="yes"/>
+      <point x="83" y="145"/>
+      <point x="269" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -4,182 +4,182 @@
   <outline>
     <contour>
       <point x="460" y="-16" type="curve" smooth="yes"/>
-      <point x="580" y="-16"/>
-      <point x="670" y="25"/>
-      <point x="742" y="99" type="curve" smooth="yes"/>
-      <point x="814" y="174"/>
-      <point x="836" y="277"/>
-      <point x="836" y="361" type="curve" smooth="yes"/>
-      <point x="836" y="387"/>
-      <point x="834" y="411"/>
-      <point x="830" y="431" type="curve"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
       <point x="460" y="431" type="line"/>
-      <point x="460" y="339" type="line"/>
-      <point x="739" y="339" type="line"/>
-      <point x="738" y="275"/>
-      <point x="715" y="204"/>
-      <point x="670" y="159" type="curve" smooth="yes"/>
-      <point x="625" y="114"/>
-      <point x="564" y="77"/>
-      <point x="458" y="77" type="curve" smooth="yes"/>
-      <point x="285" y="77"/>
-      <point x="151" y="217"/>
-      <point x="151" y="391" type="curve" smooth="yes"/>
-      <point x="151" y="566"/>
-      <point x="285" y="706"/>
-      <point x="458" y="706" type="curve" smooth="yes"/>
-      <point x="551" y="706"/>
-      <point x="619" y="669"/>
-      <point x="669" y="621" type="curve"/>
-      <point x="738" y="690" type="line"/>
-      <point x="672" y="757"/>
-      <point x="582" y="804"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
       <point x="460" y="804" type="curve" smooth="yes"/>
-      <point x="236" y="804"/>
-      <point x="49" y="620"/>
-      <point x="49" y="394" type="curve" smooth="yes"/>
-      <point x="49" y="168"/>
-      <point x="236" y="-16"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
     <contour>
-      <point x="1147" y="-16" type="curve" smooth="yes"/>
-      <point x="1289" y="-16"/>
-      <point x="1404" y="96"/>
-      <point x="1404" y="248" type="curve" smooth="yes"/>
-      <point x="1404" y="401"/>
-      <point x="1289" y="512"/>
-      <point x="1147" y="512" type="curve" smooth="yes"/>
-      <point x="1005" y="512"/>
-      <point x="890" y="401"/>
-      <point x="890" y="248" type="curve" smooth="yes"/>
-      <point x="890" y="96"/>
-      <point x="1005" y="-16"/>
+      <point x="1148" y="-16" type="curve" smooth="yes"/>
+      <point x="1294" y="-16"/>
+      <point x="1413" y="96"/>
+      <point x="1413" y="248" type="curve" smooth="yes"/>
+      <point x="1413" y="401"/>
+      <point x="1294" y="512"/>
+      <point x="1148" y="512" type="curve" smooth="yes"/>
+      <point x="1002" y="512"/>
+      <point x="883" y="401"/>
+      <point x="883" y="248" type="curve" smooth="yes"/>
+      <point x="883" y="96"/>
+      <point x="1002" y="-16"/>
     </contour>
     <contour>
-      <point x="1147" y="72" type="curve" smooth="yes"/>
-      <point x="1060" y="72"/>
-      <point x="985" y="144"/>
-      <point x="985" y="247" type="curve" smooth="yes"/>
-      <point x="985" y="352"/>
-      <point x="1060" y="423"/>
-      <point x="1147" y="423" type="curve" smooth="yes"/>
-      <point x="1233" y="423"/>
-      <point x="1309" y="352"/>
-      <point x="1309" y="247" type="curve" smooth="yes"/>
-      <point x="1309" y="144"/>
-      <point x="1233" y="72"/>
+      <point x="1148" y="88" type="curve" smooth="yes"/>
+      <point x="1068" y="88"/>
+      <point x="999" y="154"/>
+      <point x="999" y="248" type="curve" smooth="yes"/>
+      <point x="999" y="343"/>
+      <point x="1068" y="408"/>
+      <point x="1148" y="408" type="curve" smooth="yes"/>
+      <point x="1228" y="408"/>
+      <point x="1297" y="343"/>
+      <point x="1297" y="248" type="curve" smooth="yes"/>
+      <point x="1297" y="154"/>
+      <point x="1228" y="88"/>
     </contour>
     <contour>
-      <point x="1727" y="-16" type="curve" smooth="yes"/>
-      <point x="1869" y="-16"/>
-      <point x="1984" y="96"/>
-      <point x="1984" y="248" type="curve" smooth="yes"/>
-      <point x="1984" y="401"/>
-      <point x="1869" y="512"/>
-      <point x="1727" y="512" type="curve" smooth="yes"/>
-      <point x="1585" y="512"/>
-      <point x="1470" y="401"/>
-      <point x="1470" y="248" type="curve" smooth="yes"/>
-      <point x="1470" y="96"/>
-      <point x="1585" y="-16"/>
+      <point x="1726" y="-16" type="curve" smooth="yes"/>
+      <point x="1872" y="-16"/>
+      <point x="1991" y="96"/>
+      <point x="1991" y="248" type="curve" smooth="yes"/>
+      <point x="1991" y="401"/>
+      <point x="1872" y="512"/>
+      <point x="1726" y="512" type="curve" smooth="yes"/>
+      <point x="1580" y="512"/>
+      <point x="1461" y="401"/>
+      <point x="1461" y="248" type="curve" smooth="yes"/>
+      <point x="1461" y="96"/>
+      <point x="1580" y="-16"/>
     </contour>
     <contour>
-      <point x="1727" y="72" type="curve" smooth="yes"/>
-      <point x="1640" y="72"/>
-      <point x="1565" y="144"/>
-      <point x="1565" y="247" type="curve" smooth="yes"/>
-      <point x="1565" y="352"/>
-      <point x="1640" y="423"/>
-      <point x="1727" y="423" type="curve" smooth="yes"/>
-      <point x="1813" y="423"/>
-      <point x="1889" y="352"/>
-      <point x="1889" y="247" type="curve" smooth="yes"/>
-      <point x="1889" y="144"/>
-      <point x="1813" y="72"/>
+      <point x="1726" y="88" type="curve" smooth="yes"/>
+      <point x="1646" y="88"/>
+      <point x="1577" y="154"/>
+      <point x="1577" y="248" type="curve" smooth="yes"/>
+      <point x="1577" y="343"/>
+      <point x="1646" y="408"/>
+      <point x="1726" y="408" type="curve" smooth="yes"/>
+      <point x="1806" y="408"/>
+      <point x="1875" y="343"/>
+      <point x="1875" y="248" type="curve" smooth="yes"/>
+      <point x="1875" y="154"/>
+      <point x="1806" y="88"/>
     </contour>
     <contour>
-      <point x="2295" y="-253" type="curve" smooth="yes"/>
-      <point x="2431" y="-253"/>
-      <point x="2539" y="-173"/>
-      <point x="2539" y="22" type="curve" smooth="yes"/>
-      <point x="2539" y="496" type="line"/>
-      <point x="2444" y="496" type="line"/>
-      <point x="2444" y="445" type="line"/>
-      <point x="2440" y="445" type="line"/>
-      <point x="2420" y="469"/>
-      <point x="2369" y="512"/>
-      <point x="2296" y="512" type="curve" smooth="yes"/>
-      <point x="2171" y="512"/>
-      <point x="2049" y="406"/>
-      <point x="2049" y="247" type="curve" smooth="yes"/>
-      <point x="2049" y="86"/>
-      <point x="2171" y="-12"/>
-      <point x="2294" y="-12" type="curve" smooth="yes"/>
-      <point x="2361" y="-12"/>
-      <point x="2417" y="29"/>
-      <point x="2440" y="58" type="curve"/>
-      <point x="2444" y="58" type="line"/>
-      <point x="2444" y="-11" type="line" smooth="yes"/>
-      <point x="2444" y="-112"/>
-      <point x="2391" y="-170"/>
-      <point x="2304" y="-170" type="curve" smooth="yes"/>
-      <point x="2217" y="-170"/>
-      <point x="2167" y="-108"/>
-      <point x="2149" y="-60" type="curve"/>
-      <point x="2061" y="-97" type="line"/>
-      <point x="2090" y="-167"/>
-      <point x="2167" y="-253"/>
+      <point x="2294" y="-253" type="curve" smooth="yes"/>
+      <point x="2430" y="-253"/>
+      <point x="2545" y="-173"/>
+      <point x="2545" y="22" type="curve" smooth="yes"/>
+      <point x="2545" y="496" type="line"/>
+      <point x="2435" y="496" type="line"/>
+      <point x="2435" y="453" type="line"/>
+      <point x="2431" y="453" type="line"/>
+      <point x="2405" y="484"/>
+      <point x="2355" y="512"/>
+      <point x="2292" y="512" type="curve" smooth="yes"/>
+      <point x="2160" y="512"/>
+      <point x="2039" y="396"/>
+      <point x="2039" y="247" type="curve" smooth="yes"/>
+      <point x="2039" y="99"/>
+      <point x="2160" y="-16"/>
+      <point x="2292" y="-16" type="curve" smooth="yes"/>
+      <point x="2355" y="-16"/>
+      <point x="2405" y="12"/>
+      <point x="2431" y="44" type="curve"/>
+      <point x="2435" y="44" type="line"/>
+      <point x="2435" y="6" type="line" smooth="yes"/>
+      <point x="2435" y="-95"/>
+      <point x="2381" y="-149"/>
+      <point x="2294" y="-149" type="curve" smooth="yes"/>
+      <point x="2223" y="-149"/>
+      <point x="2179" y="-98"/>
+      <point x="2161" y="-55" type="curve"/>
+      <point x="2060" y="-97" type="line"/>
+      <point x="2089" y="-167"/>
+      <point x="2166" y="-253"/>
     </contour>
     <contour>
-      <point x="2302" y="71" type="curve" smooth="yes"/>
-      <point x="2213" y="71"/>
-      <point x="2143" y="145"/>
-      <point x="2143" y="246" type="curve" smooth="yes"/>
-      <point x="2143" y="348"/>
-      <point x="2213" y="423"/>
-      <point x="2297" y="423" type="curve" smooth="yes"/>
-      <point x="2390" y="423"/>
-      <point x="2449" y="353"/>
-      <point x="2449" y="246" type="curve" smooth="yes"/>
-      <point x="2449" y="139"/>
-      <point x="2390" y="71"/>
+      <point x="2302" y="88" type="curve" smooth="yes"/>
+      <point x="2222" y="88"/>
+      <point x="2155" y="155"/>
+      <point x="2155" y="247" type="curve" smooth="yes"/>
+      <point x="2155" y="340"/>
+      <point x="2222" y="408"/>
+      <point x="2302" y="408" type="curve" smooth="yes"/>
+      <point x="2381" y="408"/>
+      <point x="2443" y="340"/>
+      <point x="2443" y="247" type="curve" smooth="yes"/>
+      <point x="2443" y="155"/>
+      <point x="2381" y="88"/>
     </contour>
     <contour>
-      <point x="2636" y="0" type="line"/>
-      <point x="2732" y="0" type="line"/>
-      <point x="2732" y="776" type="line"/>
-      <point x="2636" y="776" type="line"/>
+      <point x="2625" y="0" type="line"/>
+      <point x="2741" y="0" type="line"/>
+      <point x="2741" y="776" type="line"/>
+      <point x="2625" y="776" type="line"/>
     </contour>
     <contour>
-      <point x="2902" y="249" type="curve" smooth="yes"/>
-      <point x="2902" y="371"/>
-      <point x="2982" y="427"/>
-      <point x="3049" y="427" type="curve" smooth="yes"/>
-      <point x="3107" y="427"/>
-      <point x="3144" y="392"/>
-      <point x="3164" y="351" type="curve"/>
-      <point x="2877" y="224" type="line"/>
-      <point x="2900" y="155" type="line"/>
-      <point x="3284" y="316" type="line"/>
-      <point x="3273" y="344" type="line" smooth="yes"/>
-      <point x="3249" y="406"/>
-      <point x="3186" y="512"/>
-      <point x="3052" y="512" type="curve" smooth="yes"/>
-      <point x="2919" y="512"/>
-      <point x="2809" y="405"/>
-      <point x="2809" y="248" type="curve" smooth="yes"/>
-      <point x="2809" y="100"/>
-      <point x="2918" y="-16"/>
-      <point x="3065" y="-16" type="curve" smooth="yes"/>
-      <point x="3183" y="-16"/>
-      <point x="3251" y="58"/>
+      <point x="2912" y="248" type="curve" smooth="yes"/>
+      <point x="2912.0" y="348.0"/>
+      <point x="2985.0" y="410"/>
+      <point x="3050" y="410" type="curve" smooth="yes"/>
+      <point x="3096" y="410"/>
+      <point x="3135" y="387"/>
+      <point x="3148" y="354" type="curve"/>
+      <point x="2859" y="234" type="line"/>
+      <point x="2888" y="151" type="line"/>
+      <point x="3284" y="314" type="line"/>
+      <point x="3272" y="344" type="line" smooth="yes"/>
+      <point x="3250" y="403"/>
+      <point x="3183" y="512"/>
+      <point x="3046" y="512" type="curve" smooth="yes"/>
+      <point x="2910" y="512"/>
+      <point x="2797" y="405"/>
+      <point x="2797" y="248" type="curve" smooth="yes"/>
+      <point x="2797" y="100"/>
+      <point x="2909" y="-16"/>
+      <point x="3059" y="-16" type="curve" smooth="yes"/>
+      <point x="3180" y="-16"/>
+      <point x="3250" y="58"/>
       <point x="3279" y="101" type="curve"/>
-      <point x="3209" y="153" type="line"/>
-      <point x="3177" y="106"/>
-      <point x="3131" y="77"/>
-      <point x="3067" y="77" type="curve" smooth="yes"/>
-      <point x="2984" y="77"/>
-      <point x="2902" y="132"/>
+      <point x="3189" y="161" type="line"/>
+      <point x="3159" y="117"/>
+      <point x="3118" y="88"/>
+      <point x="3059" y="88" type="curve" smooth="yes"/>
+      <point x="2977.0" y="88.0"/>
+      <point x="2912" y="154"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -3,35 +3,35 @@
   <advance width="514"/>
   <outline>
     <contour>
-      <point x="128.0" y="249.0" type="curve" smooth="yes"/>
-      <point x="128.0" y="371.0"/>
-      <point x="208" y="427.0"/>
-      <point x="275" y="427.0" type="curve" smooth="yes"/>
-      <point x="333" y="427"/>
-      <point x="370" y="392.0"/>
-      <point x="390" y="351.0" type="curve"/>
-      <point x="103" y="224.0" type="line"/>
-      <point x="126" y="155.0" type="line"/>
-      <point x="510" y="316.0" type="line"/>
-      <point x="499" y="344.0" type="line" smooth="yes"/>
-      <point x="475" y="406"/>
-      <point x="412" y="512.0"/>
-      <point x="278" y="512.0" type="curve" smooth="yes"/>
-      <point x="145" y="512.0"/>
-      <point x="35" y="405.0"/>
-      <point x="35" y="248.0" type="curve" smooth="yes"/>
-      <point x="35" y="100.0"/>
-      <point x="144" y="-16.0"/>
-      <point x="291" y="-16.0" type="curve" smooth="yes"/>
-      <point x="409" y="-16.0"/>
-      <point x="477" y="58.0"/>
-      <point x="505" y="101.0" type="curve"/>
-      <point x="435" y="153.0" type="line"/>
-      <point x="403" y="106.0"/>
-      <point x="357" y="77.0"/>
-      <point x="293" y="77.0" type="curve" smooth="yes"/>
-      <point x="210" y="77.0"/>
-      <point x="128.0" y="132.0"/>
+      <point x="141.0" y="249" type="curve" smooth="yes"/>
+      <point x="141" y="363"/>
+      <point x="221" y="410"/>
+      <point x="280" y="410" type="curve" smooth="yes"/>
+      <point x="326" y="410"/>
+      <point x="365" y="387"/>
+      <point x="378" y="354" type="curve"/>
+      <point x="100" y="238" type="line"/>
+      <point x="121" y="151" type="line"/>
+      <point x="514" y="314" type="line"/>
+      <point x="502" y="344" type="line" smooth="yes"/>
+      <point x="480" y="403"/>
+      <point x="413" y="512"/>
+      <point x="276" y="512" type="curve" smooth="yes"/>
+      <point x="140" y="512"/>
+      <point x="27" y="405"/>
+      <point x="27" y="248" type="curve" smooth="yes"/>
+      <point x="27" y="100"/>
+      <point x="139" y="-16"/>
+      <point x="289" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="480" y="58"/>
+      <point x="509" y="101" type="curve"/>
+      <point x="419" y="161" type="line"/>
+      <point x="389" y="117"/>
+      <point x="348" y="88"/>
+      <point x="289" y="88" type="curve" smooth="yes"/>
+      <point x="215.0" y="88.0"/>
+      <point x="141" y="140.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -3,51 +3,51 @@
   <advance width="566"/>
   <outline>
     <contour>
-      <point x="277.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="413.0" y="-253.0"/>
-      <point x="521" y="-173"/>
-      <point x="521.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="521.0" y="496.0" type="line"/>
-      <point x="426" y="496.0" type="line"/>
-      <point x="426" y="445.0" type="line"/>
-      <point x="422" y="445.0" type="line"/>
-      <point x="402" y="469.0"/>
-      <point x="351" y="512.0"/>
-      <point x="278" y="512.0" type="curve" smooth="yes"/>
-      <point x="153" y="512"/>
-      <point x="31" y="406"/>
-      <point x="31" y="247.0" type="curve" smooth="yes"/>
-      <point x="31" y="86"/>
-      <point x="153" y="-12"/>
-      <point x="276" y="-12.0" type="curve" smooth="yes"/>
-      <point x="343" y="-12.0"/>
-      <point x="399" y="29.0"/>
-      <point x="422" y="58.0" type="curve"/>
-      <point x="426" y="58.0" type="line"/>
-      <point x="426" y="-11.0" type="line" smooth="yes"/>
-      <point x="426" y="-112"/>
-      <point x="373.0" y="-170.0"/>
-      <point x="286" y="-170" type="curve" smooth="yes"/>
-      <point x="199" y="-170"/>
-      <point x="149" y="-108"/>
-      <point x="131" y="-60" type="curve"/>
-      <point x="43.0" y="-97.0" type="line"/>
-      <point x="72.0" y="-167.0"/>
-      <point x="149.0" y="-253.0"/>
+      <point x="277" y="-253" type="curve" smooth="yes"/>
+      <point x="413" y="-253"/>
+      <point x="528" y="-173"/>
+      <point x="528" y="22" type="curve" smooth="yes"/>
+      <point x="528" y="496" type="line"/>
+      <point x="418" y="496" type="line"/>
+      <point x="418" y="453" type="line"/>
+      <point x="414" y="453" type="line"/>
+      <point x="388" y="484"/>
+      <point x="338" y="512"/>
+      <point x="275" y="512" type="curve" smooth="yes"/>
+      <point x="143" y="512"/>
+      <point x="22" y="396"/>
+      <point x="22" y="247" type="curve" smooth="yes"/>
+      <point x="22" y="99"/>
+      <point x="143" y="-16"/>
+      <point x="275" y="-16" type="curve" smooth="yes"/>
+      <point x="338" y="-16"/>
+      <point x="388" y="12"/>
+      <point x="414" y="44" type="curve"/>
+      <point x="418" y="44" type="line"/>
+      <point x="418" y="6" type="line" smooth="yes"/>
+      <point x="418" y="-95"/>
+      <point x="364" y="-149"/>
+      <point x="277" y="-149" type="curve" smooth="yes"/>
+      <point x="206" y="-149"/>
+      <point x="162" y="-98"/>
+      <point x="144" y="-55" type="curve"/>
+      <point x="43" y="-97" type="line"/>
+      <point x="72" y="-167"/>
+      <point x="149" y="-253"/>
     </contour>
     <contour>
-      <point x="284" y="71" type="curve" smooth="yes"/>
-      <point x="195.0" y="71"/>
-      <point x="125.0" y="145"/>
-      <point x="125.0" y="246" type="curve" smooth="yes"/>
-      <point x="125.0" y="348"/>
-      <point x="195.0" y="423"/>
-      <point x="279" y="423.0" type="curve" smooth="yes"/>
-      <point x="372.0" y="423"/>
-      <point x="431.0" y="353.0"/>
-      <point x="431.0" y="246" type="curve" smooth="yes"/>
-      <point x="431" y="139"/>
-      <point x="372.0" y="71"/>
+      <point x="285" y="88" type="curve" smooth="yes"/>
+      <point x="205" y="88"/>
+      <point x="138" y="155"/>
+      <point x="138" y="247" type="curve" smooth="yes"/>
+      <point x="138" y="340"/>
+      <point x="205" y="408"/>
+      <point x="285" y="408" type="curve" smooth="yes"/>
+      <point x="364" y="408"/>
+      <point x="426" y="340"/>
+      <point x="426" y="247" type="curve" smooth="yes"/>
+      <point x="426" y="155"/>
+      <point x="364" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -3,10 +3,10 @@
   <advance width="187"/>
   <outline>
     <contour>
-      <point x="52.0" y="0.0" type="line"/>
-      <point x="148.0" y="0.0" type="line"/>
-      <point x="148.0" y="776.0" type="line"/>
-      <point x="52.0" y="776.0" type="line"/>
+      <point x="42" y="0" type="line"/>
+      <point x="158" y="0" type="line"/>
+      <point x="158" y="776" type="line"/>
+      <point x="42" y="776" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -3,32 +3,32 @@
   <advance width="578"/>
   <outline>
     <contour>
-      <point x="287" y="-16.0" type="curve" smooth="yes"/>
-      <point x="429" y="-16.0"/>
-      <point x="544" y="96.0"/>
-      <point x="544" y="248.0" type="curve" smooth="yes"/>
-      <point x="544" y="401.0"/>
-      <point x="429" y="512.0"/>
-      <point x="287" y="512.0" type="curve" smooth="yes"/>
-      <point x="145" y="512.0"/>
-      <point x="30.0" y="401.0"/>
-      <point x="30.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="96.0"/>
-      <point x="145" y="-16.0"/>
+      <point x="287" y="-16" type="curve" smooth="yes"/>
+      <point x="433" y="-16"/>
+      <point x="552" y="96"/>
+      <point x="552" y="248" type="curve" smooth="yes"/>
+      <point x="552" y="401"/>
+      <point x="433" y="512"/>
+      <point x="287" y="512" type="curve" smooth="yes"/>
+      <point x="141" y="512"/>
+      <point x="22" y="401"/>
+      <point x="22" y="248" type="curve" smooth="yes"/>
+      <point x="22" y="96"/>
+      <point x="141" y="-16"/>
     </contour>
     <contour>
-      <point x="287.0" y="72" type="curve" smooth="yes"/>
-      <point x="200.0" y="72"/>
-      <point x="125.0" y="144"/>
-      <point x="125.0" y="247" type="curve" smooth="yes"/>
-      <point x="125.0" y="352"/>
-      <point x="200.0" y="423"/>
-      <point x="287.0" y="423" type="curve" smooth="yes"/>
-      <point x="373.0" y="423"/>
-      <point x="449.0" y="352"/>
-      <point x="449.0" y="247" type="curve" smooth="yes"/>
-      <point x="449.0" y="144"/>
-      <point x="373.0" y="72"/>
+      <point x="287" y="88" type="curve" smooth="yes"/>
+      <point x="207" y="88"/>
+      <point x="138" y="154"/>
+      <point x="138" y="248" type="curve" smooth="yes"/>
+      <point x="138" y="343"/>
+      <point x="207" y="408"/>
+      <point x="287" y="408" type="curve" smooth="yes"/>
+      <point x="367" y="408"/>
+      <point x="436" y="343"/>
+      <point x="436" y="248" type="curve" smooth="yes"/>
+      <point x="436" y="154"/>
+      <point x="367" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -3,43 +3,43 @@
   <advance width="861"/>
   <outline>
     <contour>
-      <point x="460.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="582.0" y="-16.0"/>
-      <point x="674.0" y="24.0"/>
-      <point x="746.0" y="99.0" type="curve"/>
-      <point x="820.0" y="173.0"/>
-      <point x="843.0" y="277.0"/>
-      <point x="843.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="843.0" y="387.0"/>
-      <point x="841.0" y="411.0"/>
-      <point x="837.0" y="431.0" type="curve"/>
-      <point x="460.0" y="431.0" type="line"/>
-      <point x="460.0" y="319.0" type="line"/>
-      <point x="728.0" y="319.0" type="line"/>
-      <point x="720.0" y="256.0"/>
-      <point x="699.0" y="210.0"/>
-      <point x="667.0" y="178.0" type="curve" smooth="yes"/>
-      <point x="628.0" y="139.0"/>
-      <point x="567.0" y="96.0"/>
-      <point x="460.0" y="96.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="96.0"/>
-      <point x="166.0" y="229.0"/>
-      <point x="166.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="166.0" y="559.0"/>
-      <point x="295.0" y="692.0"/>
-      <point x="460.0" y="692.0" type="curve" smooth="yes"/>
-      <point x="549.0" y="692.0"/>
-      <point x="614.0" y="657.0"/>
-      <point x="662.0" y="612.0" type="curve"/>
-      <point x="741.0" y="691.0" type="line"/>
-      <point x="674.0" y="755.0"/>
-      <point x="585.0" y="804.0"/>
-      <point x="460.0" y="804.0" type="curve" smooth="yes"/>
-      <point x="234.0" y="804.0"/>
-      <point x="44.0" y="620.0"/>
-      <point x="44.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="44.0" y="168.0"/>
-      <point x="234.0" y="-16.0"/>
+      <point x="460" y="-16" type="curve" smooth="yes"/>
+      <point x="582" y="-16"/>
+      <point x="674" y="24"/>
+      <point x="746" y="99" type="curve"/>
+      <point x="820" y="173"/>
+      <point x="843" y="277"/>
+      <point x="843" y="361" type="curve" smooth="yes"/>
+      <point x="843" y="387"/>
+      <point x="841" y="411"/>
+      <point x="837" y="431" type="curve"/>
+      <point x="460" y="431" type="line"/>
+      <point x="460" y="319" type="line"/>
+      <point x="728" y="319" type="line"/>
+      <point x="720" y="256"/>
+      <point x="699" y="210"/>
+      <point x="667" y="178" type="curve" smooth="yes"/>
+      <point x="628" y="139"/>
+      <point x="567" y="96"/>
+      <point x="460" y="96" type="curve" smooth="yes"/>
+      <point x="295" y="96"/>
+      <point x="166" y="229"/>
+      <point x="166" y="394" type="curve" smooth="yes"/>
+      <point x="166" y="559"/>
+      <point x="295" y="692"/>
+      <point x="460" y="692" type="curve" smooth="yes"/>
+      <point x="549" y="692"/>
+      <point x="614" y="657"/>
+      <point x="662" y="612" type="curve"/>
+      <point x="741" y="691" type="line"/>
+      <point x="674" y="755"/>
+      <point x="585" y="804"/>
+      <point x="460" y="804" type="curve" smooth="yes"/>
+      <point x="234" y="804"/>
+      <point x="44" y="620"/>
+      <point x="44" y="394" type="curve" smooth="yes"/>
+      <point x="44" y="168"/>
+      <point x="234" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -3,37 +3,37 @@
   <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499.0" y="-41.0" type="curve" smooth="yes"/>
-      <point x="739.0" y="-41.0"/>
-      <point x="898.0" y="128.0"/>
-      <point x="898.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="898.0" y="395.0"/>
-      <point x="896.0" y="423.0"/>
-      <point x="891.0" y="451.0" type="curve"/>
-      <point x="499.0" y="451.0" type="line"/>
-      <point x="499.0" y="290.0" type="line"/>
-      <point x="723.0" y="290.0" type="line"/>
-      <point x="705.0" y="194.0"/>
-      <point x="621.0" y="124.0"/>
-      <point x="499.0" y="124.0" type="curve" smooth="yes"/>
-      <point x="363.0" y="124.0"/>
-      <point x="253.0" y="239.0"/>
-      <point x="253.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="511.0"/>
-      <point x="363.0" y="625.0"/>
-      <point x="499.0" y="625.0" type="curve" smooth="yes"/>
-      <point x="560.0" y="625.0"/>
-      <point x="615.0" y="604.0"/>
-      <point x="658.0" y="563.0" type="curve"/>
-      <point x="777.0" y="683.0" type="line"/>
-      <point x="705.0" y="750.0"/>
-      <point x="611.0" y="791.0"/>
-      <point x="499.0" y="791.0" type="curve" smooth="yes"/>
-      <point x="269.0" y="791.0"/>
-      <point x="83.0" y="605.0"/>
-      <point x="83.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="83.0" y="145.0"/>
-      <point x="269.0" y="-41.0"/>
+      <point x="499" y="-41" type="curve" smooth="yes"/>
+      <point x="739" y="-41"/>
+      <point x="898" y="128"/>
+      <point x="898" y="365" type="curve" smooth="yes"/>
+      <point x="898" y="395"/>
+      <point x="896" y="423"/>
+      <point x="891" y="451" type="curve"/>
+      <point x="499" y="451" type="line"/>
+      <point x="499" y="290" type="line"/>
+      <point x="723" y="290" type="line"/>
+      <point x="705" y="194"/>
+      <point x="621" y="124"/>
+      <point x="499" y="124" type="curve" smooth="yes"/>
+      <point x="363" y="124"/>
+      <point x="253" y="239"/>
+      <point x="253" y="375" type="curve" smooth="yes"/>
+      <point x="253" y="511"/>
+      <point x="363" y="625"/>
+      <point x="499" y="625" type="curve" smooth="yes"/>
+      <point x="560" y="625"/>
+      <point x="615" y="604"/>
+      <point x="658" y="563" type="curve"/>
+      <point x="777" y="683" type="line"/>
+      <point x="705" y="750"/>
+      <point x="611" y="791"/>
+      <point x="499" y="791" type="curve" smooth="yes"/>
+      <point x="269" y="791"/>
+      <point x="83" y="605"/>
+      <point x="83" y="375" type="curve" smooth="yes"/>
+      <point x="83" y="145"/>
+      <point x="269" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -3,35 +3,35 @@
   <advance width="514"/>
   <outline>
     <contour>
-      <point x="141.0" y="249.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="363.0"/>
-      <point x="221.0" y="410.0"/>
-      <point x="280.0" y="410.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="410.0"/>
-      <point x="365.0" y="387.0"/>
-      <point x="378.0" y="354.0" type="curve"/>
-      <point x="100.0" y="238.0" type="line"/>
-      <point x="121.0" y="151.0" type="line"/>
-      <point x="514.0" y="314.0" type="line"/>
-      <point x="502.0" y="344.0" type="line" smooth="yes"/>
-      <point x="480.0" y="403.0"/>
-      <point x="413.0" y="512.0"/>
-      <point x="276.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="140.0" y="512.0"/>
-      <point x="27.0" y="405.0"/>
-      <point x="27.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="27.0" y="100.0"/>
-      <point x="139.0" y="-16.0"/>
-      <point x="289.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="410.0" y="-16.0"/>
-      <point x="480.0" y="58.0"/>
-      <point x="509.0" y="101.0" type="curve"/>
-      <point x="419.0" y="161.0" type="line"/>
-      <point x="389.0" y="117.0"/>
-      <point x="348.0" y="88.0"/>
-      <point x="289.0" y="88.0" type="curve" smooth="yes"/>
+      <point x="141.0" y="249" type="curve" smooth="yes"/>
+      <point x="141" y="363"/>
+      <point x="221" y="410"/>
+      <point x="280" y="410" type="curve" smooth="yes"/>
+      <point x="326" y="410"/>
+      <point x="365" y="387"/>
+      <point x="378" y="354" type="curve"/>
+      <point x="100" y="238" type="line"/>
+      <point x="121" y="151" type="line"/>
+      <point x="514" y="314" type="line"/>
+      <point x="502" y="344" type="line" smooth="yes"/>
+      <point x="480" y="403"/>
+      <point x="413" y="512"/>
+      <point x="276" y="512" type="curve" smooth="yes"/>
+      <point x="140" y="512"/>
+      <point x="27" y="405"/>
+      <point x="27" y="248" type="curve" smooth="yes"/>
+      <point x="27" y="100"/>
+      <point x="139" y="-16"/>
+      <point x="289" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="480" y="58"/>
+      <point x="509" y="101" type="curve"/>
+      <point x="419" y="161" type="line"/>
+      <point x="389" y="117"/>
+      <point x="348" y="88"/>
+      <point x="289" y="88" type="curve" smooth="yes"/>
       <point x="215.0" y="88.0"/>
-      <point x="141.0" y="140.0"/>
+      <point x="141" y="140.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -3,51 +3,51 @@
   <advance width="566"/>
   <outline>
     <contour>
-      <point x="277.0" y="-253.0" type="curve" smooth="yes"/>
-      <point x="413.0" y="-253.0"/>
-      <point x="528.0" y="-173.0"/>
-      <point x="528.0" y="22.0" type="curve" smooth="yes"/>
-      <point x="528.0" y="496.0" type="line"/>
-      <point x="418.0" y="496.0" type="line"/>
-      <point x="418.0" y="453.0" type="line"/>
-      <point x="414.0" y="453.0" type="line"/>
-      <point x="388.0" y="484.0"/>
-      <point x="338.0" y="512.0"/>
-      <point x="275.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="512.0"/>
-      <point x="22.0" y="396.0"/>
-      <point x="22.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="22.0" y="99.0"/>
-      <point x="143.0" y="-16.0"/>
-      <point x="275.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="-16.0"/>
-      <point x="388.0" y="12.0"/>
-      <point x="414.0" y="44.0" type="curve"/>
-      <point x="418.0" y="44.0" type="line"/>
-      <point x="418.0" y="6.0" type="line" smooth="yes"/>
-      <point x="418.0" y="-95.0"/>
-      <point x="364.0" y="-149.0"/>
-      <point x="277.0" y="-149.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="-149.0"/>
-      <point x="162.0" y="-98.0"/>
-      <point x="144.0" y="-55.0" type="curve"/>
-      <point x="43.0" y="-97.0" type="line"/>
-      <point x="72.0" y="-167.0"/>
-      <point x="149.0" y="-253.0"/>
+      <point x="277" y="-253" type="curve" smooth="yes"/>
+      <point x="413" y="-253"/>
+      <point x="528" y="-173"/>
+      <point x="528" y="22" type="curve" smooth="yes"/>
+      <point x="528" y="496" type="line"/>
+      <point x="418" y="496" type="line"/>
+      <point x="418" y="453" type="line"/>
+      <point x="414" y="453" type="line"/>
+      <point x="388" y="484"/>
+      <point x="338" y="512"/>
+      <point x="275" y="512" type="curve" smooth="yes"/>
+      <point x="143" y="512"/>
+      <point x="22" y="396"/>
+      <point x="22" y="247" type="curve" smooth="yes"/>
+      <point x="22" y="99"/>
+      <point x="143" y="-16"/>
+      <point x="275" y="-16" type="curve" smooth="yes"/>
+      <point x="338" y="-16"/>
+      <point x="388" y="12"/>
+      <point x="414" y="44" type="curve"/>
+      <point x="418" y="44" type="line"/>
+      <point x="418" y="6" type="line" smooth="yes"/>
+      <point x="418" y="-95"/>
+      <point x="364" y="-149"/>
+      <point x="277" y="-149" type="curve" smooth="yes"/>
+      <point x="206" y="-149"/>
+      <point x="162" y="-98"/>
+      <point x="144" y="-55" type="curve"/>
+      <point x="43" y="-97" type="line"/>
+      <point x="72" y="-167"/>
+      <point x="149" y="-253"/>
     </contour>
     <contour>
-      <point x="285.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="205.0" y="88.0"/>
-      <point x="138.0" y="155.0"/>
-      <point x="138.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="340.0"/>
-      <point x="205.0" y="408.0"/>
-      <point x="285.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="364.0" y="408.0"/>
-      <point x="426.0" y="340.0"/>
-      <point x="426.0" y="247.0" type="curve" smooth="yes"/>
-      <point x="426.0" y="155.0"/>
-      <point x="364.0" y="88.0"/>
+      <point x="285" y="88" type="curve" smooth="yes"/>
+      <point x="205" y="88"/>
+      <point x="138" y="155"/>
+      <point x="138" y="247" type="curve" smooth="yes"/>
+      <point x="138" y="340"/>
+      <point x="205" y="408"/>
+      <point x="285" y="408" type="curve" smooth="yes"/>
+      <point x="364" y="408"/>
+      <point x="426" y="340"/>
+      <point x="426" y="247" type="curve" smooth="yes"/>
+      <point x="426" y="155"/>
+      <point x="364" y="88"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -3,10 +3,10 @@
   <advance width="187"/>
   <outline>
     <contour>
-      <point x="42.0" y="0.0" type="line"/>
-      <point x="158.0" y="0.0" type="line"/>
-      <point x="158.0" y="776.0" type="line"/>
-      <point x="42.0" y="776.0" type="line"/>
+      <point x="42" y="0" type="line"/>
+      <point x="158" y="0" type="line"/>
+      <point x="158" y="776" type="line"/>
+      <point x="42" y="776" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -3,32 +3,32 @@
   <advance width="578"/>
   <outline>
     <contour>
-      <point x="287.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="433.0" y="-16.0"/>
-      <point x="552.0" y="96.0"/>
-      <point x="552.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="552.0" y="401.0"/>
-      <point x="433.0" y="512.0"/>
-      <point x="287.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="512.0"/>
-      <point x="22.0" y="401.0"/>
-      <point x="22.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="22.0" y="96.0"/>
-      <point x="141.0" y="-16.0"/>
+      <point x="287" y="-16" type="curve" smooth="yes"/>
+      <point x="433" y="-16"/>
+      <point x="552" y="96"/>
+      <point x="552" y="248" type="curve" smooth="yes"/>
+      <point x="552" y="401"/>
+      <point x="433" y="512"/>
+      <point x="287" y="512" type="curve" smooth="yes"/>
+      <point x="141" y="512"/>
+      <point x="22" y="401"/>
+      <point x="22" y="248" type="curve" smooth="yes"/>
+      <point x="22" y="96"/>
+      <point x="141" y="-16"/>
     </contour>
     <contour>
-      <point x="287.0" y="88.0" type="curve" smooth="yes"/>
-      <point x="207.0" y="88.0"/>
-      <point x="138.0" y="154.0"/>
-      <point x="138.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="343.0"/>
-      <point x="207.0" y="408.0"/>
-      <point x="287.0" y="408.0" type="curve" smooth="yes"/>
-      <point x="367.0" y="408.0"/>
-      <point x="436.0" y="343.0"/>
-      <point x="436.0" y="248.0" type="curve" smooth="yes"/>
-      <point x="436.0" y="154.0"/>
-      <point x="367.0" y="88.0"/>
+      <point x="287" y="88" type="curve" smooth="yes"/>
+      <point x="207" y="88"/>
+      <point x="138" y="154"/>
+      <point x="138" y="248" type="curve" smooth="yes"/>
+      <point x="138" y="343"/>
+      <point x="207" y="408"/>
+      <point x="287" y="408" type="curve" smooth="yes"/>
+      <point x="367" y="408"/>
+      <point x="436" y="343"/>
+      <point x="436" y="248" type="curve" smooth="yes"/>
+      <point x="436" y="154"/>
+      <point x="367" y="88"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
We do not want grade on the logo at this time.  

Italic does not support grade. No change is required in the Italic glyph set. 

Fixes #249
