### PR TITLE
Add KaiSymbol GRAD 1-200 support @ opsz 17 and 18

### DIFF
--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
@@ -4,33 +4,33 @@
   <unicode hex="03CF"/>
   <outline>
     <contour>
-      <point x="84.0" y="0.0" type="line"/>
-      <point x="169.0" y="0.0" type="line"/>
-      <point x="169.0" y="716.0" type="line"/>
-      <point x="84.0" y="716.0" type="line"/>
+      <point x="71.0" y="0.0" type="line"/>
+      <point x="194.0" y="0.0" type="line"/>
+      <point x="194.0" y="716.0" type="line"/>
+      <point x="71.0" y="716.0" type="line"/>
     </contour>
     <contour>
       <point x="125.0" y="157.0" type="line"/>
-      <point x="583.0" y="712.0" type="line"/>
-      <point x="583.0" y="716.0" type="line"/>
-      <point x="477.0" y="716.0" type="line"/>
-      <point x="125.0" y="285.0" type="line"/>
+      <point x="593.0" y="712.0" type="line"/>
+      <point x="593.0" y="716.0" type="line"/>
+      <point x="453.0" y="716.0" type="line"/>
+      <point x="125.0" y="309.0" type="line"/>
     </contour>
     <contour>
-      <point x="256.0" y="362.0" type="line"/>
-      <point x="523.0" y="29.0" type="line"/>
-      <point x="399.0" y="-216.0" type="line"/>
+      <point x="237.0" y="345.0" type="line"/>
+      <point x="488.0" y="29.0" type="line"/>
+      <point x="359.0" y="-216.0" type="line"/>
       <point x="488.0" y="-216.0" type="line"/>
-      <point x="622.0" y="40.0" type="line"/>
-      <point x="622.0" y="44.0" type="line"/>
-      <point x="312.0" y="429.0" type="line"/>
+      <point x="631.0" y="40.0" type="line"/>
+      <point x="631.0" y="44.0" type="line"/>
+      <point x="313.0" y="449.0" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.leftMetricsKey</key>
       <string>=K</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=K</string>
     </dict>
   </lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
@@ -4,26 +4,26 @@
   <unicode hex="03CF"/>
   <outline>
     <contour>
-      <point x="80.0" y="0.0" type="line"/>
-      <point x="165.0" y="0.0" type="line"/>
-      <point x="165.0" y="716.0" type="line"/>
-      <point x="80.0" y="716.0" type="line"/>
+      <point x="67.0" y="0.0" type="line"/>
+      <point x="188.0" y="0.0" type="line"/>
+      <point x="188.0" y="716.0" type="line"/>
+      <point x="67.0" y="716.0" type="line"/>
     </contour>
     <contour>
-      <point x="122.0" y="161.0" type="line"/>
-      <point x="600.0" y="712.0" type="line"/>
-      <point x="600.0" y="716.0" type="line"/>
-      <point x="491.0" y="716.0" type="line"/>
-      <point x="122.0" y="284.0" type="line"/>
+      <point x="130.0" y="161.0" type="line"/>
+      <point x="611.0" y="712.0" type="line"/>
+      <point x="611.0" y="716.0" type="line"/>
+      <point x="466.0" y="716.0" type="line"/>
+      <point x="130.0" y="321.0" type="line"/>
     </contour>
     <contour>
-      <point x="257.0" y="367.0" type="line"/>
-      <point x="520.0" y="37.0" type="line"/>
-      <point x="393.0" y="-216.0" type="line"/>
-      <point x="486.0" y="-216.0" type="line"/>
-      <point x="619.0" y="40.0" type="line"/>
-      <point x="619.0" y="44.0" type="line"/>
-      <point x="314.0" y="432.0" type="line"/>
+      <point x="249.0" y="350.0" type="line"/>
+      <point x="496.0" y="26.0" type="line"/>
+      <point x="381.0" y="-216.0" type="line"/>
+      <point x="505.0" y="-216.0" type="line"/>
+      <point x="638.0" y="40.0" type="line"/>
+      <point x="638.0" y="46.0" type="line"/>
+      <point x="327.0" y="444.0" type="line"/>
     </contour>
   </outline>
   <lib>


### PR DESCRIPTION
Fixes #261

Test string:

```
Ϗ
```

---

### TODO

- [x] fix opsz 18 https://github.com/googlefonts/googlesans/pull/283/commits/f76d01a7521e9ec8581eb07ed336308a464c3a47
- [x] fix opsz 17