### PR TITLE
Add grade support ustraight-cy, Italic only

### DIFF
--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
@@ -4,21 +4,21 @@
   <unicode hex="04AF"/>
   <outline>
     <contour>
-      <point x="121.0" y="-216.0" type="line"/>
-      <point x="206.0" y="-216.0" type="line"/>
-      <point x="244.0" y="0.0" type="line"/>
-      <point x="530.0" y="526.0" type="line"/>
-      <point x="443.0" y="526.0" type="line"/>
-      <point x="220.0" y="98.0" type="line"/>
-      <point x="217.0" y="98.0" type="line"/>
-      <point x="146.0" y="526.0" type="line"/>
-      <point x="60.0" y="526.0" type="line"/>
-      <point x="159.0" y="0.0" type="line"/>
+      <point x="131.0" y="-216.0" type="line"/>
+      <point x="196.0" y="-216.0" type="line"/>
+      <point x="234.0" y="0.0" type="line"/>
+      <point x="520.0" y="526.0" type="line"/>
+      <point x="453.0" y="526.0" type="line"/>
+      <point x="216.0" y="83.0" type="line"/>
+      <point x="213.0" y="83.0" type="line"/>
+      <point x="136.0" y="526.0" type="line"/>
+      <point x="70.0" y="526.0" type="line"/>
+      <point x="169.0" y="0.0" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>
   </lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
@@ -4,21 +4,21 @@
   <unicode hex="04AF"/>
   <outline>
     <contour>
-      <point x="121.0" y="-216.0" type="line"/>
-      <point x="206.0" y="-216.0" type="line"/>
-      <point x="244.0" y="0.0" type="line"/>
-      <point x="530.0" y="526.0" type="line"/>
-      <point x="443.0" y="526.0" type="line"/>
-      <point x="220.0" y="98.0" type="line"/>
-      <point x="217.0" y="98.0" type="line"/>
-      <point x="146.0" y="526.0" type="line"/>
-      <point x="60.0" y="526.0" type="line"/>
-      <point x="159.0" y="0.0" type="line"/>
+      <point x="106.0" y="-216.0" type="line"/>
+      <point x="221.0" y="-216.0" type="line"/>
+      <point x="259.0" y="0.0" type="line"/>
+      <point x="550.0" y="526.0" type="line"/>
+      <point x="423.0" y="526.0" type="line"/>
+      <point x="225.0" y="141.0" type="line"/>
+      <point x="222.0" y="141.0" type="line"/>
+      <point x="161.0" y="526.0" type="line"/>
+      <point x="40.0" y="526.0" type="line"/>
+      <point x="144.0" y="0.0" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>
   </lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
@@ -4,21 +4,21 @@
   <unicode hex="04AF"/>
   <outline>
     <contour>
-      <point x="131" y="-216" type="line"/>
-      <point x="216" y="-216" type="line"/>
-      <point x="254" y="0" type="line"/>
-      <point x="553" y="510" type="line"/>
-      <point x="462" y="510" type="line"/>
-      <point x="229" y="93" type="line"/>
-      <point x="227" y="93" type="line"/>
-      <point x="139" y="510" type="line"/>
-      <point x="52" y="510" type="line"/>
-      <point x="169" y="0" type="line"/>
+      <point x="141" y="-216" type="line"/>
+      <point x="206" y="-216" type="line"/>
+      <point x="244" y="0" type="line"/>
+      <point x="543" y="510" type="line"/>
+      <point x="472" y="510" type="line"/>
+      <point x="225" y="78" type="line"/>
+      <point x="223" y="78" type="line"/>
+      <point x="129" y="510" type="line"/>
+      <point x="62" y="510" type="line"/>
+      <point x="179" y="0" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>
   </lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
@@ -4,21 +4,21 @@
   <unicode hex="04AF"/>
   <outline>
     <contour>
-      <point x="131" y="-216" type="line"/>
-      <point x="216" y="-216" type="line"/>
-      <point x="254" y="0" type="line"/>
-      <point x="553" y="510" type="line"/>
-      <point x="462" y="510" type="line"/>
-      <point x="229" y="93" type="line"/>
-      <point x="227" y="93" type="line"/>
-      <point x="139" y="510" type="line"/>
-      <point x="52" y="510" type="line"/>
-      <point x="169" y="0" type="line"/>
+      <point x="116" y="-216" type="line"/>
+      <point x="231" y="-216" type="line"/>
+      <point x="269" y="0" type="line"/>
+      <point x="573" y="510" type="line"/>
+      <point x="442" y="510" type="line"/>
+      <point x="234" y="136" type="line"/>
+      <point x="232" y="136" type="line"/>
+      <point x="154" y="510" type="line"/>
+      <point x="32" y="510" type="line"/>
+      <point x="154" y="0" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>
   </lib>


### PR DESCRIPTION
Replaces `ustraight-cy` outlines with `ustrait-cy` outlines, Italic only.

Fixes #262
