### PR TITLE
Reimport circled numbers

### DIFF
--- a/scripts/gs-merge-designspace.py
+++ b/scripts/gs-merge-designspace.py
@@ -115,6 +115,21 @@ if skip_export_glyphs_target:
     designspace_target.lib[SKIP_EXPORT_GLYPHS_KEY] = skip_export_glyphs
 
 
+def canonical_location(
+    location: Dict[str, float], designspace: DesignSpaceDocument
+) -> Dict[str, float]:
+    """Returns a canonical location from a raw Designspace location.
+
+    Vendor sources are inconsistent, so using user values and tags to match
+    source axes is hopefully more reliable.
+    """
+    name_to_axis = {a.name: a for a in designspace.axes}
+    name_to_tag = {a.name: a.tag for a in designspace.axes}
+    return {
+        name_to_tag[k]: name_to_axis[k].map_backward(v) for k, v in location.items()
+    }
+
+
 # Actually import now.
 for import_source in designspace_import.sources:
     if import_source.layerName is not None:
@@ -122,9 +137,10 @@ for import_source in designspace_import.sources:
         sys.exit(1)
 
     # Fill in the defaults if the import DS does not have e.g. a GRAD axis.
+    # Match axes by tags because those are more consistent across vendor sources.
     import_source_location = {
-        **designspace_target.default.location,
-        **import_source.location,
+        **canonical_location(designspace_target.default.location, designspace_target),
+        **canonical_location(import_source.location, designspace_import),
     }
 
     # Match import to target UFO.
@@ -132,7 +148,10 @@ for import_source in designspace_import.sources:
         target_source = next(
             s
             for s in designspace_target.sources
-            if s.location == import_source_location
+            if (
+                canonical_location(s.location, designspace_target)
+                == import_source_location
+            )
         )
     except StopIteration:
         try:

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-14.0" type="curve" smooth="yes"/>
-      <point x="630.0" y="-14.0"/>
-      <point x="797.0" y="153.0"/>
-      <point x="797.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="797.0" y="563.0"/>
-      <point x="630.0" y="730.0"/>
-      <point x="425.0" y="730.0" type="curve" smooth="yes"/>
-      <point x="220.0" y="730.0"/>
-      <point x="53.0" y="563.0"/>
-      <point x="53.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="153.0"/>
-      <point x="220.0" y="-14.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="34.0" type="curve" smooth="yes"/>
-      <point x="249.0" y="34.0"/>
-      <point x="101.0" y="182.0"/>
-      <point x="101.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="101.0" y="538.0"/>
-      <point x="249.0" y="682.0"/>
-      <point x="425.0" y="682.0" type="curve" smooth="yes"/>
-      <point x="606.0" y="682.0"/>
-      <point x="749.0" y="538.0"/>
-      <point x="749.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="749.0" y="182.0"/>
-      <point x="606.0" y="34.0"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="330.0"/>
-      <point x="288.0" y="373.0"/>
-      <point x="288.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="488.0"/>
-      <point x="264.0" y="527.0"/>
-      <point x="217.0" y="540.0" type="curve"/>
-      <point x="251.0" y="549.0"/>
-      <point x="276.0" y="578.0"/>
-      <point x="276.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="276.0" y="682.0"/>
-      <point x="235.0" y="724.0"/>
-      <point x="162.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="90.0" y="724.0"/>
-      <point x="47.0" y="682.0"/>
-      <point x="47.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="47.0" y="580.0"/>
-      <point x="70.0" y="550.0"/>
-      <point x="105.0" y="540.0" type="curve"/>
-      <point x="59.0" y="523.0"/>
-      <point x="35.0" y="488.0"/>
-      <point x="35.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="35.0" y="375.0"/>
-      <point x="84.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="295" y="373"/>
+      <point x="295" y="447" type="curve" smooth="yes"/>
+      <point x="295" y="488"/>
+      <point x="275" y="520"/>
+      <point x="241" y="540" type="curve"/>
+      <point x="263" y="555"/>
+      <point x="283" y="586"/>
+      <point x="283" y="617" type="curve" smooth="yes"/>
+      <point x="283" y="682"/>
+      <point x="230" y="724"/>
+      <point x="162" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="40" y="682"/>
+      <point x="40" y="617" type="curve" smooth="yes"/>
+      <point x="40" y="585"/>
+      <point x="59" y="555"/>
+      <point x="82" y="540" type="curve"/>
+      <point x="48" y="520"/>
+      <point x="28" y="488"/>
+      <point x="28" y="447" type="curve" smooth="yes"/>
+      <point x="28" y="375"/>
+      <point x="88" y="330"/>
     </contour>
     <contour>
-      <point x="162.0" y="374.0" type="curve" smooth="yes"/>
-      <point x="109.0" y="374.0"/>
-      <point x="82.0" y="404.0"/>
-      <point x="82.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="82.0" y="486.0"/>
-      <point x="110.0" y="516.0"/>
-      <point x="162.0" y="516.0" type="curve" smooth="yes"/>
-      <point x="216.0" y="516.0"/>
-      <point x="241.0" y="485.0"/>
-      <point x="241.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="405.0"/>
-      <point x="218.0" y="374.0"/>
+      <point x="162" y="389" type="curve" smooth="yes"/>
+      <point x="123" y="389"/>
+      <point x="95" y="414"/>
+      <point x="95" y="450" type="curve" smooth="yes"/>
+      <point x="95" y="485"/>
+      <point x="123" y="510"/>
+      <point x="162" y="510" type="curve" smooth="yes"/>
+      <point x="201" y="510"/>
+      <point x="228" y="484"/>
+      <point x="228" y="450" type="curve" smooth="yes"/>
+      <point x="228" y="415"/>
+      <point x="201" y="389"/>
     </contour>
     <contour>
-      <point x="162.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="556.0"/>
-      <point x="97.0" y="584.0"/>
-      <point x="97.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="97.0" y="656.0"/>
-      <point x="123.0" y="680.0"/>
-      <point x="162.0" y="680.0" type="curve" smooth="yes"/>
-      <point x="203.0" y="680.0"/>
-      <point x="226.0" y="655.0"/>
-      <point x="226.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="226.0" y="584.0"/>
-      <point x="204.0" y="556.0"/>
+      <point x="162" y="564" type="curve" smooth="yes"/>
+      <point x="130" y="564"/>
+      <point x="107" y="584"/>
+      <point x="107" y="614" type="curve" smooth="yes"/>
+      <point x="107" y="644"/>
+      <point x="130" y="665"/>
+      <point x="162" y="665" type="curve" smooth="yes"/>
+      <point x="194" y="665"/>
+      <point x="216" y="644"/>
+      <point x="216" y="614" type="curve" smooth="yes"/>
+      <point x="216" y="584"/>
+      <point x="194" y="564"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="eight.numerator" xOffset="264" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>eight.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="162.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="331.0"/>
-      <point x="289.0" y="386.0"/>
-      <point x="289.0" y="461.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="539.0"/>
-      <point x="249.0" y="589.0"/>
-      <point x="178.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="133.0" y="589.0"/>
-      <point x="100.0" y="570.0"/>
-      <point x="84.0" y="548.0" type="curve"/>
-      <point x="101.0" y="673.0" type="line"/>
-      <point x="268.0" y="673.0" type="line"/>
-      <point x="268.0" y="716.0" type="line"/>
-      <point x="71.0" y="716.0" type="line"/>
-      <point x="46.0" y="521.0" type="line"/>
-      <point x="85.0" y="504.0" type="line"/>
-      <point x="104.0" y="531.0"/>
-      <point x="130.0" y="546.0"/>
-      <point x="165.0" y="546.0" type="curve" smooth="yes"/>
-      <point x="212.0" y="546.0"/>
-      <point x="241.0" y="517.0"/>
-      <point x="241.0" y="462.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="406.0"/>
-      <point x="215.0" y="375.0"/>
-      <point x="165.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="119.0" y="375.0"/>
-      <point x="84.0" y="405.0"/>
-      <point x="76.0" y="443.0" type="curve"/>
-      <point x="33.0" y="436.0" type="line"/>
-      <point x="45.0" y="371.0"/>
-      <point x="92.0" y="331.0"/>
+      <point x="162" y="331" type="curve" smooth="yes"/>
+      <point x="244" y="331"/>
+      <point x="294" y="386"/>
+      <point x="294" y="461" type="curve" smooth="yes"/>
+      <point x="294" y="539"/>
+      <point x="249" y="589"/>
+      <point x="172" y="589" type="curve" smooth="yes"/>
+      <point x="142" y="589"/>
+      <point x="117" y="579"/>
+      <point x="103" y="563" type="curve"/>
+      <point x="118" y="660" type="line"/>
+      <point x="273" y="660" type="line"/>
+      <point x="273" y="716" type="line"/>
+      <point x="66" y="716" type="line"/>
+      <point x="41" y="521" type="line"/>
+      <point x="97" y="498" type="line"/>
+      <point x="111" y="520"/>
+      <point x="133" y="533"/>
+      <point x="162" y="533" type="curve" smooth="yes"/>
+      <point x="201" y="533"/>
+      <point x="228" y="507"/>
+      <point x="228" y="462" type="curve" smooth="yes"/>
+      <point x="228" y="417"/>
+      <point x="201" y="390"/>
+      <point x="162" y="390" type="curve" smooth="yes"/>
+      <point x="124" y="390"/>
+      <point x="99" y="416"/>
+      <point x="92" y="448" type="curve"/>
+      <point x="28" y="435" type="line"/>
+      <point x="40" y="370"/>
+      <point x="92" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="five.numerator" xOffset="265" yOffset="-168"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>five.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="30.0" y="423.0" type="line"/>
-      <point x="321.0" y="423.0" type="line"/>
-      <point x="321.0" y="466.0" type="line"/>
-      <point x="93.0" y="466.0" type="line"/>
-      <point x="215.0" y="644.0" type="line"/>
-      <point x="219.0" y="644.0" type="line"/>
-      <point x="219.0" y="338.0" type="line"/>
-      <point x="264.0" y="338.0" type="line"/>
-      <point x="264.0" y="716.0" type="line"/>
-      <point x="216.0" y="716.0" type="line"/>
-      <point x="30.0" y="455.0" type="line"/>
+      <point x="30" y="416" type="line"/>
+      <point x="321" y="416" type="line"/>
+      <point x="321" y="472" type="line"/>
+      <point x="105" y="472" type="line"/>
+      <point x="203" y="617" type="line"/>
+      <point x="207" y="617" type="line"/>
+      <point x="207" y="338" type="line"/>
+      <point x="272" y="338" type="line"/>
+      <point x="272" y="716" type="line"/>
+      <point x="211" y="716" type="line"/>
+      <point x="30" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="four.numerator" xOffset="230" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>four.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="322"/>
   <outline>
     <contour>
-      <point x="130.0" y="332.0" type="line"/>
-      <point x="174.0" y="351.0"/>
-      <point x="215.0" y="383.0"/>
-      <point x="244.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="462.0"/>
-      <point x="293.0" y="509.0"/>
-      <point x="293.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="293.0" y="670.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="158.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="88.0" y="724.0"/>
-      <point x="30.0" y="670.0"/>
-      <point x="30.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="529.0"/>
-      <point x="64.0" y="474.0"/>
-      <point x="138.0" y="474.0" type="curve" smooth="yes"/>
-      <point x="187.0" y="474.0"/>
-      <point x="239.0" y="499.0"/>
-      <point x="263.0" y="534.0" type="curve"/>
-      <point x="229.0" y="451.0"/>
-      <point x="179.0" y="404.0"/>
-      <point x="114.0" y="372.0" type="curve"/>
+      <point x="130" y="332" type="line"/>
+      <point x="174" y="351"/>
+      <point x="216" y="383"/>
+      <point x="246" y="423" type="curve" smooth="yes"/>
+      <point x="275" y="462"/>
+      <point x="295" y="509"/>
+      <point x="295" y="568" type="curve" smooth="yes"/>
+      <point x="295" y="670"/>
+      <point x="235" y="724"/>
+      <point x="159" y="724" type="curve" smooth="yes"/>
+      <point x="87" y="724"/>
+      <point x="27" y="670"/>
+      <point x="27" y="598" type="curve" smooth="yes"/>
+      <point x="27" y="529"/>
+      <point x="71" y="474"/>
+      <point x="138" y="474" type="curve" smooth="yes"/>
+      <point x="177" y="474"/>
+      <point x="212" y="489"/>
+      <point x="231" y="518" type="curve"/>
+      <point x="218" y="458"/>
+      <point x="166" y="411"/>
+      <point x="101" y="379" type="curve"/>
     </contour>
     <contour>
-      <point x="159.0" y="514.0" type="curve" smooth="yes"/>
-      <point x="107.0" y="514.0"/>
-      <point x="74.0" y="551.0"/>
-      <point x="74.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="74.0" y="642.0"/>
-      <point x="107.0" y="681.0"/>
-      <point x="159.0" y="681.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="681.0"/>
-      <point x="245.0" y="642.0"/>
-      <point x="245.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="551.0"/>
-      <point x="213.0" y="514.0"/>
+      <point x="160" y="530" type="curve" smooth="yes"/>
+      <point x="119" y="530"/>
+      <point x="94" y="560"/>
+      <point x="94" y="597" type="curve" smooth="yes"/>
+      <point x="94" y="634"/>
+      <point x="119" y="665"/>
+      <point x="160" y="665" type="curve" smooth="yes"/>
+      <point x="201" y="665"/>
+      <point x="226" y="634"/>
+      <point x="226" y="597" type="curve" smooth="yes"/>
+      <point x="226" y="560"/>
+      <point x="201" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="nine.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>nine.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="131.0" y="338.0" type="line"/>
-      <point x="178.0" y="338.0" type="line"/>
-      <point x="178.0" y="716.0" type="line"/>
-      <point x="130.0" y="716.0" type="line"/>
-      <point x="32.0" y="644.0" type="line"/>
-      <point x="24.0" y="576.0" type="line"/>
-      <point x="131.0" y="651.0" type="line"/>
+      <point x="121" y="338" type="line"/>
+      <point x="186" y="338" type="line"/>
+      <point x="186" y="716" type="line"/>
+      <point x="130" y="716" type="line"/>
+      <point x="32" y="644" type="line"/>
+      <point x="32" y="565" type="line"/>
+      <point x="121" y="629" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="one.numerator" xOffset="285" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>one.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="162.0" y="338.0" type="line"/>
-      <point x="159.0" y="461.0"/>
-      <point x="199.0" y="596.0"/>
-      <point x="283.0" y="676.0" type="curve"/>
-      <point x="283.0" y="716.0" type="line"/>
-      <point x="28.0" y="716.0" type="line"/>
-      <point x="28.0" y="672.0" type="line"/>
-      <point x="233.0" y="672.0" type="line"/>
-      <point x="176.0" y="609.0"/>
-      <point x="103.0" y="484.0"/>
-      <point x="106.0" y="330.0" type="curve"/>
+      <point x="162" y="338" type="line"/>
+      <point x="162" y="460"/>
+      <point x="199" y="581"/>
+      <point x="283" y="661" type="curve"/>
+      <point x="283" y="716" type="line"/>
+      <point x="28" y="716" type="line"/>
+      <point x="28" y="657" type="line"/>
+      <point x="211" y="657" type="line"/>
+      <point x="153" y="594"/>
+      <point x="90" y="491"/>
+      <point x="90" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="161.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="330.0"/>
-      <point x="290.0" y="384.0"/>
-      <point x="290.0" y="456.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="525.0"/>
-      <point x="256.0" y="580.0"/>
-      <point x="182.0" y="580.0" type="curve" smooth="yes"/>
-      <point x="133.0" y="580.0"/>
-      <point x="81.0" y="555.0"/>
-      <point x="56.0" y="520.0" type="curve"/>
-      <point x="90.0" y="603.0"/>
-      <point x="141.0" y="650.0"/>
-      <point x="206.0" y="682.0" type="curve"/>
-      <point x="190.0" y="722.0" type="line"/>
-      <point x="146.0" y="703.0"/>
-      <point x="105.0" y="671.0"/>
-      <point x="76.0" y="631.0" type="curve" smooth="yes"/>
-      <point x="47.0" y="592.0"/>
-      <point x="27.0" y="545.0"/>
-      <point x="27.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="27.0" y="384.0"/>
-      <point x="86.0" y="330.0"/>
+      <point x="161" y="330" type="curve" smooth="yes"/>
+      <point x="233" y="330"/>
+      <point x="293" y="384"/>
+      <point x="293" y="456" type="curve" smooth="yes"/>
+      <point x="293" y="525"/>
+      <point x="249" y="580"/>
+      <point x="182" y="580" type="curve" smooth="yes"/>
+      <point x="143" y="580"/>
+      <point x="108" y="565"/>
+      <point x="89" y="536" type="curve"/>
+      <point x="102" y="596"/>
+      <point x="154" y="643"/>
+      <point x="219" y="675" type="curve"/>
+      <point x="190" y="722" type="line"/>
+      <point x="146" y="703"/>
+      <point x="104" y="671"/>
+      <point x="74" y="631" type="curve" smooth="yes"/>
+      <point x="45" y="592"/>
+      <point x="25" y="545"/>
+      <point x="25" y="486" type="curve" smooth="yes"/>
+      <point x="25" y="384"/>
+      <point x="85" y="330"/>
     </contour>
     <contour>
-      <point x="160.0" y="373.0" type="curve" smooth="yes"/>
-      <point x="107.0" y="373.0"/>
-      <point x="75.0" y="412.0"/>
-      <point x="75.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="75.0" y="503.0"/>
-      <point x="107.0" y="540.0"/>
-      <point x="160.0" y="540.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="540.0"/>
-      <point x="246.0" y="503.0"/>
-      <point x="246.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="246.0" y="412.0"/>
-      <point x="213.0" y="373.0"/>
+      <point x="160" y="389" type="curve" smooth="yes"/>
+      <point x="119" y="389"/>
+      <point x="94" y="420"/>
+      <point x="94" y="457" type="curve" smooth="yes"/>
+      <point x="94" y="494"/>
+      <point x="119" y="524"/>
+      <point x="160" y="524" type="curve" smooth="yes"/>
+      <point x="201" y="524"/>
+      <point x="226" y="494"/>
+      <point x="226" y="457" type="curve" smooth="yes"/>
+      <point x="226" y="420"/>
+      <point x="201" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="six.numerator" xOffset="258" yOffset="-161"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>six.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="236.0" y="330.0"/>
-      <point x="287.0" y="375.0"/>
-      <point x="287.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="287.0" y="494.0"/>
-      <point x="257.0" y="524.0"/>
-      <point x="217.0" y="536.0" type="curve"/>
-      <point x="249.0" y="551.0"/>
-      <point x="275.0" y="586.0"/>
-      <point x="275.0" y="623.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="684.0"/>
-      <point x="231.0" y="724.0"/>
-      <point x="160.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="47.0" y="682.0"/>
-      <point x="37.0" y="627.0" type="curve"/>
-      <point x="88.0" y="622.0" type="line"/>
-      <point x="96.0" y="647.0"/>
-      <point x="124.0" y="677.0"/>
-      <point x="159.0" y="677.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="677.0"/>
-      <point x="225.0" y="651.0"/>
-      <point x="225.0" y="620.0" type="curve" smooth="yes"/>
-      <point x="225.0" y="581.0"/>
-      <point x="195.0" y="556.0"/>
-      <point x="151.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="556.0"/>
-      <point x="127.0" y="556.0"/>
-      <point x="127.0" y="556.0" type="curve"/>
-      <point x="127.0" y="510.0" type="line"/>
-      <point x="127.0" y="510.0"/>
-      <point x="133.0" y="510.0"/>
-      <point x="158.0" y="510.0" type="curve" smooth="yes"/>
-      <point x="208.0" y="510.0"/>
-      <point x="237.0" y="481.0"/>
-      <point x="237.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="237.0" y="403.0"/>
-      <point x="214.0" y="374.0"/>
-      <point x="167.0" y="374.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="374.0"/>
-      <point x="84.0" y="399.0"/>
-      <point x="76.0" y="448.0" type="curve"/>
-      <point x="32.0" y="444.0" type="line"/>
-      <point x="42.0" y="370.0"/>
-      <point x="92.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="292" y="375"/>
+      <point x="292" y="446" type="curve" smooth="yes"/>
+      <point x="292" y="494"/>
+      <point x="270" y="522"/>
+      <point x="234" y="536" type="curve"/>
+      <point x="261" y="557"/>
+      <point x="280" y="586"/>
+      <point x="280" y="623" type="curve" smooth="yes"/>
+      <point x="280" y="684"/>
+      <point x="231" y="724"/>
+      <point x="160" y="724" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="45" y="683"/>
+      <point x="35" y="628" type="curve"/>
+      <point x="98" y="617" type="line"/>
+      <point x="106" y="642"/>
+      <point x="126" y="665"/>
+      <point x="160" y="665" type="curve" smooth="yes"/>
+      <point x="193" y="665"/>
+      <point x="213" y="645"/>
+      <point x="213" y="616" type="curve" smooth="yes"/>
+      <point x="213" y="577"/>
+      <point x="186" y="561"/>
+      <point x="151" y="561" type="curve" smooth="yes"/>
+      <point x="143" y="561"/>
+      <point x="127" y="561"/>
+      <point x="127" y="561" type="curve"/>
+      <point x="127" y="505" type="line"/>
+      <point x="127" y="505"/>
+      <point x="133" y="505"/>
+      <point x="158" y="505" type="curve" smooth="yes"/>
+      <point x="200" y="505"/>
+      <point x="226" y="481"/>
+      <point x="226" y="449" type="curve" smooth="yes"/>
+      <point x="226" y="411"/>
+      <point x="199" y="389"/>
+      <point x="162" y="389" type="curve" smooth="yes"/>
+      <point x="126" y="389"/>
+      <point x="99" y="410"/>
+      <point x="91" y="454" type="curve"/>
+      <point x="27" y="443" type="line"/>
+      <point x="37" y="369"/>
+      <point x="92" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="three.numerator" xOffset="266" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>three.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="36.0" y="338.0" type="line"/>
-      <point x="283.0" y="338.0" type="line"/>
-      <point x="283.0" y="382.0" type="line"/>
-      <point x="100.0" y="382.0" type="line"/>
-      <point x="134.0" y="407.0"/>
-      <point x="187.0" y="457.0"/>
-      <point x="212.0" y="485.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="525.0"/>
-      <point x="274.0" y="559.0"/>
-      <point x="274.0" y="610.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="680.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="156.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="34.0" y="679.0"/>
-      <point x="28.0" y="608.0" type="curve"/>
-      <point x="80.0" y="603.0" type="line"/>
-      <point x="85.0" y="643.0"/>
-      <point x="108.0" y="679.0"/>
-      <point x="157.0" y="679.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="679.0"/>
-      <point x="223.0" y="651.0"/>
-      <point x="223.0" y="607.0" type="curve" smooth="yes"/>
-      <point x="223.0" y="575.0"/>
-      <point x="206.0" y="546.0"/>
-      <point x="180.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="481.0"/>
-      <point x="102.0" y="439.0"/>
-      <point x="36.0" y="389.0" type="curve"/>
+      <point x="36" y="338" type="line"/>
+      <point x="283" y="338" type="line"/>
+      <point x="283" y="397" type="line"/>
+      <point x="132" y="397" type="line"/>
+      <point x="166" y="422"/>
+      <point x="197" y="448"/>
+      <point x="222" y="476" type="curve" smooth="yes"/>
+      <point x="258" y="516"/>
+      <point x="281" y="559"/>
+      <point x="281" y="610" type="curve" smooth="yes"/>
+      <point x="281" y="680"/>
+      <point x="233" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="34" y="679"/>
+      <point x="28" y="608" type="curve"/>
+      <point x="94" y="597" type="line"/>
+      <point x="99" y="637"/>
+      <point x="119" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="189" y="665"/>
+      <point x="215" y="645"/>
+      <point x="215" y="607" type="curve" smooth="yes"/>
+      <point x="215" y="575"/>
+      <point x="203" y="546"/>
+      <point x="177" y="515" type="curve" smooth="yes"/>
+      <point x="148" y="481"/>
+      <point x="102" y="444"/>
+      <point x="36" y="394" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>two.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/kerning.plist
@@ -12369,12 +12369,18 @@
     </dict>
     <key>six</key>
     <dict>
+      <key>five.numerator</key>
+      <integer>-10</integer>
+      <key>nine.numerator</key>
+      <integer>-10</integer>
       <key>public.kern2.GRK_Psi</key>
       <integer>-30</integer>
       <key>public.kern2.GRK_Tau</key>
       <integer>-10</integer>
       <key>public.kern2.GRK_Upsilon</key>
       <integer>-30</integer>
+      <key>six.numerator</key>
+      <integer>-10</integer>
     </dict>
     <key>six.alt</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/kerning.plist
@@ -12369,12 +12369,18 @@
     </dict>
     <key>six</key>
     <dict>
+      <key>five.numerator</key>
+      <integer>-10</integer>
+      <key>nine.numerator</key>
+      <integer>-10</integer>
       <key>public.kern2.GRK_Psi</key>
       <integer>-30</integer>
       <key>public.kern2.GRK_Tau</key>
       <integer>-10</integer>
       <key>public.kern2.GRK_Upsilon</key>
       <integer>-30</integer>
+      <key>six.numerator</key>
+      <integer>-10</integer>
     </dict>
     <key>six.alt</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-23.0" type="curve" smooth="yes"/>
-      <point x="635.0" y="-23.0"/>
-      <point x="806.0" y="148.0"/>
-      <point x="806.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="806.0" y="568.0"/>
-      <point x="635.0" y="739.0"/>
-      <point x="425.0" y="739.0" type="curve" smooth="yes"/>
-      <point x="215.0" y="739.0"/>
-      <point x="44.0" y="568.0"/>
-      <point x="44.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="44.0" y="148.0"/>
-      <point x="215.0" y="-23.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="56.0" type="curve" smooth="yes"/>
-      <point x="260.0" y="56.0"/>
-      <point x="123.0" y="193.0"/>
-      <point x="123.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="123.0" y="526.0"/>
-      <point x="260.0" y="660.0"/>
-      <point x="425.0" y="660.0" type="curve" smooth="yes"/>
-      <point x="594.0" y="660.0"/>
-      <point x="727.0" y="526.0"/>
-      <point x="727.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="727.0" y="193.0"/>
-      <point x="594.0" y="56.0"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="330.0"/>
-      <point x="300.0" y="373.0"/>
-      <point x="300.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="300.0" y="498.0"/>
-      <point x="271.0" y="531.0"/>
-      <point x="238.0" y="540.0" type="curve"/>
-      <point x="268.0" y="550.0"/>
-      <point x="288.0" y="577.0"/>
-      <point x="288.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="682.0"/>
-      <point x="236.0" y="724.0"/>
-      <point x="162.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="35.0" y="682.0"/>
-      <point x="35.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="35.0" y="579.0"/>
-      <point x="52.0" y="553.0"/>
-      <point x="77.0" y="540.0" type="curve"/>
-      <point x="48.0" y="530.0"/>
-      <point x="23.0" y="496.0"/>
-      <point x="23.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="23.0" y="375.0"/>
-      <point x="80.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="295" y="373"/>
+      <point x="295" y="447" type="curve" smooth="yes"/>
+      <point x="295" y="488"/>
+      <point x="275" y="520"/>
+      <point x="241" y="540" type="curve"/>
+      <point x="263" y="555"/>
+      <point x="283" y="586"/>
+      <point x="283" y="617" type="curve" smooth="yes"/>
+      <point x="283" y="682"/>
+      <point x="230" y="724"/>
+      <point x="162" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="40" y="682"/>
+      <point x="40" y="617" type="curve" smooth="yes"/>
+      <point x="40" y="585"/>
+      <point x="59" y="555"/>
+      <point x="82" y="540" type="curve"/>
+      <point x="48" y="520"/>
+      <point x="28" y="488"/>
+      <point x="28" y="447" type="curve" smooth="yes"/>
+      <point x="28" y="375"/>
+      <point x="88" y="330"/>
     </contour>
     <contour>
-      <point x="162.0" y="401.0" type="curve" smooth="yes"/>
-      <point x="129.0" y="401.0"/>
-      <point x="110.0" y="418.0"/>
-      <point x="110.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="110.0" y="482.0"/>
-      <point x="125.0" y="503.0"/>
-      <point x="162.0" y="503.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="503.0"/>
-      <point x="213.0" y="480.0"/>
-      <point x="213.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="420.0"/>
-      <point x="198.0" y="401.0"/>
+      <point x="162" y="389" type="curve" smooth="yes"/>
+      <point x="123" y="389"/>
+      <point x="95" y="414"/>
+      <point x="95" y="450" type="curve" smooth="yes"/>
+      <point x="95" y="485"/>
+      <point x="123" y="510"/>
+      <point x="162" y="510" type="curve" smooth="yes"/>
+      <point x="201" y="510"/>
+      <point x="228" y="484"/>
+      <point x="228" y="450" type="curve" smooth="yes"/>
+      <point x="228" y="415"/>
+      <point x="201" y="389"/>
     </contour>
     <contour>
-      <point x="162.0" y="566.0" type="curve" smooth="yes"/>
-      <point x="135.0" y="566.0"/>
-      <point x="120.0" y="587.0"/>
-      <point x="120.0" y="609.0" type="curve" smooth="yes"/>
-      <point x="120.0" y="633.0"/>
-      <point x="138.0" y="653.0"/>
-      <point x="162.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="188.0" y="653.0"/>
-      <point x="203.0" y="636.0"/>
-      <point x="203.0" y="609.0" type="curve" smooth="yes"/>
-      <point x="203.0" y="583.0"/>
-      <point x="191.0" y="566.0"/>
+      <point x="162" y="564" type="curve" smooth="yes"/>
+      <point x="130" y="564"/>
+      <point x="107" y="584"/>
+      <point x="107" y="614" type="curve" smooth="yes"/>
+      <point x="107" y="644"/>
+      <point x="130" y="665"/>
+      <point x="162" y="665" type="curve" smooth="yes"/>
+      <point x="194" y="665"/>
+      <point x="216" y="644"/>
+      <point x="216" y="614" type="curve" smooth="yes"/>
+      <point x="216" y="584"/>
+      <point x="194" y="564"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="eight.numerator" xOffset="264" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>eight.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="162.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="331.0"/>
-      <point x="299.0" y="380.0"/>
-      <point x="299.0" y="461.0" type="curve" smooth="yes"/>
-      <point x="299.0" y="542.0"/>
-      <point x="256.0" y="589.0"/>
-      <point x="172.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="589.0"/>
-      <point x="119.0" y="579.0"/>
-      <point x="105.0" y="563.0" type="curve"/>
-      <point x="118.0" y="641.0" type="line"/>
-      <point x="273.0" y="641.0" type="line"/>
-      <point x="273.0" y="716.0" type="line"/>
-      <point x="61.0" y="716.0" type="line"/>
-      <point x="36.0" y="521.0" type="line"/>
-      <point x="105.0" y="493.0" type="line"/>
-      <point x="115.0" y="509.0"/>
-      <point x="133.0" y="523.0"/>
-      <point x="162.0" y="523.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="523.0"/>
-      <point x="218.0" y="501.0"/>
-      <point x="218.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="218.0" y="417.0"/>
-      <point x="198.0" y="400.0"/>
-      <point x="162.0" y="400.0" type="curve" smooth="yes"/>
-      <point x="124.0" y="400.0"/>
-      <point x="108.0" y="421.0"/>
-      <point x="101.0" y="453.0" type="curve"/>
-      <point x="23.0" y="435.0" type="line"/>
-      <point x="34.0" y="375.0"/>
-      <point x="81.0" y="331.0"/>
+      <point x="162" y="331" type="curve" smooth="yes"/>
+      <point x="244" y="331"/>
+      <point x="294" y="386"/>
+      <point x="294" y="461" type="curve" smooth="yes"/>
+      <point x="294" y="539"/>
+      <point x="249" y="589"/>
+      <point x="172" y="589" type="curve" smooth="yes"/>
+      <point x="142" y="589"/>
+      <point x="117" y="579"/>
+      <point x="103" y="563" type="curve"/>
+      <point x="118" y="660" type="line"/>
+      <point x="273" y="660" type="line"/>
+      <point x="273" y="716" type="line"/>
+      <point x="66" y="716" type="line"/>
+      <point x="41" y="521" type="line"/>
+      <point x="97" y="498" type="line"/>
+      <point x="111" y="520"/>
+      <point x="133" y="533"/>
+      <point x="162" y="533" type="curve" smooth="yes"/>
+      <point x="201" y="533"/>
+      <point x="228" y="507"/>
+      <point x="228" y="462" type="curve" smooth="yes"/>
+      <point x="228" y="417"/>
+      <point x="201" y="390"/>
+      <point x="162" y="390" type="curve" smooth="yes"/>
+      <point x="124" y="390"/>
+      <point x="99" y="416"/>
+      <point x="92" y="448" type="curve"/>
+      <point x="28" y="435" type="line"/>
+      <point x="40" y="370"/>
+      <point x="92" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="five.numerator" xOffset="265" yOffset="-168"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>five.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="21.0" y="409.0" type="line"/>
-      <point x="321.0" y="409.0" type="line"/>
-      <point x="321.0" y="477.0" type="line"/>
-      <point x="117.0" y="477.0" type="line"/>
-      <point x="193.0" y="592.0" type="line"/>
-      <point x="200.0" y="592.0" type="line"/>
-      <point x="200.0" y="338.0" type="line"/>
-      <point x="279.0" y="338.0" type="line"/>
-      <point x="279.0" y="716.0" type="line"/>
-      <point x="202.0" y="716.0" type="line"/>
-      <point x="21.0" y="460.0" type="line"/>
+      <point x="30" y="416" type="line"/>
+      <point x="321" y="416" type="line"/>
+      <point x="321" y="472" type="line"/>
+      <point x="105" y="472" type="line"/>
+      <point x="203" y="617" type="line"/>
+      <point x="207" y="617" type="line"/>
+      <point x="207" y="338" type="line"/>
+      <point x="272" y="338" type="line"/>
+      <point x="272" y="716" type="line"/>
+      <point x="211" y="716" type="line"/>
+      <point x="30" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="four.numerator" xOffset="230" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>four.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="322"/>
   <outline>
     <contour>
-      <point x="136.0" y="329.0" type="line"/>
-      <point x="180.0" y="348.0"/>
-      <point x="227.0" y="382.0"/>
-      <point x="256.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="284.0" y="463.0"/>
-      <point x="302.0" y="509.0"/>
-      <point x="302.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="302.0" y="670.0"/>
-      <point x="238.0" y="724.0"/>
-      <point x="158.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="79.0" y="724.0"/>
-      <point x="19.0" y="670.0"/>
-      <point x="19.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="19.0" y="511.0"/>
-      <point x="57.0" y="464.0"/>
-      <point x="134.0" y="464.0" type="curve" smooth="yes"/>
-      <point x="169.0" y="464.0"/>
-      <point x="194.0" y="477.0"/>
-      <point x="209.0" y="503.0" type="curve"/>
-      <point x="207.0" y="458.0"/>
-      <point x="156.0" y="411.0"/>
-      <point x="91.0" y="379.0" type="curve"/>
+      <point x="130" y="332" type="line"/>
+      <point x="174" y="351"/>
+      <point x="216" y="383"/>
+      <point x="246" y="423" type="curve" smooth="yes"/>
+      <point x="275" y="462"/>
+      <point x="295" y="509"/>
+      <point x="295" y="568" type="curve" smooth="yes"/>
+      <point x="295" y="670"/>
+      <point x="235" y="724"/>
+      <point x="159" y="724" type="curve" smooth="yes"/>
+      <point x="87" y="724"/>
+      <point x="27" y="670"/>
+      <point x="27" y="598" type="curve" smooth="yes"/>
+      <point x="27" y="529"/>
+      <point x="71" y="474"/>
+      <point x="138" y="474" type="curve" smooth="yes"/>
+      <point x="177" y="474"/>
+      <point x="212" y="489"/>
+      <point x="231" y="518" type="curve"/>
+      <point x="218" y="458"/>
+      <point x="166" y="411"/>
+      <point x="101" y="379" type="curve"/>
     </contour>
     <contour>
-      <point x="159.0" y="535.0" type="curve" smooth="yes"/>
-      <point x="120.0" y="535.0"/>
-      <point x="102.0" y="560.0"/>
-      <point x="102.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="102.0" y="627.0"/>
-      <point x="124.0" y="650.0"/>
-      <point x="159.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="195.0" y="650.0"/>
-      <point x="216.0" y="629.0"/>
-      <point x="216.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="216.0" y="558.0"/>
-      <point x="200.0" y="535.0"/>
+      <point x="160" y="530" type="curve" smooth="yes"/>
+      <point x="119" y="530"/>
+      <point x="94" y="560"/>
+      <point x="94" y="597" type="curve" smooth="yes"/>
+      <point x="94" y="634"/>
+      <point x="119" y="665"/>
+      <point x="160" y="665" type="curve" smooth="yes"/>
+      <point x="201" y="665"/>
+      <point x="226" y="634"/>
+      <point x="226" y="597" type="curve" smooth="yes"/>
+      <point x="226" y="560"/>
+      <point x="201" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="nine.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>nine.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="111.0" y="338.0" type="line"/>
-      <point x="206.0" y="338.0" type="line"/>
-      <point x="206.0" y="716.0" type="line"/>
-      <point x="120.0" y="716.0" type="line"/>
-      <point x="14.0" y="640.0" type="line"/>
-      <point x="32.0" y="538.0" type="line"/>
-      <point x="111.0" y="587.0" type="line"/>
+      <point x="121" y="338" type="line"/>
+      <point x="186" y="338" type="line"/>
+      <point x="186" y="716" type="line"/>
+      <point x="130" y="716" type="line"/>
+      <point x="32" y="644" type="line"/>
+      <point x="32" y="565" type="line"/>
+      <point x="121" y="629" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="one.numerator" xOffset="285" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>one.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="167.0" y="338.0" type="line"/>
-      <point x="166.0" y="459.0"/>
-      <point x="199.0" y="573.0"/>
-      <point x="283.0" y="653.0" type="curve"/>
-      <point x="283.0" y="716.0" type="line"/>
-      <point x="28.0" y="716.0" type="line"/>
-      <point x="28.0" y="640.0" type="line"/>
-      <point x="193.0" y="640.0" type="line"/>
-      <point x="135.0" y="577.0"/>
-      <point x="85.0" y="491.0"/>
-      <point x="80.0" y="338.0" type="curve"/>
+      <point x="162" y="338" type="line"/>
+      <point x="162" y="460"/>
+      <point x="199" y="581"/>
+      <point x="283" y="661" type="curve"/>
+      <point x="283" y="716" type="line"/>
+      <point x="28" y="716" type="line"/>
+      <point x="28" y="657" type="line"/>
+      <point x="211" y="657" type="line"/>
+      <point x="153" y="594"/>
+      <point x="90" y="491"/>
+      <point x="90" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="161.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="330.0"/>
-      <point x="301.0" y="384.0"/>
-      <point x="301.0" y="456.0" type="curve" smooth="yes"/>
-      <point x="301.0" y="543.0"/>
-      <point x="263.0" y="590.0"/>
-      <point x="186.0" y="590.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="590.0"/>
-      <point x="126.0" y="577.0"/>
-      <point x="110.0" y="551.0" type="curve"/>
-      <point x="112.0" y="596.0"/>
-      <point x="164.0" y="643.0"/>
-      <point x="229.0" y="675.0" type="curve"/>
-      <point x="184.0" y="725.0" type="line"/>
-      <point x="140.0" y="706.0"/>
-      <point x="93.0" y="672.0"/>
-      <point x="64.0" y="631.0" type="curve" smooth="yes"/>
-      <point x="36.0" y="591.0"/>
-      <point x="18.0" y="545.0"/>
-      <point x="18.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="18.0" y="384.0"/>
-      <point x="81.0" y="330.0"/>
+      <point x="161" y="330" type="curve" smooth="yes"/>
+      <point x="233" y="330"/>
+      <point x="293" y="384"/>
+      <point x="293" y="456" type="curve" smooth="yes"/>
+      <point x="293" y="525"/>
+      <point x="249" y="580"/>
+      <point x="182" y="580" type="curve" smooth="yes"/>
+      <point x="143" y="580"/>
+      <point x="108" y="565"/>
+      <point x="89" y="536" type="curve"/>
+      <point x="102" y="596"/>
+      <point x="154" y="643"/>
+      <point x="219" y="675" type="curve"/>
+      <point x="190" y="722" type="line"/>
+      <point x="146" y="703"/>
+      <point x="104" y="671"/>
+      <point x="74" y="631" type="curve" smooth="yes"/>
+      <point x="45" y="592"/>
+      <point x="25" y="545"/>
+      <point x="25" y="486" type="curve" smooth="yes"/>
+      <point x="25" y="384"/>
+      <point x="85" y="330"/>
     </contour>
     <contour>
-      <point x="160.0" y="404.0" type="curve" smooth="yes"/>
-      <point x="125.0" y="404.0"/>
-      <point x="104.0" y="425.0"/>
-      <point x="104.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="104.0" y="496.0"/>
-      <point x="120.0" y="519.0"/>
-      <point x="160.0" y="519.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="519.0"/>
-      <point x="218.0" y="494.0"/>
-      <point x="218.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="218.0" y="427.0"/>
-      <point x="196.0" y="404.0"/>
+      <point x="160" y="389" type="curve" smooth="yes"/>
+      <point x="119" y="389"/>
+      <point x="94" y="420"/>
+      <point x="94" y="457" type="curve" smooth="yes"/>
+      <point x="94" y="494"/>
+      <point x="119" y="524"/>
+      <point x="160" y="524" type="curve" smooth="yes"/>
+      <point x="201" y="524"/>
+      <point x="226" y="494"/>
+      <point x="226" y="457" type="curve" smooth="yes"/>
+      <point x="226" y="420"/>
+      <point x="201" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="six.numerator" xOffset="258" yOffset="-161"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>six.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="330.0"/>
-      <point x="298.0" y="375.0"/>
-      <point x="298.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="298.0" y="499.0"/>
-      <point x="274.0" y="529.0"/>
-      <point x="241.0" y="536.0" type="curve"/>
-      <point x="267.0" y="553.0"/>
-      <point x="290.0" y="586.0"/>
-      <point x="290.0" y="624.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="684.0"/>
-      <point x="239.0" y="724.0"/>
-      <point x="166.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="92.0" y="724.0"/>
-      <point x="41.0" y="685.0"/>
-      <point x="29.0" y="625.0" type="curve"/>
-      <point x="109.0" y="610.0" type="line"/>
-      <point x="116.0" y="636.0"/>
-      <point x="141.0" y="653.0"/>
-      <point x="161.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="191.0" y="653.0"/>
-      <point x="201.0" y="635.0"/>
-      <point x="201.0" y="613.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="583.0"/>
-      <point x="180.0" y="565.0"/>
-      <point x="151.0" y="565.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="565.0"/>
-      <point x="124.0" y="565.0"/>
-      <point x="124.0" y="565.0" type="curve"/>
-      <point x="124.0" y="498.0" type="line"/>
-      <point x="124.0" y="498.0"/>
-      <point x="150.0" y="498.0"/>
-      <point x="154.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="196.0" y="498.0"/>
-      <point x="217.0" y="478.0"/>
-      <point x="217.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="217.0" y="421.0"/>
-      <point x="201.0" y="402.0"/>
-      <point x="164.0" y="402.0" type="curve" smooth="yes"/>
-      <point x="126.0" y="402.0"/>
-      <point x="106.0" y="428.0"/>
-      <point x="98.0" y="462.0" type="curve"/>
-      <point x="23.0" y="445.0" type="line"/>
-      <point x="33.0" y="371.0"/>
-      <point x="92.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="292" y="375"/>
+      <point x="292" y="446" type="curve" smooth="yes"/>
+      <point x="292" y="494"/>
+      <point x="270" y="522"/>
+      <point x="234" y="536" type="curve"/>
+      <point x="261" y="557"/>
+      <point x="280" y="586"/>
+      <point x="280" y="623" type="curve" smooth="yes"/>
+      <point x="280" y="684"/>
+      <point x="231" y="724"/>
+      <point x="160" y="724" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="45" y="683"/>
+      <point x="35" y="628" type="curve"/>
+      <point x="98" y="617" type="line"/>
+      <point x="106" y="642"/>
+      <point x="126" y="665"/>
+      <point x="160" y="665" type="curve" smooth="yes"/>
+      <point x="193" y="665"/>
+      <point x="213" y="645"/>
+      <point x="213" y="616" type="curve" smooth="yes"/>
+      <point x="213" y="577"/>
+      <point x="186" y="561"/>
+      <point x="151" y="561" type="curve" smooth="yes"/>
+      <point x="143" y="561"/>
+      <point x="127" y="561"/>
+      <point x="127" y="561" type="curve"/>
+      <point x="127" y="505" type="line"/>
+      <point x="127" y="505"/>
+      <point x="133" y="505"/>
+      <point x="158" y="505" type="curve" smooth="yes"/>
+      <point x="200" y="505"/>
+      <point x="226" y="481"/>
+      <point x="226" y="449" type="curve" smooth="yes"/>
+      <point x="226" y="411"/>
+      <point x="199" y="389"/>
+      <point x="162" y="389" type="curve" smooth="yes"/>
+      <point x="126" y="389"/>
+      <point x="99" y="410"/>
+      <point x="91" y="454" type="curve"/>
+      <point x="27" y="443" type="line"/>
+      <point x="37" y="369"/>
+      <point x="92" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="three.numerator" xOffset="266" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>three.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="36.0" y="338.0" type="line"/>
-      <point x="288.0" y="338.0" type="line"/>
-      <point x="288.0" y="417.0" type="line"/>
-      <point x="155.0" y="417.0" type="line"/>
-      <point x="189.0" y="442.0"/>
-      <point x="197.0" y="444.0"/>
-      <point x="223.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="259.0" y="511.0"/>
-      <point x="284.0" y="559.0"/>
-      <point x="285.0" y="615.0" type="curve" smooth="yes"/>
-      <point x="286.0" y="680.0"/>
-      <point x="250.0" y="724.0"/>
-      <point x="159.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="86.0" y="724.0"/>
-      <point x="27.0" y="674.0"/>
-      <point x="22.0" y="610.0" type="curve"/>
-      <point x="106.0" y="592.0" type="line"/>
-      <point x="111.0" y="617.0"/>
-      <point x="124.0" y="645.0"/>
-      <point x="157.0" y="645.0" type="curve" smooth="yes"/>
-      <point x="182.0" y="645.0"/>
-      <point x="201.0" y="631.0"/>
-      <point x="201.0" y="601.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="579.0"/>
-      <point x="193.0" y="556.0"/>
-      <point x="167.0" y="525.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="491.0"/>
-      <point x="102.0" y="464.0"/>
-      <point x="36.0" y="414.0" type="curve"/>
+      <point x="36" y="338" type="line"/>
+      <point x="283" y="338" type="line"/>
+      <point x="283" y="397" type="line"/>
+      <point x="132" y="397" type="line"/>
+      <point x="166" y="422"/>
+      <point x="197" y="448"/>
+      <point x="222" y="476" type="curve" smooth="yes"/>
+      <point x="258" y="516"/>
+      <point x="281" y="559"/>
+      <point x="281" y="610" type="curve" smooth="yes"/>
+      <point x="281" y="680"/>
+      <point x="233" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="34" y="679"/>
+      <point x="28" y="608" type="curve"/>
+      <point x="94" y="597" type="line"/>
+      <point x="99" y="637"/>
+      <point x="119" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="189" y="665"/>
+      <point x="215" y="645"/>
+      <point x="215" y="607" type="curve" smooth="yes"/>
+      <point x="215" y="575"/>
+      <point x="203" y="546"/>
+      <point x="177" y="515" type="curve" smooth="yes"/>
+      <point x="148" y="481"/>
+      <point x="102" y="444"/>
+      <point x="36" y="394" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>two.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/kerning.plist
@@ -12369,12 +12369,18 @@
     </dict>
     <key>six</key>
     <dict>
+      <key>five.numerator</key>
+      <integer>-10</integer>
+      <key>nine.numerator</key>
+      <integer>-10</integer>
       <key>public.kern2.GRK_Psi</key>
       <integer>-30</integer>
       <key>public.kern2.GRK_Tau</key>
       <integer>-10</integer>
       <key>public.kern2.GRK_Upsilon</key>
       <integer>-30</integer>
+      <key>six.numerator</key>
+      <integer>-10</integer>
     </dict>
     <key>six.alt</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425" y="-14" type="curve" smooth="yes"/>
-      <point x="630" y="-14"/>
-      <point x="797" y="153"/>
-      <point x="797" y="358" type="curve" smooth="yes"/>
-      <point x="797" y="563"/>
-      <point x="630" y="730"/>
-      <point x="425" y="730" type="curve" smooth="yes"/>
-      <point x="220" y="730"/>
-      <point x="53" y="563"/>
-      <point x="53" y="358" type="curve" smooth="yes"/>
-      <point x="53" y="153"/>
-      <point x="220" y="-14"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="34" type="curve" smooth="yes"/>
-      <point x="249" y="34"/>
-      <point x="101" y="182"/>
-      <point x="101" y="358.0" type="curve" smooth="yes"/>
-      <point x="101" y="538"/>
-      <point x="249" y="682"/>
-      <point x="425.0" y="682" type="curve" smooth="yes"/>
-      <point x="606" y="682"/>
-      <point x="749" y="538"/>
-      <point x="749" y="358.0" type="curve" smooth="yes"/>
-      <point x="749" y="182"/>
-      <point x="606" y="34"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="313"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="228.0" y="342.0"/>
-      <point x="283.0" y="384.0"/>
-      <point x="283.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="490.0"/>
-      <point x="259.0" y="529.0"/>
-      <point x="212.0" y="543.0" type="curve"/>
-      <point x="247" y="552"/>
-      <point x="271.0" y="580.0"/>
-      <point x="271.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="271" y="682"/>
-      <point x="224" y="724.0"/>
-      <point x="157.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="90" y="724"/>
-      <point x="42" y="682"/>
-      <point x="42.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="42.0" y="582"/>
-      <point x="64.0" y="553.0"/>
-      <point x="100.0" y="543.0" type="curve"/>
-      <point x="54.0" y="525.0"/>
-      <point x="30.0" y="490.0"/>
-      <point x="30.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="385.0"/>
-      <point x="86" y="342"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="223" y="342"/>
+      <point x="290" y="384"/>
+      <point x="290" y="455" type="curve" smooth="yes"/>
+      <point x="290" y="490"/>
+      <point x="270" y="522"/>
+      <point x="236" y="543" type="curve"/>
+      <point x="259" y="558"/>
+      <point x="278" y="588"/>
+      <point x="278" y="616" type="curve" smooth="yes"/>
+      <point x="278" y="682"/>
+      <point x="219" y="724"/>
+      <point x="157" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="35" y="682"/>
+      <point x="35" y="616" type="curve" smooth="yes"/>
+      <point x="35" y="587"/>
+      <point x="53" y="558"/>
+      <point x="77" y="543" type="curve"/>
+      <point x="43" y="522"/>
+      <point x="23" y="490"/>
+      <point x="23" y="455" type="curve" smooth="yes"/>
+      <point x="23" y="385"/>
+      <point x="90" y="342"/>
     </contour>
     <contour>
-      <point x="157.0" y="386.0" type="curve" smooth="yes"/>
-      <point x="109.0" y="386"/>
-      <point x="77.0" y="414.0"/>
-      <point x="77.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="77" y="492"/>
-      <point x="111.0" y="520.0"/>
-      <point x="157.0" y="520.0" type="curve" smooth="yes"/>
-      <point x="203" y="520"/>
-      <point x="236" y="491.0"/>
-      <point x="236.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="236" y="415"/>
-      <point x="205" y="386"/>
+      <point x="157" y="401" type="curve" smooth="yes"/>
+      <point x="123" y="401"/>
+      <point x="90" y="424"/>
+      <point x="90" y="458" type="curve" smooth="yes"/>
+      <point x="90" y="491"/>
+      <point x="124" y="514"/>
+      <point x="157" y="514" type="curve" smooth="yes"/>
+      <point x="188" y="514"/>
+      <point x="223" y="490"/>
+      <point x="223" y="458" type="curve" smooth="yes"/>
+      <point x="223" y="425"/>
+      <point x="188" y="401"/>
     </contour>
     <contour>
-      <point x="157.0" y="560.0" type="curve" smooth="yes"/>
-      <point x="119.0" y="560.0"/>
-      <point x="92" y="587"/>
-      <point x="92.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="92.0" y="655.0"/>
-      <point x="117" y="680"/>
-      <point x="157.0" y="680.0" type="curve" smooth="yes"/>
-      <point x="197.0" y="680.0"/>
-      <point x="221" y="654"/>
-      <point x="221.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="221.0" y="588.0"/>
-      <point x="195" y="560"/>
+      <point x="157" y="568" type="curve" smooth="yes"/>
+      <point x="127" y="568"/>
+      <point x="102" y="587"/>
+      <point x="102" y="616" type="curve" smooth="yes"/>
+      <point x="102" y="643"/>
+      <point x="124" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="188" y="665"/>
+      <point x="211" y="643"/>
+      <point x="211" y="616" type="curve" smooth="yes"/>
+      <point x="211" y="588"/>
+      <point x="185" y="568"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="eight.numerator" xOffset="269" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>eight.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="156.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="227.0" y="343.0"/>
-      <point x="283.0" y="397.0"/>
-      <point x="283.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="546.0"/>
+      <point x="156" y="343" type="curve" smooth="yes"/>
+      <point x="227" y="343"/>
+      <point x="288" y="397"/>
+      <point x="288" y="470" type="curve" smooth="yes"/>
+      <point x="288" y="546"/>
       <point x="232" y="595"/>
-      <point x="170" y="595.0" type="curve" smooth="yes"/>
-      <point x="131.0" y="595.0"/>
-      <point x="99" y="578.0"/>
-      <point x="83.0" y="559.0" type="curve"/>
-      <point x="97.0" y="673.0" type="line"/>
-      <point x="262.0" y="673.0" type="line"/>
-      <point x="262.0" y="716.0" type="line"/>
-      <point x="65.0" y="716.0" type="line"/>
-      <point x="40.0" y="527.0" type="line"/>
-      <point x="79" y="510.0" type="line"/>
-      <point x="102" y="540.0"/>
-      <point x="128" y="552.0"/>
-      <point x="159" y="552.0" type="curve" smooth="yes"/>
-      <point x="204" y="552.0"/>
-      <point x="235" y="520"/>
-      <point x="235" y="471.0" type="curve" smooth="yes"/>
-      <point x="235" y="422.0"/>
-      <point x="207" y="387.0"/>
-      <point x="159" y="387.0" type="curve" smooth="yes"/>
-      <point x="115" y="387"/>
-      <point x="77" y="411.0"/>
-      <point x="68" y="452.0" type="curve"/>
-      <point x="28.0" y="435.0" type="line"/>
-      <point x="46.0" y="369.0"/>
-      <point x="102.0" y="343.0"/>
+      <point x="164" y="595" type="curve" smooth="yes"/>
+      <point x="140" y="595"/>
+      <point x="116" y="587"/>
+      <point x="102" y="574" type="curve"/>
+      <point x="114" y="660" type="line"/>
+      <point x="267" y="660" type="line"/>
+      <point x="267" y="716" type="line"/>
+      <point x="60" y="716" type="line"/>
+      <point x="35" y="527" type="line"/>
+      <point x="91" y="504" type="line"/>
+      <point x="109" y="529"/>
+      <point x="131" y="539"/>
+      <point x="156" y="539" type="curve" smooth="yes"/>
+      <point x="193" y="539"/>
+      <point x="222" y="510"/>
+      <point x="222" y="471" type="curve" smooth="yes"/>
+      <point x="222" y="433"/>
+      <point x="193" y="402"/>
+      <point x="156" y="402" type="curve" smooth="yes"/>
+      <point x="120" y="402"/>
+      <point x="92" y="422"/>
+      <point x="84" y="457" type="curve"/>
+      <point x="23" y="434" type="line"/>
+      <point x="41" y="368"/>
+      <point x="102" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="five.numerator" xOffset="270" yOffset="-174"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>five.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="340"/>
   <outline>
     <contour>
-      <point x="27.0" y="431.0" type="line"/>
-      <point x="313.0" y="431.0" type="line"/>
-      <point x="313.0" y="474.0" type="line"/>
-      <point x="85.0" y="474.0" type="line"/>
-      <point x="207.0" y="644.0" type="line"/>
-      <point x="211.0" y="644.0" type="line"/>
-      <point x="211.0" y="350.0" type="line"/>
-      <point x="256.0" y="350.0" type="line"/>
-      <point x="256.0" y="716.0" type="line"/>
-      <point x="208.0" y="716.0" type="line"/>
-      <point x="27.0" y="463.0" type="line"/>
+      <point x="27" y="424" type="line"/>
+      <point x="313" y="424" type="line"/>
+      <point x="313" y="480" type="line"/>
+      <point x="97" y="480" type="line"/>
+      <point x="195" y="617" type="line"/>
+      <point x="199" y="617" type="line"/>
+      <point x="199" y="350" type="line"/>
+      <point x="264" y="350" type="line"/>
+      <point x="264" y="716" type="line"/>
+      <point x="203" y="716" type="line"/>
+      <point x="27" y="468" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="four.numerator" xOffset="233" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>four.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="136.0" y="334.0" type="line"/>
-      <point x="172.0" y="384.0"/>
-      <point x="207.0" y="434.0"/>
-      <point x="242.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="269.0" y="521.0"/>
-      <point x="287.0" y="557.0"/>
-      <point x="287.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="287.0" y="667.0"/>
-      <point x="228.0" y="724.0"/>
-      <point x="155.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="86.0" y="724.0"/>
-      <point x="26.0" y="667.0"/>
-      <point x="26.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="26.0" y="534.0"/>
-      <point x="70.0" y="474.0"/>
-      <point x="146.0" y="474.0" type="curve" smooth="yes"/>
-      <point x="165.0" y="474.0"/>
-      <point x="193.0" y="486.0"/>
-      <point x="205.0" y="496.0" type="curve"/>
-      <point x="155.0" y="436.0"/>
-      <point x="127.0" y="399.0"/>
-      <point x="98.0" y="362.0" type="curve"/>
+      <point x="136" y="334" type="line"/>
+      <point x="172" y="384"/>
+      <point x="208" y="434"/>
+      <point x="244" y="484" type="curve" smooth="yes"/>
+      <point x="271" y="521"/>
+      <point x="289" y="557"/>
+      <point x="289" y="598" type="curve" smooth="yes"/>
+      <point x="289" y="667"/>
+      <point x="230" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="85" y="724"/>
+      <point x="23" y="667"/>
+      <point x="23" y="598" type="curve" smooth="yes"/>
+      <point x="23" y="534"/>
+      <point x="77" y="474"/>
+      <point x="146" y="474" type="curve" smooth="yes"/>
+      <point x="155" y="474"/>
+      <point x="166" y="476"/>
+      <point x="173" y="480" type="curve"/>
+      <point x="144" y="443"/>
+      <point x="114" y="406"/>
+      <point x="85" y="369" type="curve"/>
     </contour>
     <contour>
-      <point x="156.0" y="514.0" type="curve" smooth="yes"/>
-      <point x="105.0" y="514.0"/>
-      <point x="70.0" y="553.0"/>
-      <point x="70.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="70.0" y="641.0"/>
-      <point x="105.0" y="681.0"/>
-      <point x="156.0" y="681.0" type="curve" smooth="yes"/>
-      <point x="208.0" y="681.0"/>
-      <point x="241.0" y="641.0"/>
-      <point x="241.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="553.0"/>
-      <point x="207.0" y="514.0"/>
+      <point x="157" y="530" type="curve" smooth="yes"/>
+      <point x="117" y="530"/>
+      <point x="90" y="562"/>
+      <point x="90" y="597" type="curve" smooth="yes"/>
+      <point x="90" y="633"/>
+      <point x="117" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="196" y="665"/>
+      <point x="222" y="633"/>
+      <point x="222" y="597" type="curve" smooth="yes"/>
+      <point x="222" y="562"/>
+      <point x="195" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="nine.numerator" xOffset="267" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>nine.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="235"/>
   <outline>
     <contour>
-      <point x="122.0" y="350.0" type="line"/>
-      <point x="169.0" y="350.0" type="line"/>
-      <point x="169.0" y="716.0" type="line"/>
-      <point x="121.0" y="716.0" type="line"/>
-      <point x="23.0" y="637.0" type="line"/>
-      <point x="52.0" y="600.0" type="line"/>
-      <point x="122.0" y="654.0" type="line"/>
+      <point x="112" y="350" type="line"/>
+      <point x="177" y="350" type="line"/>
+      <point x="177" y="716" type="line"/>
+      <point x="121" y="716" type="line"/>
+      <point x="23" y="637" type="line"/>
+      <point x="60" y="589" type="line"/>
+      <point x="112" y="632" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="one.numerator" xOffset="295" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>one.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="295"/>
   <outline>
     <contour>
-      <point x="96.0" y="335.0" type="line"/>
-      <point x="151.0" y="445.0"/>
-      <point x="213.0" y="567.0"/>
-      <point x="271.0" y="676.0" type="curve"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="23.0" y="716.0" type="line"/>
-      <point x="23.0" y="672.0" type="line"/>
-      <point x="217.0" y="672.0" type="line"/>
-      <point x="166.0" y="575.0"/>
-      <point x="103.0" y="456.0"/>
-      <point x="54.0" y="358.0" type="curve"/>
+      <point x="96" y="335" type="line"/>
+      <point x="154" y="444"/>
+      <point x="213" y="552"/>
+      <point x="271" y="661" type="curve"/>
+      <point x="271" y="716" type="line"/>
+      <point x="23" y="716" type="line"/>
+      <point x="23" y="657" type="line"/>
+      <point x="195" y="657" type="line"/>
+      <point x="143" y="560"/>
+      <point x="90" y="463"/>
+      <point x="38" y="366" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="157" y="342.0" type="curve" smooth="yes"/>
-      <point x="226" y="342.0"/>
-      <point x="286" y="399.0"/>
-      <point x="286" y="468.0" type="curve" smooth="yes"/>
-      <point x="286" y="532.0"/>
-      <point x="242" y="592"/>
-      <point x="166" y="592.0" type="curve" smooth="yes"/>
-      <point x="147" y="592.0"/>
-      <point x="119" y="580.0"/>
-      <point x="107" y="570.0" type="curve"/>
-      <point x="157" y="630.0"/>
-      <point x="185" y="667.0"/>
-      <point x="214" y="704.0" type="curve"/>
-      <point x="176" y="732.0" type="line"/>
-      <point x="140" y="682.0"/>
-      <point x="105" y="632.0"/>
-      <point x="70" y="582.0" type="curve" smooth="yes"/>
-      <point x="43" y="545.0"/>
-      <point x="25" y="509.0"/>
-      <point x="25" y="468.0" type="curve" smooth="yes"/>
-      <point x="25" y="399.0"/>
-      <point x="84" y="342.0"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="227" y="342"/>
+      <point x="289" y="399"/>
+      <point x="289" y="468" type="curve" smooth="yes"/>
+      <point x="289" y="532"/>
+      <point x="235" y="592"/>
+      <point x="166" y="592" type="curve" smooth="yes"/>
+      <point x="157" y="592"/>
+      <point x="146" y="590"/>
+      <point x="140" y="586" type="curve"/>
+      <point x="169" y="623"/>
+      <point x="198" y="660"/>
+      <point x="227" y="697" type="curve"/>
+      <point x="176" y="732" type="line"/>
+      <point x="140" y="682"/>
+      <point x="104" y="632"/>
+      <point x="68" y="582" type="curve" smooth="yes"/>
+      <point x="41" y="545"/>
+      <point x="23" y="509"/>
+      <point x="23" y="468" type="curve" smooth="yes"/>
+      <point x="23" y="399"/>
+      <point x="83" y="342"/>
     </contour>
     <contour>
-      <point x="156.0" y="385" type="curve" smooth="yes"/>
-      <point x="104.0" y="385"/>
-      <point x="71.0" y="425"/>
-      <point x="71.0" y="469" type="curve" smooth="yes"/>
-      <point x="71.0" y="513"/>
-      <point x="105.0" y="552"/>
-      <point x="156.0" y="552" type="curve" smooth="yes"/>
-      <point x="207.0" y="552"/>
-      <point x="242.0" y="513"/>
-      <point x="242.0" y="469" type="curve" smooth="yes"/>
-      <point x="242.0" y="425"/>
-      <point x="207.0" y="385"/>
+      <point x="156" y="401" type="curve" smooth="yes"/>
+      <point x="116" y="401"/>
+      <point x="90" y="433"/>
+      <point x="90" y="469" type="curve" smooth="yes"/>
+      <point x="90" y="504"/>
+      <point x="117" y="536"/>
+      <point x="156" y="536" type="curve" smooth="yes"/>
+      <point x="195" y="536"/>
+      <point x="222" y="504"/>
+      <point x="222" y="469" type="curve" smooth="yes"/>
+      <point x="222" y="433"/>
+      <point x="195" y="401"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="six.numerator" xOffset="265" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>six.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="226.0" y="342.0"/>
-      <point x="283.0" y="385.0"/>
-      <point x="283.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="498.0"/>
-      <point x="250.0" y="527.0"/>
-      <point x="213.0" y="543.0" type="curve"/>
-      <point x="246.0" y="555.0"/>
-      <point x="271.0" y="585.0"/>
-      <point x="271.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="271.0" y="680.0"/>
-      <point x="227.0" y="724.0"/>
-      <point x="156.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="94.0" y="724.0"/>
-      <point x="56.0" y="690.0"/>
-      <point x="39.0" y="642.0" type="curve"/>
-      <point x="84.0" y="625.0" type="line"/>
-      <point x="92.0" y="645.0"/>
-      <point x="116" y="677"/>
-      <point x="155" y="677.0" type="curve" smooth="yes"/>
-      <point x="197" y="677"/>
-      <point x="221.0" y="653"/>
-      <point x="221.0" y="622.0" type="curve" smooth="yes"/>
-      <point x="221" y="592"/>
-      <point x="195.0" y="563.0"/>
-      <point x="153.0" y="563.0" type="curve" smooth="yes"/>
-      <point x="145" y="563"/>
-      <point x="117.0" y="563.0"/>
-      <point x="117.0" y="563.0" type="curve"/>
-      <point x="117.0" y="517.0" type="line"/>
-      <point x="117.0" y="517.0"/>
-      <point x="127" y="517"/>
-      <point x="158.0" y="517.0" type="curve" smooth="yes"/>
-      <point x="201" y="517.0"/>
-      <point x="233" y="492"/>
-      <point x="233.0" y="455" type="curve" smooth="yes"/>
-      <point x="233.0" y="416"/>
-      <point x="206" y="386"/>
-      <point x="162" y="386.0" type="curve" smooth="yes"/>
-      <point x="122" y="386"/>
-      <point x="80.0" y="407.0"/>
-      <point x="68.0" y="458.0" type="curve"/>
-      <point x="28.0" y="442.0" type="line"/>
-      <point x="45.0" y="373.0"/>
-      <point x="97.0" y="342.0"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="226" y="342"/>
+      <point x="288" y="385"/>
+      <point x="288" y="459" type="curve" smooth="yes"/>
+      <point x="288" y="498"/>
+      <point x="263" y="525"/>
+      <point x="230" y="543" type="curve"/>
+      <point x="258" y="561"/>
+      <point x="276" y="585"/>
+      <point x="276" y="619" type="curve" smooth="yes"/>
+      <point x="276" y="680"/>
+      <point x="227" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="54" y="691"/>
+      <point x="37" y="643" type="curve"/>
+      <point x="94" y="620" type="line"/>
+      <point x="102" y="640"/>
+      <point x="118" y="665"/>
+      <point x="156" y="665" type="curve" smooth="yes"/>
+      <point x="184" y="665"/>
+      <point x="209" y="647"/>
+      <point x="209" y="618" type="curve" smooth="yes"/>
+      <point x="209" y="588"/>
+      <point x="186" y="568"/>
+      <point x="153" y="568" type="curve" smooth="yes"/>
+      <point x="145" y="568"/>
+      <point x="117" y="568"/>
+      <point x="117" y="568" type="curve"/>
+      <point x="117" y="512" type="line"/>
+      <point x="117" y="512"/>
+      <point x="127" y="512"/>
+      <point x="158" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="222" y="492"/>
+      <point x="222" y="459" type="curve" smooth="yes"/>
+      <point x="222" y="424"/>
+      <point x="191" y="401"/>
+      <point x="157" y="401" type="curve" smooth="yes"/>
+      <point x="126" y="401"/>
+      <point x="95" y="418"/>
+      <point x="83" y="464" type="curve"/>
+      <point x="23" y="441" type="line"/>
+      <point x="40" y="372"/>
+      <point x="97" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="three.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>three.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="300"/>
   <outline>
     <contour>
-      <point x="25.0" y="350.0" type="line"/>
-      <point x="272.0" y="350.0" type="line"/>
-      <point x="272.0" y="394.0" type="line"/>
-      <point x="79.0" y="394.0" type="line"/>
-      <point x="79.0" y="394.0"/>
-      <point x="175.0" y="492.0"/>
-      <point x="198.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="221.0" y="538.0"/>
-      <point x="263.0" y="569.0"/>
-      <point x="263.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="263.0" y="683.0"/>
-      <point x="210.0" y="724.0"/>
-      <point x="147.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="90.0" y="724.0"/>
-      <point x="37.0" y="689.0"/>
-      <point x="23.0" y="629.0" type="curve"/>
-      <point x="69.0" y="610.0" type="line"/>
-      <point x="78.0" y="652.0"/>
-      <point x="107.0" y="679.0"/>
-      <point x="148.0" y="679.0" type="curve" smooth="yes"/>
-      <point x="189" y="679"/>
-      <point x="212.0" y="650"/>
-      <point x="212.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="212" y="587"/>
-      <point x="183.0" y="562.0"/>
-      <point x="163.0" y="541.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="533.0"/>
-      <point x="25.0" y="401.0"/>
-      <point x="25.0" y="401.0" type="curve"/>
+      <point x="25" y="350" type="line"/>
+      <point x="272" y="350" type="line"/>
+      <point x="272" y="409" type="line"/>
+      <point x="111" y="409" type="line"/>
+      <point x="111" y="409"/>
+      <point x="185" y="483"/>
+      <point x="208" y="506" type="curve" smooth="yes"/>
+      <point x="231" y="529"/>
+      <point x="270" y="569"/>
+      <point x="270" y="617" type="curve" smooth="yes"/>
+      <point x="270" y="683"/>
+      <point x="210" y="724"/>
+      <point x="147" y="724" type="curve" smooth="yes"/>
+      <point x="90" y="724"/>
+      <point x="37" y="689"/>
+      <point x="23" y="629" type="curve"/>
+      <point x="83" y="604" type="line"/>
+      <point x="92" y="646"/>
+      <point x="118" y="665"/>
+      <point x="148" y="665" type="curve" smooth="yes"/>
+      <point x="180" y="665"/>
+      <point x="204" y="644"/>
+      <point x="204" y="617" type="curve" smooth="yes"/>
+      <point x="204" y="587"/>
+      <point x="180" y="562"/>
+      <point x="160" y="541" type="curve" smooth="yes"/>
+      <point x="152" y="533"/>
+      <point x="25" y="406"/>
+      <point x="25" y="406" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>two.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-23" type="curve" smooth="yes"/>
-      <point x="635" y="-23"/>
-      <point x="806" y="148"/>
-      <point x="806" y="358.0" type="curve" smooth="yes"/>
-      <point x="806" y="568"/>
-      <point x="635" y="739"/>
-      <point x="425.0" y="739" type="curve" smooth="yes"/>
-      <point x="215" y="739"/>
-      <point x="44" y="568"/>
-      <point x="44" y="358.0" type="curve" smooth="yes"/>
-      <point x="44" y="148"/>
-      <point x="215" y="-23"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="56" type="curve" smooth="yes"/>
-      <point x="260" y="56"/>
-      <point x="123" y="193"/>
-      <point x="123" y="358.0" type="curve" smooth="yes"/>
-      <point x="123" y="526"/>
-      <point x="260" y="660"/>
-      <point x="425.0" y="660" type="curve" smooth="yes"/>
-      <point x="594" y="660"/>
-      <point x="727" y="526"/>
-      <point x="727" y="358.0" type="curve" smooth="yes"/>
-      <point x="727" y="193"/>
-      <point x="594" y="56"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="313"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="342.0"/>
-      <point x="295" y="384"/>
-      <point x="295.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="500.0"/>
-      <point x="266" y="533"/>
-      <point x="233.0" y="543.0" type="curve"/>
-      <point x="264" y="553"/>
-      <point x="283.0" y="579.0"/>
-      <point x="283.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="283" y="682"/>
-      <point x="225.0" y="724.0"/>
-      <point x="157.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89" y="724"/>
-      <point x="30" y="682"/>
-      <point x="30.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="30" y="581"/>
-      <point x="46" y="556"/>
-      <point x="72.0" y="543.0" type="curve"/>
-      <point x="43.0" y="532.0"/>
-      <point x="18" y="498.0"/>
-      <point x="18.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="18" y="385"/>
-      <point x="82" y="342"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="223" y="342"/>
+      <point x="290" y="384"/>
+      <point x="290" y="455" type="curve" smooth="yes"/>
+      <point x="290" y="490"/>
+      <point x="270" y="522"/>
+      <point x="236" y="543" type="curve"/>
+      <point x="259" y="558"/>
+      <point x="278" y="588"/>
+      <point x="278" y="616" type="curve" smooth="yes"/>
+      <point x="278" y="682"/>
+      <point x="219" y="724"/>
+      <point x="157" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="35" y="682"/>
+      <point x="35" y="616" type="curve" smooth="yes"/>
+      <point x="35" y="587"/>
+      <point x="53" y="558"/>
+      <point x="77" y="543" type="curve"/>
+      <point x="43" y="522"/>
+      <point x="23" y="490"/>
+      <point x="23" y="455" type="curve" smooth="yes"/>
+      <point x="23" y="385"/>
+      <point x="90" y="342"/>
     </contour>
     <contour>
-      <point x="157.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="129" y="413"/>
-      <point x="105.0" y="428.0"/>
-      <point x="105.0" y="458.0" type="curve" smooth="yes"/>
-      <point x="105" y="488"/>
-      <point x="126.0" y="507.0"/>
-      <point x="157.0" y="507.0" type="curve" smooth="yes"/>
-      <point x="188" y="507"/>
-      <point x="208.0" y="486.0"/>
-      <point x="208.0" y="458.0" type="curve" smooth="yes"/>
-      <point x="208" y="430"/>
-      <point x="185.0" y="413.0"/>
+      <point x="157" y="401" type="curve" smooth="yes"/>
+      <point x="123" y="401"/>
+      <point x="90" y="424"/>
+      <point x="90" y="458" type="curve" smooth="yes"/>
+      <point x="90" y="491"/>
+      <point x="124" y="514"/>
+      <point x="157" y="514" type="curve" smooth="yes"/>
+      <point x="188" y="514"/>
+      <point x="223" y="490"/>
+      <point x="223" y="458" type="curve" smooth="yes"/>
+      <point x="223" y="425"/>
+      <point x="188" y="401"/>
     </contour>
     <contour>
-      <point x="157.0" y="570.0" type="curve" smooth="yes"/>
-      <point x="132" y="570"/>
-      <point x="115" y="590"/>
-      <point x="115.0" y="611.0" type="curve" smooth="yes"/>
-      <point x="115.0" y="632.0"/>
-      <point x="132" y="653"/>
-      <point x="157.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="182.0" y="653.0"/>
-      <point x="198" y="635"/>
-      <point x="198.0" y="611.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="587.0"/>
-      <point x="182.0" y="570.0"/>
+      <point x="157" y="568" type="curve" smooth="yes"/>
+      <point x="127" y="568"/>
+      <point x="102" y="587"/>
+      <point x="102" y="616" type="curve" smooth="yes"/>
+      <point x="102" y="643"/>
+      <point x="124" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="188" y="665"/>
+      <point x="211" y="643"/>
+      <point x="211" y="616" type="curve" smooth="yes"/>
+      <point x="211" y="588"/>
+      <point x="185" y="568"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="eight.numerator" xOffset="269" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>eight.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="156.0" y="343.0" type="curve" smooth="yes"/>
+      <point x="156" y="343" type="curve" smooth="yes"/>
       <point x="227" y="343"/>
-      <point x="293.0" y="391.0"/>
-      <point x="293.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="293" y="549"/>
-      <point x="239" y="595.0"/>
-      <point x="164.0" y="595.0" type="curve" smooth="yes"/>
+      <point x="288" y="397"/>
+      <point x="288" y="470" type="curve" smooth="yes"/>
+      <point x="288" y="546"/>
+      <point x="232" y="595"/>
+      <point x="164" y="595" type="curve" smooth="yes"/>
       <point x="140" y="595"/>
-      <point x="118.0" y="587.0"/>
-      <point x="104.0" y="574.0" type="curve"/>
-      <point x="114.0" y="641.0" type="line"/>
-      <point x="267.0" y="641.0" type="line"/>
-      <point x="267.0" y="716.0" type="line"/>
-      <point x="55.0" y="716.0" type="line"/>
-      <point x="30.0" y="527.0" type="line"/>
-      <point x="99.0" y="499.0" type="line"/>
-      <point x="113.0" y="518.0"/>
-      <point x="131" y="529"/>
-      <point x="156.0" y="529.0" type="curve" smooth="yes"/>
-      <point x="192.0" y="529.0"/>
-      <point x="212.0" y="504.0"/>
-      <point x="212.0" y="469" type="curve" smooth="yes"/>
-      <point x="212" y="433"/>
-      <point x="190.0" y="412.0"/>
-      <point x="156.0" y="412.0" type="curve" smooth="yes"/>
-      <point x="120" y="412"/>
-      <point x="101.0" y="427.0"/>
-      <point x="93.0" y="462.0" type="curve"/>
-      <point x="18.0" y="434.0" type="line"/>
-      <point x="35" y="373"/>
-      <point x="91.0" y="343"/>
+      <point x="116" y="587"/>
+      <point x="102" y="574" type="curve"/>
+      <point x="114" y="660" type="line"/>
+      <point x="267" y="660" type="line"/>
+      <point x="267" y="716" type="line"/>
+      <point x="60" y="716" type="line"/>
+      <point x="35" y="527" type="line"/>
+      <point x="91" y="504" type="line"/>
+      <point x="109" y="529"/>
+      <point x="131" y="539"/>
+      <point x="156" y="539" type="curve" smooth="yes"/>
+      <point x="193" y="539"/>
+      <point x="222" y="510"/>
+      <point x="222" y="471" type="curve" smooth="yes"/>
+      <point x="222" y="433"/>
+      <point x="193" y="402"/>
+      <point x="156" y="402" type="curve" smooth="yes"/>
+      <point x="120" y="402"/>
+      <point x="92" y="422"/>
+      <point x="84" y="457" type="curve"/>
+      <point x="23" y="434" type="line"/>
+      <point x="41" y="368"/>
+      <point x="102" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="five.numerator" xOffset="270" yOffset="-174"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>five.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="340"/>
   <outline>
     <contour>
-      <point x="18.0" y="417.0" type="line"/>
-      <point x="313.0" y="417.0" type="line"/>
-      <point x="313.0" y="485.0" type="line"/>
-      <point x="109.0" y="485.0" type="line"/>
-      <point x="185.0" y="592.0" type="line"/>
-      <point x="192.0" y="592.0" type="line"/>
-      <point x="192.0" y="350.0" type="line"/>
-      <point x="271.0" y="350.0" type="line"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="194.0" y="716.0" type="line"/>
-      <point x="18.0" y="468.0" type="line"/>
+      <point x="27" y="424" type="line"/>
+      <point x="313" y="424" type="line"/>
+      <point x="313" y="480" type="line"/>
+      <point x="97" y="480" type="line"/>
+      <point x="195" y="617" type="line"/>
+      <point x="199" y="617" type="line"/>
+      <point x="199" y="350" type="line"/>
+      <point x="264" y="350" type="line"/>
+      <point x="264" y="716" type="line"/>
+      <point x="203" y="716" type="line"/>
+      <point x="27" y="468" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="four.numerator" xOffset="233" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>four.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="142.0" y="331.0" type="line"/>
-      <point x="178.0" y="381.0"/>
-      <point x="219.0" y="433.0"/>
-      <point x="254.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="280.0" y="522.0"/>
-      <point x="296.0" y="557.0"/>
-      <point x="296.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="296.0" y="667.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="155.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="77.0" y="724.0"/>
-      <point x="15.0" y="667.0"/>
-      <point x="15.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="15.0" y="516.0"/>
-      <point x="63.0" y="464.0"/>
-      <point x="142.0" y="464.0" type="curve" smooth="yes"/>
-      <point x="147.0" y="464.0"/>
-      <point x="148.0" y="464.0"/>
-      <point x="151.0" y="465.0" type="curve"/>
-      <point x="133.0" y="443.0"/>
-      <point x="104.0" y="406.0"/>
-      <point x="75.0" y="369.0" type="curve"/>
+      <point x="136" y="334" type="line"/>
+      <point x="172" y="384"/>
+      <point x="208" y="434"/>
+      <point x="244" y="484" type="curve" smooth="yes"/>
+      <point x="271" y="521"/>
+      <point x="289" y="557"/>
+      <point x="289" y="598" type="curve" smooth="yes"/>
+      <point x="289" y="667"/>
+      <point x="230" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="85" y="724"/>
+      <point x="23" y="667"/>
+      <point x="23" y="598" type="curve" smooth="yes"/>
+      <point x="23" y="534"/>
+      <point x="77" y="474"/>
+      <point x="146" y="474" type="curve" smooth="yes"/>
+      <point x="155" y="474"/>
+      <point x="166" y="476"/>
+      <point x="173" y="480" type="curve"/>
+      <point x="144" y="443"/>
+      <point x="114" y="406"/>
+      <point x="85" y="369" type="curve"/>
     </contour>
     <contour>
-      <point x="156.0" y="535.0" type="curve" smooth="yes"/>
-      <point x="118.0" y="535.0"/>
-      <point x="98.0" y="562.0"/>
-      <point x="98.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="98.0" y="626.0"/>
-      <point x="122.0" y="650.0"/>
-      <point x="156.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="650.0"/>
-      <point x="212.0" y="628.0"/>
-      <point x="212.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="212.0" y="560.0"/>
-      <point x="194.0" y="535.0"/>
+      <point x="157" y="530" type="curve" smooth="yes"/>
+      <point x="117" y="530"/>
+      <point x="90" y="562"/>
+      <point x="90" y="597" type="curve" smooth="yes"/>
+      <point x="90" y="633"/>
+      <point x="117" y="665"/>
+      <point x="157" y="665" type="curve" smooth="yes"/>
+      <point x="196" y="665"/>
+      <point x="222" y="633"/>
+      <point x="222" y="597" type="curve" smooth="yes"/>
+      <point x="222" y="562"/>
+      <point x="195" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="nine.numerator" xOffset="267" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>nine.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="235"/>
   <outline>
     <contour>
-      <point x="102.0" y="350.0" type="line"/>
-      <point x="197.0" y="350.0" type="line"/>
-      <point x="197.0" y="716.0" type="line"/>
-      <point x="111.0" y="716.0" type="line"/>
-      <point x="5.0" y="633.0" type="line"/>
-      <point x="60.0" y="562.0" type="line"/>
-      <point x="102.0" y="590.0" type="line"/>
+      <point x="112" y="350" type="line"/>
+      <point x="177" y="350" type="line"/>
+      <point x="177" y="716" type="line"/>
+      <point x="121" y="716" type="line"/>
+      <point x="23" y="637" type="line"/>
+      <point x="60" y="589" type="line"/>
+      <point x="112" y="632" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="one.numerator" xOffset="295" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>one.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="295"/>
   <outline>
     <contour>
-      <point x="101.0" y="335.0" type="line"/>
-      <point x="158.0" y="443.0"/>
-      <point x="213.0" y="544.0"/>
-      <point x="271.0" y="653.0" type="curve"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="23.0" y="716.0" type="line"/>
-      <point x="23.0" y="640.0" type="line"/>
-      <point x="177.0" y="640.0" type="line"/>
-      <point x="125.0" y="543.0"/>
-      <point x="85.0" y="463.0"/>
-      <point x="28.0" y="366.0" type="curve"/>
+      <point x="96" y="335" type="line"/>
+      <point x="154" y="444"/>
+      <point x="213" y="552"/>
+      <point x="271" y="661" type="curve"/>
+      <point x="271" y="716" type="line"/>
+      <point x="23" y="716" type="line"/>
+      <point x="23" y="657" type="line"/>
+      <point x="195" y="657" type="line"/>
+      <point x="143" y="560"/>
+      <point x="90" y="463"/>
+      <point x="38" y="366" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="235.0" y="342.0"/>
-      <point x="297" y="399"/>
-      <point x="297.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="297.0" y="550"/>
-      <point x="249" y="602.0"/>
-      <point x="170" y="602.0" type="curve" smooth="yes"/>
-      <point x="165" y="602"/>
-      <point x="164.0" y="602.0"/>
-      <point x="161.0" y="601.0" type="curve"/>
-      <point x="179.0" y="623.0"/>
-      <point x="208.0" y="660.0"/>
-      <point x="237.0" y="697.0" type="curve"/>
-      <point x="170.0" y="735.0" type="line"/>
-      <point x="134.0" y="685.0"/>
-      <point x="93.0" y="633.0"/>
-      <point x="58.0" y="582.0" type="curve" smooth="yes"/>
-      <point x="32" y="544"/>
-      <point x="16.0" y="509.0"/>
-      <point x="16.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="16.0" y="399.0"/>
-      <point x="79" y="342"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="227" y="342"/>
+      <point x="289" y="399"/>
+      <point x="289" y="468" type="curve" smooth="yes"/>
+      <point x="289" y="532"/>
+      <point x="235" y="592"/>
+      <point x="166" y="592" type="curve" smooth="yes"/>
+      <point x="157" y="592"/>
+      <point x="146" y="590"/>
+      <point x="140" y="586" type="curve"/>
+      <point x="169" y="623"/>
+      <point x="198" y="660"/>
+      <point x="227" y="697" type="curve"/>
+      <point x="176" y="732" type="line"/>
+      <point x="140" y="682"/>
+      <point x="104" y="632"/>
+      <point x="68" y="582" type="curve" smooth="yes"/>
+      <point x="41" y="545"/>
+      <point x="23" y="509"/>
+      <point x="23" y="468" type="curve" smooth="yes"/>
+      <point x="23" y="399"/>
+      <point x="83" y="342"/>
     </contour>
     <contour>
-      <point x="156.0" y="416.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="416.0"/>
-      <point x="100" y="438"/>
-      <point x="100.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="100.0" y="506.0"/>
-      <point x="118.0" y="531.0"/>
-      <point x="156.0" y="531.0" type="curve" smooth="yes"/>
-      <point x="194" y="531"/>
-      <point x="214.0" y="504.0"/>
-      <point x="214.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="214" y="440"/>
-      <point x="190" y="416"/>
+      <point x="156" y="401" type="curve" smooth="yes"/>
+      <point x="116" y="401"/>
+      <point x="90" y="433"/>
+      <point x="90" y="469" type="curve" smooth="yes"/>
+      <point x="90" y="504"/>
+      <point x="117" y="536"/>
+      <point x="156" y="536" type="curve" smooth="yes"/>
+      <point x="195" y="536"/>
+      <point x="222" y="504"/>
+      <point x="222" y="469" type="curve" smooth="yes"/>
+      <point x="222" y="433"/>
+      <point x="195" y="401"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="six.numerator" xOffset="265" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>six.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,50 +3,50 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="235.0" y="342.0"/>
-      <point x="294" y="385"/>
-      <point x="294.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="294.0" y="503"/>
-      <point x="267.0" y="532.0"/>
-      <point x="237.0" y="543.0" type="curve"/>
-      <point x="264.0" y="557.0"/>
-      <point x="286.0" y="585.0"/>
-      <point x="286.0" y="620" type="curve" smooth="yes"/>
-      <point x="286.0" y="680.0"/>
-      <point x="235" y="724"/>
-      <point x="162" y="724.0" type="curve" smooth="yes"/>
-      <point x="97" y="724"/>
-      <point x="50.0" y="693.0"/>
-      <point x="31.0" y="640.0" type="curve"/>
-      <point x="105.0" y="613.0" type="line"/>
-      <point x="112.0" y="634.0"/>
-      <point x="133" y="653"/>
-      <point x="157" y="653.0" type="curve" smooth="yes"/>
-      <point x="182" y="653.0"/>
-      <point x="197" y="637"/>
-      <point x="197.0" y="615" type="curve" smooth="yes"/>
-      <point x="197" y="594"/>
-      <point x="180" y="572.0"/>
-      <point x="153.0" y="572.0" type="curve" smooth="yes"/>
-      <point x="145" y="572"/>
-      <point x="114.0" y="572.0"/>
-      <point x="114.0" y="572.0" type="curve"/>
-      <point x="114.0" y="505.0" type="line"/>
-      <point x="114.0" y="505.0"/>
-      <point x="144" y="505.0"/>
-      <point x="154.0" y="505.0" type="curve" smooth="yes"/>
-      <point x="189" y="505"/>
-      <point x="213" y="489"/>
-      <point x="213.0" y="462" type="curve" smooth="yes"/>
-      <point x="213" y="434"/>
-      <point x="193.0" y="414.0"/>
-      <point x="159" y="414.0" type="curve" smooth="yes"/>
-      <point x="126" y="414"/>
-      <point x="102.0" y="436.0"/>
-      <point x="90.0" y="472.0" type="curve"/>
-      <point x="19.0" y="443.0" type="line"/>
-      <point x="36.0" y="374.0"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="226" y="342"/>
+      <point x="288" y="385"/>
+      <point x="288" y="459" type="curve" smooth="yes"/>
+      <point x="288" y="498"/>
+      <point x="263" y="525"/>
+      <point x="230" y="543" type="curve"/>
+      <point x="258" y="561"/>
+      <point x="276" y="585"/>
+      <point x="276" y="619" type="curve" smooth="yes"/>
+      <point x="276" y="680"/>
+      <point x="227" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="54" y="691"/>
+      <point x="37" y="643" type="curve"/>
+      <point x="94" y="620" type="line"/>
+      <point x="102" y="640"/>
+      <point x="118" y="665"/>
+      <point x="156" y="665" type="curve" smooth="yes"/>
+      <point x="184" y="665"/>
+      <point x="209" y="647"/>
+      <point x="209" y="618" type="curve" smooth="yes"/>
+      <point x="209" y="588"/>
+      <point x="186" y="568"/>
+      <point x="153" y="568" type="curve" smooth="yes"/>
+      <point x="145" y="568"/>
+      <point x="117" y="568"/>
+      <point x="117" y="568" type="curve"/>
+      <point x="117" y="512" type="line"/>
+      <point x="117" y="512"/>
+      <point x="127" y="512"/>
+      <point x="158" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="222" y="492"/>
+      <point x="222" y="459" type="curve" smooth="yes"/>
+      <point x="222" y="424"/>
+      <point x="191" y="401"/>
+      <point x="157" y="401" type="curve" smooth="yes"/>
+      <point x="126" y="401"/>
+      <point x="95" y="418"/>
+      <point x="83" y="464" type="curve"/>
+      <point x="23" y="441" type="line"/>
+      <point x="40" y="372"/>
       <point x="97" y="342"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="three.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>three.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="300"/>
   <outline>
     <contour>
-      <point x="25.0" y="350.0" type="line"/>
-      <point x="277.0" y="350.0" type="line"/>
-      <point x="277.0" y="429.0" type="line"/>
-      <point x="134.0" y="429.0" type="line"/>
-      <point x="134.0" y="429.0"/>
-      <point x="185" y="479"/>
-      <point x="209.0" y="502.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="524.0"/>
-      <point x="273.0" y="569.0"/>
-      <point x="274.0" y="622" type="curve" smooth="yes"/>
-      <point x="275" y="683"/>
-      <point x="227" y="724.0"/>
-      <point x="150" y="724.0" type="curve" smooth="yes"/>
-      <point x="87" y="724"/>
-      <point x="30" y="684.0"/>
-      <point x="17.0" y="631.0" type="curve"/>
-      <point x="95.0" y="599.0" type="line"/>
-      <point x="104.0" y="626.0"/>
-      <point x="123" y="645"/>
-      <point x="148" y="645.0" type="curve" smooth="yes"/>
-      <point x="173" y="645.0"/>
-      <point x="190" y="630"/>
-      <point x="190.0" y="611" type="curve" smooth="yes"/>
-      <point x="190" y="591"/>
-      <point x="170.0" y="572.0"/>
-      <point x="150.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="543.0"/>
-      <point x="25.0" y="426.0"/>
-      <point x="25.0" y="426.0" type="curve"/>
+      <point x="25" y="350" type="line"/>
+      <point x="272" y="350" type="line"/>
+      <point x="272" y="409" type="line"/>
+      <point x="111" y="409" type="line"/>
+      <point x="111" y="409"/>
+      <point x="185" y="483"/>
+      <point x="208" y="506" type="curve" smooth="yes"/>
+      <point x="231" y="529"/>
+      <point x="270" y="569"/>
+      <point x="270" y="617" type="curve" smooth="yes"/>
+      <point x="270" y="683"/>
+      <point x="210" y="724"/>
+      <point x="147" y="724" type="curve" smooth="yes"/>
+      <point x="90" y="724"/>
+      <point x="37" y="689"/>
+      <point x="23" y="629" type="curve"/>
+      <point x="83" y="604" type="line"/>
+      <point x="92" y="646"/>
+      <point x="118" y="665"/>
+      <point x="148" y="665" type="curve" smooth="yes"/>
+      <point x="180" y="665"/>
+      <point x="204" y="644"/>
+      <point x="204" y="617" type="curve" smooth="yes"/>
+      <point x="204" y="587"/>
+      <point x="180" y="562"/>
+      <point x="160" y="541" type="curve" smooth="yes"/>
+      <point x="152" y="533"/>
+      <point x="25" y="406"/>
+      <point x="25" y="406" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>two.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="28.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="28.0"/>
-      <point x="95.0" y="178.0"/>
-      <point x="95.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="95.0" y="541.0"/>
-      <point x="245.0" y="688.0"/>
-      <point x="425.0" y="688.0" type="curve" smooth="yes"/>
-      <point x="609.0" y="688.0"/>
-      <point x="755.0" y="541.0"/>
-      <point x="755.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="755.0" y="178.0"/>
-      <point x="609.0" y="28.0"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="182.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="272.0" y="330.0"/>
-      <point x="326.0" y="381.0"/>
-      <point x="326.0" y="462.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="496.0"/>
-      <point x="302.0" y="526.0"/>
-      <point x="269.0" y="538.0" type="curve"/>
-      <point x="306.0" y="551.0"/>
-      <point x="344.0" y="586.0"/>
-      <point x="344.0" y="628.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="687.0"/>
-      <point x="302.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="724.0"/>
-      <point x="101.0" y="681.0"/>
-      <point x="101.0" y="613.0" type="curve" smooth="yes"/>
-      <point x="101.0" y="586.0"/>
-      <point x="129.0" y="559.0"/>
-      <point x="155.0" y="547.0" type="curve"/>
-      <point x="108.0" y="535.0"/>
-      <point x="61.0" y="495.0"/>
-      <point x="61.0" y="438.0" type="curve" smooth="yes"/>
-      <point x="61.0" y="378.0"/>
-      <point x="110.0" y="330.0"/>
+      <point x="182" y="330" type="curve" smooth="yes"/>
+      <point x="272" y="330"/>
+      <point x="329" y="381"/>
+      <point x="329" y="462" type="curve" smooth="yes"/>
+      <point x="329" y="496"/>
+      <point x="314" y="523"/>
+      <point x="289" y="538" type="curve"/>
+      <point x="323" y="558"/>
+      <point x="344" y="586"/>
+      <point x="344" y="628" type="curve" smooth="yes"/>
+      <point x="344" y="687"/>
+      <point x="302" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="151" y="724"/>
+      <point x="101" y="681"/>
+      <point x="101" y="613" type="curve" smooth="yes"/>
+      <point x="101" y="586"/>
+      <point x="120" y="560"/>
+      <point x="137" y="547" type="curve"/>
+      <point x="94" y="531"/>
+      <point x="58" y="495"/>
+      <point x="58" y="438" type="curve" smooth="yes"/>
+      <point x="58" y="378"/>
+      <point x="110" y="330"/>
     </contour>
     <contour>
-      <point x="188.0" y="377.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="377.0"/>
-      <point x="114.0" y="404.0"/>
-      <point x="114.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="114.0" y="494.0"/>
-      <point x="148.0" y="516.0"/>
-      <point x="201.0" y="516.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="516.0"/>
-      <point x="273.0" y="498.0"/>
-      <point x="273.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="405.0"/>
-      <point x="242.0" y="377.0"/>
+      <point x="188" y="389" type="curve" smooth="yes"/>
+      <point x="152" y="389"/>
+      <point x="126" y="414"/>
+      <point x="126" y="444" type="curve" smooth="yes"/>
+      <point x="126" y="485"/>
+      <point x="158" y="510"/>
+      <point x="201" y="510" type="curve" smooth="yes"/>
+      <point x="238" y="510"/>
+      <point x="261" y="489"/>
+      <point x="261" y="455" type="curve" smooth="yes"/>
+      <point x="261" y="415"/>
+      <point x="232" y="389"/>
     </contour>
     <contour>
-      <point x="216.0" y="560.0" type="curve" smooth="yes"/>
-      <point x="176.0" y="560.0"/>
-      <point x="157.0" y="582.0"/>
-      <point x="157.0" y="614.0" type="curve" smooth="yes"/>
-      <point x="157.0" y="657.0"/>
-      <point x="181.0" y="675.0"/>
-      <point x="229.0" y="675.0" type="curve" smooth="yes"/>
-      <point x="267.0" y="675.0"/>
-      <point x="288.0" y="653.0"/>
-      <point x="288.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="585.0"/>
-      <point x="265.0" y="560.0"/>
+      <point x="216" y="564" type="curve" smooth="yes"/>
+      <point x="186" y="564"/>
+      <point x="167" y="585"/>
+      <point x="167" y="610" type="curve" smooth="yes"/>
+      <point x="167" y="643"/>
+      <point x="191" y="665"/>
+      <point x="229" y="665" type="curve" smooth="yes"/>
+      <point x="261" y="665"/>
+      <point x="278" y="642"/>
+      <point x="278" y="618" type="curve" smooth="yes"/>
+      <point x="278" y="586"/>
+      <point x="255" y="564"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="248.0"/>
-      <point x="492.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="465.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="343.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="247.0"/>
-      <point x="387.0" y="222.0"/>
+      <point x="412" y="223" type="curve" smooth="yes"/>
+      <point x="456" y="223"/>
+      <point x="485" y="249"/>
+      <point x="485" y="289" type="curve" smooth="yes"/>
+      <point x="485" y="323"/>
+      <point x="462" y="344"/>
+      <point x="425" y="344" type="curve" smooth="yes"/>
+      <point x="382" y="344"/>
+      <point x="350" y="319"/>
+      <point x="350" y="278" type="curve" smooth="yes"/>
+      <point x="350" y="248"/>
+      <point x="376" y="223"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="282" y="212"/>
+      <point x="282" y="272" type="curve" smooth="yes"/>
+      <point x="282" y="329"/>
+      <point x="318" y="365"/>
+      <point x="361" y="381" type="curve"/>
+      <point x="344" y="394"/>
+      <point x="325" y="420"/>
+      <point x="325" y="447" type="curve" smooth="yes"/>
+      <point x="325" y="515"/>
+      <point x="375" y="558"/>
+      <point x="462" y="558" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="568" y="521"/>
+      <point x="568" y="462" type="curve" smooth="yes"/>
+      <point x="568" y="420"/>
+      <point x="547" y="392"/>
+      <point x="513" y="372" type="curve"/>
+      <point x="538" y="357"/>
+      <point x="553" y="330"/>
+      <point x="553" y="296" type="curve" smooth="yes"/>
+      <point x="553" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="458.0" y="397.0"/>
-      <point x="480.0" y="417.0"/>
-      <point x="480.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="477.0"/>
-      <point x="458.0" y="498.0"/>
-      <point x="426.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="498.0"/>
-      <point x="371.0" y="477.0"/>
-      <point x="371.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="417.0"/>
-      <point x="394.0" y="397.0"/>
+      <point x="440" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="502" y="420"/>
+      <point x="502" y="452" type="curve" smooth="yes"/>
+      <point x="502" y="476"/>
+      <point x="485" y="499"/>
+      <point x="453" y="499" type="curve" smooth="yes"/>
+      <point x="415" y="499"/>
+      <point x="391" y="477"/>
+      <point x="391" y="444" type="curve" smooth="yes"/>
+      <point x="391" y="419"/>
+      <point x="410" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="183.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="331.0"/>
-      <point x="327.0" y="388.0"/>
-      <point x="327.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="327.0" y="541.0"/>
-      <point x="289.0" y="589.0"/>
-      <point x="228.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="589.0"/>
-      <point x="163.0" y="574.0"/>
-      <point x="149.0" y="560.0" type="curve"/>
-      <point x="181.0" y="665.0" type="line"/>
-      <point x="344.0" y="665.0" type="line"/>
-      <point x="353.0" y="716.0" type="line"/>
-      <point x="147.0" y="716.0" type="line"/>
-      <point x="91.0" y="521.0" type="line"/>
-      <point x="135.0" y="499.0" type="line"/>
-      <point x="146.0" y="521.0"/>
-      <point x="173.0" y="543.0"/>
-      <point x="212.0" y="543.0" type="curve" smooth="yes"/>
-      <point x="250.0" y="543.0"/>
-      <point x="275.0" y="519.0"/>
-      <point x="275.0" y="465.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="411.0"/>
-      <point x="253.0" y="378.0"/>
-      <point x="189.0" y="378.0" type="curve" smooth="yes"/>
-      <point x="149.0" y="378.0"/>
-      <point x="116.0" y="396.0"/>
-      <point x="108.0" y="443.0" type="curve"/>
-      <point x="58.0" y="435.0" type="line"/>
-      <point x="67.0" y="370.0"/>
-      <point x="121.0" y="331.0"/>
+      <point x="183" y="331" type="curve" smooth="yes"/>
+      <point x="274" y="331"/>
+      <point x="332" y="388"/>
+      <point x="332" y="481" type="curve" smooth="yes"/>
+      <point x="332" y="541"/>
+      <point x="294" y="589"/>
+      <point x="228" y="589" type="curve" smooth="yes"/>
+      <point x="198" y="589"/>
+      <point x="177" y="581"/>
+      <point x="160" y="567" type="curve"/>
+      <point x="190" y="660" type="line"/>
+      <point x="343" y="660" type="line"/>
+      <point x="353" y="716" type="line"/>
+      <point x="142" y="716" type="line"/>
+      <point x="86" y="521" type="line"/>
+      <point x="139" y="498" type="line"/>
+      <point x="154" y="519"/>
+      <point x="177" y="533"/>
+      <point x="207" y="533" type="curve" smooth="yes"/>
+      <point x="241" y="533"/>
+      <point x="265" y="509"/>
+      <point x="265" y="471" type="curve" smooth="yes"/>
+      <point x="265" y="426"/>
+      <point x="243" y="390"/>
+      <point x="189" y="390" type="curve" smooth="yes"/>
+      <point x="149" y="390"/>
+      <point x="128" y="414"/>
+      <point x="122" y="448" type="curve"/>
+      <point x="58" y="435" type="line"/>
+      <point x="67" y="370"/>
+      <point x="121" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="356.0" y="280.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="388.0" y="222.0"/>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="249.0"/>
-      <point x="492.0" y="294.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="339.0"/>
-      <point x="465.0" y="365.0"/>
-      <point x="426.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="397.0" y="365.0"/>
-      <point x="375.0" y="352.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
-      <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="492.0" type="line"/>
-      <point x="382.0" y="492.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
-      <point x="508.0" y="163.0"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="338" y="273" type="line"/>
+      <point x="344" y="239"/>
+      <point x="365" y="215"/>
+      <point x="405" y="215" type="curve" smooth="yes"/>
+      <point x="459" y="215"/>
+      <point x="481" y="251"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="334"/>
+      <point x="457" y="358"/>
+      <point x="423" y="358" type="curve" smooth="yes"/>
+      <point x="393" y="358"/>
+      <point x="370" y="344"/>
+      <point x="355" y="323" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="559" y="485" type="line"/>
+      <point x="406" y="485" type="line"/>
+      <point x="376" y="392" type="line"/>
+      <point x="393" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="548" y="366"/>
+      <point x="548" y="306" type="curve" smooth="yes"/>
+      <point x="548" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="59.0" y="426.0" type="line"/>
-      <point x="350.0" y="426.0" type="line"/>
-      <point x="357.0" y="468.0" type="line"/>
-      <point x="134.0" y="468.0" type="line"/>
-      <point x="271.0" y="634.0" type="line"/>
-      <point x="277.0" y="634.0" type="line"/>
-      <point x="223.0" y="338.0" type="line"/>
-      <point x="276.0" y="338.0" type="line"/>
-      <point x="342.0" y="716.0" type="line"/>
-      <point x="286.0" y="716.0" type="line"/>
-      <point x="65.0" y="460.0" type="line"/>
+      <point x="57" y="416" type="line"/>
+      <point x="348" y="416" type="line"/>
+      <point x="358" y="472" type="line"/>
+      <point x="147" y="472" type="line"/>
+      <point x="266" y="617" type="line"/>
+      <point x="270" y="617" type="line"/>
+      <point x="221" y="338" type="line"/>
+      <point x="286" y="338" type="line"/>
+      <point x="352" y="716" type="line"/>
+      <point x="286" y="716" type="line"/>
+      <point x="65" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="331.0" y="305.0" type="line"/>
-      <point x="433.0" y="305.0" type="line"/>
-      <point x="433.0" y="450.0" type="line"/>
-      <point x="429.0" y="450.0" type="line"/>
+      <point x="337" y="309" type="line"/>
+      <point x="435" y="309" type="line"/>
+      <point x="460" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="171.0" type="line"/>
-      <point x="433.0" y="249.0" type="line"/>
-      <point x="256.0" y="249.0" type="line"/>
-      <point x="256.0" y="293.0" type="line"/>
-      <point x="437.0" y="549.0" type="line"/>
-      <point x="498.0" y="549.0" type="line"/>
-      <point x="498.0" y="305.0" type="line"/>
-      <point x="547.0" y="305.0" type="line"/>
-      <point x="547.0" y="249.0" type="line"/>
-      <point x="498.0" y="249.0" type="line"/>
-      <point x="498.0" y="171.0" type="line"/>
+      <point x="411" y="175" type="line"/>
+      <point x="425" y="253" type="line"/>
+      <point x="247" y="253" type="line"/>
+      <point x="255" y="297" type="line"/>
+      <point x="476" y="553" type="line"/>
+      <point x="542" y="553" type="line"/>
+      <point x="499" y="309" type="line"/>
+      <point x="548" y="309" type="line"/>
+      <point x="538" y="253" type="line"/>
+      <point x="490" y="253" type="line"/>
+      <point x="476" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="141.0" y="332.0" type="line"/>
-      <point x="199.0" y="351.0"/>
-      <point x="248.0" y="384.0"/>
-      <point x="281.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="330.0" y="475.0"/>
-      <point x="348.0" y="540.0"/>
-      <point x="348.0" y="586.0" type="curve" smooth="yes"/>
-      <point x="348.0" y="682.0"/>
-      <point x="299.0" y="724.0"/>
-      <point x="236.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="147.0" y="724.0"/>
-      <point x="88.0" y="662.0"/>
-      <point x="88.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="88.0" y="523.0"/>
-      <point x="130.0" y="479.0"/>
-      <point x="193.0" y="479.0" type="curve" smooth="yes"/>
-      <point x="224.0" y="479.0"/>
-      <point x="275.0" y="492.0"/>
-      <point x="298.0" y="521.0" type="curve"/>
-      <point x="276.0" y="462.0"/>
-      <point x="189.0" y="399.0"/>
-      <point x="129.0" y="375.0" type="curve"/>
+      <point x="141" y="332" type="line"/>
+      <point x="199" y="351"/>
+      <point x="246" y="384"/>
+      <point x="280" y="420" type="curve" smooth="yes"/>
+      <point x="332" y="475"/>
+      <point x="353" y="540"/>
+      <point x="353" y="586" type="curve" smooth="yes"/>
+      <point x="353" y="682"/>
+      <point x="299" y="724"/>
+      <point x="236" y="724" type="curve" smooth="yes"/>
+      <point x="147" y="724"/>
+      <point x="83" y="662"/>
+      <point x="83" y="581" type="curve" smooth="yes"/>
+      <point x="83" y="523"/>
+      <point x="123" y="474"/>
+      <point x="186" y="474" type="curve" smooth="yes"/>
+      <point x="217" y="474"/>
+      <point x="252" y="485"/>
+      <point x="276" y="514" type="curve"/>
+      <point x="254" y="455"/>
+      <point x="181" y="405"/>
+      <point x="121" y="381" type="curve"/>
     </contour>
     <contour>
-      <point x="210.0" y="520.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="520.0"/>
-      <point x="141.0" y="548.0"/>
-      <point x="141.0" y="588.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="641.0"/>
-      <point x="171.0" y="675.0"/>
-      <point x="227.0" y="675.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="675.0"/>
-      <point x="295.0" y="647.0"/>
-      <point x="295.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="553.0"/>
-      <point x="266.0" y="520.0"/>
+      <point x="210" y="530" type="curve" smooth="yes"/>
+      <point x="174" y="530"/>
+      <point x="151" y="558"/>
+      <point x="151" y="588" type="curve" smooth="yes"/>
+      <point x="151" y="631"/>
+      <point x="181" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="263" y="665"/>
+      <point x="285" y="637"/>
+      <point x="285" y="606" type="curve" smooth="yes"/>
+      <point x="285" y="563"/>
+      <point x="256" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="415.0" y="171.0" type="curve"/>
-      <point x="338.0" y="171.0" type="line"/>
-      <point x="371.0" y="218.0"/>
-      <point x="405.0" y="266.0"/>
-      <point x="438.0" y="313.0" type="curve"/>
-      <point x="432.0" y="310.0"/>
-      <point x="420.0" y="307.0"/>
-      <point x="406.0" y="307.0" type="curve" smooth="yes"/>
-      <point x="339.0" y="307.0"/>
-      <point x="289.0" y="361.0"/>
-      <point x="289.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="503.0"/>
-      <point x="349.0" y="557.0"/>
-      <point x="421.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="497.0" y="557.0"/>
-      <point x="555.0" y="504.0"/>
-      <point x="555.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="555.0" y="383.0"/>
-      <point x="538.0" y="351.0"/>
-      <point x="513.0" y="313.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="266.0"/>
-      <point x="448.0" y="218.0"/>
+      <point x="364" y="161" type="curve"/>
+      <point x="344" y="210" type="line"/>
+      <point x="404" y="234"/>
+      <point x="477" y="284"/>
+      <point x="499" y="343" type="curve"/>
+      <point x="475" y="314"/>
+      <point x="440" y="303"/>
+      <point x="409" y="303" type="curve" smooth="yes"/>
+      <point x="346" y="303"/>
+      <point x="306" y="352"/>
+      <point x="306" y="410" type="curve" smooth="yes"/>
+      <point x="306" y="491"/>
+      <point x="370" y="553"/>
+      <point x="459" y="553" type="curve" smooth="yes"/>
+      <point x="522" y="553"/>
+      <point x="576" y="511"/>
+      <point x="576" y="415" type="curve" smooth="yes"/>
+      <point x="576" y="369"/>
+      <point x="555" y="304"/>
+      <point x="503" y="249" type="curve" smooth="yes"/>
+      <point x="469" y="213"/>
+      <point x="422" y="180"/>
     </contour>
     <contour>
-      <point x="422.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="363.0"/>
-      <point x="488.0" y="393.0"/>
-      <point x="488.0" y="430.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="467.0"/>
-      <point x="463.0" y="498.0"/>
-      <point x="422.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="381.0" y="498.0"/>
-      <point x="356.0" y="467.0"/>
-      <point x="356.0" y="430.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="393.0"/>
-      <point x="381.0" y="363.0"/>
+      <point x="433" y="359" type="curve" smooth="yes"/>
+      <point x="479" y="359"/>
+      <point x="508" y="392"/>
+      <point x="508" y="435" type="curve" smooth="yes"/>
+      <point x="508" y="466"/>
+      <point x="486" y="494"/>
+      <point x="450" y="494" type="curve" smooth="yes"/>
+      <point x="404" y="494"/>
+      <point x="374" y="460"/>
+      <point x="374" y="417" type="curve" smooth="yes"/>
+      <point x="374" y="387"/>
+      <point x="397" y="359"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="135.0" y="338.0" type="line"/>
-      <point x="192.0" y="338.0" type="line"/>
-      <point x="258.0" y="716.0" type="line"/>
-      <point x="210.0" y="716.0" type="line"/>
-      <point x="100.0" y="644.0" type="line"/>
-      <point x="80.0" y="570.0" type="line"/>
-      <point x="188.0" y="637.0" type="line"/>
+      <point x="135" y="338" type="line"/>
+      <point x="200" y="338" type="line"/>
+      <point x="266" y="716" type="line"/>
+      <point x="210" y="716" type="line"/>
+      <point x="100" y="644" type="line"/>
+      <point x="85" y="562" type="line"/>
+      <point x="185" y="626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406.0" y="171.0" type="line"/>
-      <point x="406.0" y="462.0" type="line"/>
-      <point x="317.0" y="398.0" type="line"/>
-      <point x="317.0" y="477.0" type="line"/>
-      <point x="415.0" y="549.0" type="line"/>
-      <point x="471.0" y="549.0" type="line"/>
-      <point x="471.0" y="171.0" type="line"/>
+      <point x="373" y="176" type="line"/>
+      <point x="423" y="464" type="line"/>
+      <point x="323" y="400" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="504" y="554" type="line"/>
+      <point x="438" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -4,6 +4,6 @@
   <unicode hex="2780"/>
   <outline>
     <component base="one.numerator" xOffset="243" yOffset="-169"/>
-    <component base="SansSerifCircle" yOffset="1"/>
+    <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="175.0" y="338.0" type="line"/>
-      <point x="194.0" y="466.0"/>
-      <point x="255.0" y="582.0"/>
-      <point x="353.0" y="661.0" type="curve"/>
-      <point x="362.0" y="716.0" type="line"/>
-      <point x="107.0" y="716.0" type="line"/>
-      <point x="99.0" y="667.0" type="line"/>
-      <point x="298.0" y="667.0" type="line"/>
-      <point x="224.0" y="609.0"/>
-      <point x="139.0" y="486.0"/>
-      <point x="111.0" y="333.0" type="curve"/>
+      <point x="175" y="338" type="line"/>
+      <point x="194" y="466"/>
+      <point x="255" y="582"/>
+      <point x="353" y="661" type="curve"/>
+      <point x="362" y="716" type="line"/>
+      <point x="107" y="716" type="line"/>
+      <point x="97" y="657" type="line"/>
+      <point x="280" y="657" type="line"/>
+      <point x="206" y="599"/>
+      <point x="130" y="491"/>
+      <point x="103" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="368.0" y="171.0" type="line"/>
-      <point x="368.0" y="324.0"/>
-      <point x="431.0" y="427.0"/>
-      <point x="489.0" y="490.0" type="curve"/>
-      <point x="306.0" y="490.0" type="line"/>
-      <point x="306.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="400" y="164" type="curve"/>
+      <point x="328" y="164" type="line"/>
+      <point x="355" y="317"/>
+      <point x="431" y="425"/>
+      <point x="505" y="483" type="curve"/>
+      <point x="322" y="483" type="line"/>
+      <point x="332" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="578" y="487" type="line"/>
+      <point x="480" y="408"/>
+      <point x="419" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="176.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="265.0" y="330.0"/>
-      <point x="324.0" y="392.0"/>
-      <point x="324.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="324.0" y="531.0"/>
-      <point x="290.0" y="575.0"/>
-      <point x="221.0" y="575.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="575.0"/>
-      <point x="137.0" y="562.0"/>
-      <point x="113.0" y="533.0" type="curve"/>
-      <point x="135.0" y="592.0"/>
-      <point x="223.0" y="655.0"/>
-      <point x="283.0" y="679.0" type="curve"/>
-      <point x="271.0" y="722.0" type="line"/>
-      <point x="213.0" y="703.0"/>
-      <point x="165.0" y="671.0"/>
-      <point x="132.0" y="634.0" type="curve" smooth="yes"/>
-      <point x="82.0" y="578.0"/>
-      <point x="64.0" y="514.0"/>
-      <point x="64.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="64.0" y="372.0"/>
-      <point x="113.0" y="330.0"/>
+      <point x="176" y="330" type="curve" smooth="yes"/>
+      <point x="265" y="330"/>
+      <point x="329" y="392"/>
+      <point x="329" y="473" type="curve" smooth="yes"/>
+      <point x="329" y="531"/>
+      <point x="297" y="580"/>
+      <point x="228" y="580" type="curve" smooth="yes"/>
+      <point x="197" y="580"/>
+      <point x="160" y="569"/>
+      <point x="136" y="540" type="curve"/>
+      <point x="158" y="599"/>
+      <point x="231" y="649"/>
+      <point x="291" y="673" type="curve"/>
+      <point x="271" y="722" type="line"/>
+      <point x="213" y="703"/>
+      <point x="166" y="670"/>
+      <point x="132" y="634" type="curve" smooth="yes"/>
+      <point x="81" y="579"/>
+      <point x="59" y="514"/>
+      <point x="59" y="468" type="curve" smooth="yes"/>
+      <point x="59" y="372"/>
+      <point x="113" y="330"/>
     </contour>
     <contour>
-      <point x="185.0" y="379.0" type="curve" smooth="yes"/>
-      <point x="139.0" y="379.0"/>
-      <point x="117.0" y="407.0"/>
-      <point x="117.0" y="448.0" type="curve" smooth="yes"/>
-      <point x="117.0" y="501.0"/>
-      <point x="146.0" y="534.0"/>
-      <point x="202.0" y="534.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="534.0"/>
-      <point x="271.0" y="506.0"/>
-      <point x="271.0" y="466.0" type="curve" smooth="yes"/>
-      <point x="271.0" y="413.0"/>
-      <point x="241.0" y="379.0"/>
+      <point x="185" y="389" type="curve" smooth="yes"/>
+      <point x="149" y="389"/>
+      <point x="127" y="417"/>
+      <point x="127" y="448" type="curve" smooth="yes"/>
+      <point x="127" y="491"/>
+      <point x="156" y="524"/>
+      <point x="202" y="524" type="curve" smooth="yes"/>
+      <point x="238" y="524"/>
+      <point x="261" y="496"/>
+      <point x="261" y="466" type="curve" smooth="yes"/>
+      <point x="261" y="423"/>
+      <point x="231" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="462.0" y="222.0"/>
-      <point x="487.0" y="253.0"/>
-      <point x="487.0" y="290.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="327.0"/>
-      <point x="462.0" y="357.0"/>
-      <point x="421.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="380.0" y="357.0"/>
-      <point x="355.0" y="327.0"/>
-      <point x="355.0" y="290.0" type="curve" smooth="yes"/>
-      <point x="355.0" y="253.0"/>
-      <point x="380.0" y="222.0"/>
+      <point x="420" y="230" type="curve" smooth="yes"/>
+      <point x="466" y="230"/>
+      <point x="496" y="264"/>
+      <point x="496" y="307" type="curve" smooth="yes"/>
+      <point x="496" y="337"/>
+      <point x="473" y="365"/>
+      <point x="437" y="365" type="curve" smooth="yes"/>
+      <point x="391" y="365"/>
+      <point x="362" y="332"/>
+      <point x="362" y="289" type="curve" smooth="yes"/>
+      <point x="362" y="258"/>
+      <point x="384" y="230"/>
     </contour>
     <contour>
-      <point x="422.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="346.0" y="163.0"/>
-      <point x="288.0" y="216.0"/>
-      <point x="288.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="337.0"/>
-      <point x="305.0" y="369.0"/>
-      <point x="330.0" y="407.0" type="curve" smooth="yes"/>
-      <point x="363.0" y="455.0"/>
-      <point x="395.0" y="503.0"/>
-      <point x="428.0" y="549.0" type="curve"/>
-      <point x="505.0" y="549.0" type="line"/>
-      <point x="472.0" y="502.0"/>
-      <point x="438.0" y="454.0"/>
-      <point x="405.0" y="407.0" type="curve"/>
-      <point x="411.0" y="410.0"/>
-      <point x="423.0" y="413.0"/>
-      <point x="437.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="504.0" y="413.0"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="217.0"/>
-      <point x="494.0" y="163.0"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="294" y="213"/>
+      <point x="294" y="309" type="curve" smooth="yes"/>
+      <point x="294" y="355"/>
+      <point x="316" y="420"/>
+      <point x="367" y="475" type="curve" smooth="yes"/>
+      <point x="401" y="511"/>
+      <point x="448" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="526" y="514" type="line"/>
+      <point x="466" y="490"/>
+      <point x="393" y="440"/>
+      <point x="371" y="381" type="curve"/>
+      <point x="395" y="410"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="532" y="421"/>
+      <point x="564" y="372"/>
+      <point x="564" y="314" type="curve" smooth="yes"/>
+      <point x="564" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="198.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="272.0" y="330.0"/>
-      <point x="326.0" y="380.0"/>
-      <point x="326.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="493.0"/>
-      <point x="307.0" y="522.0"/>
-      <point x="283.0" y="534.0" type="curve"/>
-      <point x="317.0" y="553.0"/>
-      <point x="344.0" y="577.0"/>
-      <point x="344.0" y="627.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="681.0"/>
-      <point x="305.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="724.0"/>
-      <point x="120.0" y="686.0"/>
-      <point x="103.0" y="628.0" type="curve"/>
-      <point x="156.0" y="621.0" type="line"/>
-      <point x="167.0" y="649.0"/>
-      <point x="188.0" y="676.0"/>
-      <point x="228.0" y="676.0" type="curve" smooth="yes"/>
-      <point x="270.0" y="676.0"/>
-      <point x="291.0" y="653.0"/>
-      <point x="291.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="291.0" y="583.0"/>
-      <point x="269.0" y="557.0"/>
-      <point x="211.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="557.0"/>
-      <point x="192.0" y="557.0"/>
-      <point x="182.0" y="557.0" type="curve"/>
-      <point x="174.0" y="511.0" type="line"/>
-      <point x="180.0" y="511.0"/>
-      <point x="195.0" y="511.0"/>
-      <point x="205.0" y="511.0" type="curve" smooth="yes"/>
-      <point x="250.0" y="511.0"/>
-      <point x="273.0" y="479.0"/>
-      <point x="273.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="405.0"/>
-      <point x="248.0" y="379.0"/>
-      <point x="194.0" y="379.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="379.0"/>
-      <point x="123.0" y="402.0"/>
-      <point x="116.0" y="450.0" type="curve"/>
-      <point x="62.0" y="443.0" type="line"/>
-      <point x="70.0" y="369.0"/>
-      <point x="128.0" y="330.0"/>
+      <point x="189" y="330" type="curve" smooth="yes"/>
+      <point x="275" y="330"/>
+      <point x="330" y="380"/>
+      <point x="330" y="459" type="curve" smooth="yes"/>
+      <point x="330" y="493"/>
+      <point x="314" y="522"/>
+      <point x="290" y="534" type="curve"/>
+      <point x="321" y="553"/>
+      <point x="347" y="577"/>
+      <point x="347" y="627" type="curve" smooth="yes"/>
+      <point x="347" y="681"/>
+      <point x="305" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="164" y="724"/>
+      <point x="120" y="686"/>
+      <point x="103" y="628" type="curve"/>
+      <point x="164" y="617" type="line"/>
+      <point x="175" y="645"/>
+      <point x="192" y="665"/>
+      <point x="229" y="665" type="curve" smooth="yes"/>
+      <point x="259" y="665"/>
+      <point x="280" y="646"/>
+      <point x="280" y="617" type="curve" smooth="yes"/>
+      <point x="280" y="583"/>
+      <point x="262" y="561"/>
+      <point x="212" y="561" type="curve" smooth="yes"/>
+      <point x="202" y="561.0"/>
+      <point x="193" y="561.0"/>
+      <point x="183" y="561" type="curve"/>
+      <point x="173" y="505" type="line"/>
+      <point x="179" y="505"/>
+      <point x="194" y="505.0"/>
+      <point x="204" y="505" type="curve" smooth="yes"/>
+      <point x="241" y="505"/>
+      <point x="263" y="479"/>
+      <point x="263" y="452" type="curve" smooth="yes"/>
+      <point x="263" y="415"/>
+      <point x="238" y="389"/>
+      <point x="194" y="389" type="curve" smooth="yes"/>
+      <point x="155" y="389"/>
+      <point x="133" y="416"/>
+      <point x="126" y="454" type="curve"/>
+      <point x="62" y="443" type="line"/>
+      <point x="70" y="369"/>
+      <point x="128" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="352.0" y="284.0" type="line"/>
-      <point x="360.0" y="240.0"/>
-      <point x="387.0" y="219.0"/>
-      <point x="423.0" y="219.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="219.0"/>
-      <point x="487.0" y="241.0"/>
-      <point x="487.0" y="279.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="311.0"/>
-      <point x="461.0" y="335.0"/>
-      <point x="419.0" y="335.0" type="curve" smooth="yes"/>
-      <point x="409.0" y="335.0"/>
-      <point x="398.0" y="335.0"/>
-      <point x="388.0" y="335.0" type="curve"/>
-      <point x="388.0" y="391.0" type="line"/>
-      <point x="396.0" y="391.0"/>
-      <point x="404.0" y="391.0"/>
-      <point x="412.0" y="391.0" type="curve"/>
-      <point x="447.0" y="391.0"/>
-      <point x="474.0" y="407.0"/>
-      <point x="474.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="475.0"/>
-      <point x="454.0" y="495.0"/>
-      <point x="421.0" y="495.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="495.0"/>
-      <point x="367.0" y="472.0"/>
-      <point x="359.0" y="447.0" type="curve"/>
-      <point x="296.0" y="458.0" type="line"/>
-      <point x="306.0" y="513.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="287" y="201"/>
+      <point x="279" y="275" type="curve"/>
+      <point x="343" y="286" type="line"/>
+      <point x="350" y="248"/>
+      <point x="372" y="221"/>
+      <point x="411" y="221" type="curve" smooth="yes"/>
+      <point x="455" y="221"/>
+      <point x="480" y="247"/>
+      <point x="480" y="284" type="curve" smooth="yes"/>
+      <point x="480" y="311"/>
+      <point x="458" y="337"/>
+      <point x="421" y="337" type="curve" smooth="yes"/>
+      <point x="411" y="337"/>
+      <point x="396" y="337"/>
+      <point x="390" y="337" type="curve"/>
+      <point x="400" y="393" type="line"/>
+      <point x="410" y="393"/>
+      <point x="419" y="393"/>
+      <point x="429" y="393" type="curve" smooth="yes"/>
+      <point x="479" y="393"/>
+      <point x="497" y="415"/>
+      <point x="497" y="449" type="curve" smooth="yes"/>
+      <point x="497" y="478"/>
+      <point x="476" y="497"/>
+      <point x="446" y="497" type="curve" smooth="yes"/>
+      <point x="409" y="497"/>
+      <point x="392" y="477"/>
+      <point x="381" y="449" type="curve"/>
+      <point x="320" y="460" type="line"/>
+      <point x="337" y="518"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="564" y="513"/>
+      <point x="564" y="459" type="curve" smooth="yes"/>
+      <point x="564" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="547" y="325"/>
+      <point x="547" y="291" type="curve" smooth="yes"/>
+      <point x="547" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="49.0" y="338.0" type="line"/>
-      <point x="296.0" y="338.0" type="line"/>
-      <point x="304.0" y="387.0" type="line"/>
-      <point x="134.0" y="387.0" type="line"/>
-      <point x="184.0" y="420.0"/>
-      <point x="252.0" y="468.0"/>
-      <point x="286.0" y="506.0" type="curve" smooth="yes"/>
-      <point x="318.0" y="541.0"/>
-      <point x="334.0" y="570.0"/>
-      <point x="334.0" y="618.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="679.0"/>
-      <point x="302.0" y="724.0"/>
-      <point x="229.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="148.0" y="724.0"/>
-      <point x="103.0" y="679.0"/>
-      <point x="89.0" y="608.0" type="curve"/>
-      <point x="143.0" y="601.0" type="line"/>
-      <point x="148.0" y="639.0"/>
-      <point x="182.0" y="673.0"/>
-      <point x="218.0" y="673.0" type="curve" smooth="yes"/>
-      <point x="259.0" y="673.0"/>
-      <point x="278.0" y="653.0"/>
-      <point x="278.0" y="615.0" type="curve" smooth="yes"/>
-      <point x="278.0" y="591.0"/>
-      <point x="262.0" y="568.0"/>
-      <point x="239.0" y="539.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="501.0"/>
-      <point x="148.0" y="449.0"/>
-      <point x="57.0" y="387.0" type="curve"/>
+      <point x="49" y="338" type="line"/>
+      <point x="296" y="338" type="line"/>
+      <point x="306" y="397" type="line"/>
+      <point x="157" y="397" type="line"/>
+      <point x="207" y="430"/>
+      <point x="253" y="463"/>
+      <point x="287" y="501" type="curve" smooth="yes"/>
+      <point x="319" y="536"/>
+      <point x="339" y="570"/>
+      <point x="339" y="618" type="curve" smooth="yes"/>
+      <point x="339" y="679"/>
+      <point x="302" y="724"/>
+      <point x="229" y="724" type="curve" smooth="yes"/>
+      <point x="148" y="724"/>
+      <point x="103" y="679"/>
+      <point x="89" y="608" type="curve"/>
+      <point x="153" y="597" type="line"/>
+      <point x="160" y="639"/>
+      <point x="188" y="665"/>
+      <point x="220" y="665" type="curve" smooth="yes"/>
+      <point x="253" y="665"/>
+      <point x="273" y="646"/>
+      <point x="273" y="615" type="curve" smooth="yes"/>
+      <point x="273" y="591"/>
+      <point x="263" y="566"/>
+      <point x="239" y="539" type="curve" smooth="yes"/>
+      <point x="206" y="502"/>
+      <point x="150" y="456"/>
+      <point x="59" y="394" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="227.0" type="line"/>
-      <point x="372.0" y="277.0"/>
-      <point x="418.0" y="314.0"/>
-      <point x="447.0" y="348.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="379.0"/>
-      <point x="485.0" y="408.0"/>
-      <point x="485.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="478.0"/>
-      <point x="459.0" y="498.0"/>
-      <point x="427.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="389.0" y="498.0"/>
-      <point x="369.0" y="470.0"/>
-      <point x="364.0" y="430.0" type="curve"/>
-      <point x="298.0" y="441.0" type="line"/>
-      <point x="304.0" y="512.0"/>
-      <point x="359.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="436.0" y="255.0"/>
-      <point x="402.0" y="230.0" type="curve"/>
-      <point x="553.0" y="230.0" type="line"/>
-      <point x="553.0" y="171.0" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="291" y="233" type="line"/>
+      <point x="382" y="295"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="505" y="430"/>
+      <point x="505" y="454" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="485" y="504"/>
+      <point x="452" y="504" type="curve" smooth="yes"/>
+      <point x="420" y="504"/>
+      <point x="392" y="478"/>
+      <point x="385" y="436" type="curve"/>
+      <point x="321" y="447" type="line"/>
+      <point x="335" y="518"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="534" y="563"/>
+      <point x="571" y="518"/>
+      <point x="571" y="457" type="curve" smooth="yes"/>
+      <point x="571" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="439" y="269"/>
+      <point x="389" y="236" type="curve"/>
+      <point x="538" y="236" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="222" type="curve" smooth="yes"/>
-      <point x="465" y="222"/>
-      <point x="492" y="248"/>
-      <point x="492" y="283" type="curve" smooth="yes"/>
-      <point x="492" y="317"/>
-      <point x="465" y="343"/>
-      <point x="426" y="343" type="curve" smooth="yes"/>
-      <point x="387" y="343"/>
-      <point x="359" y="318"/>
-      <point x="359" y="283" type="curve" smooth="yes"/>
-      <point x="359" y="247"/>
-      <point x="387" y="222"/>
+      <point x="412" y="223" type="curve" smooth="yes"/>
+      <point x="456" y="223"/>
+      <point x="485" y="249"/>
+      <point x="485" y="289" type="curve" smooth="yes"/>
+      <point x="485" y="323"/>
+      <point x="462" y="344"/>
+      <point x="425" y="344" type="curve" smooth="yes"/>
+      <point x="382" y="344"/>
+      <point x="350" y="319"/>
+      <point x="350" y="278" type="curve" smooth="yes"/>
+      <point x="350" y="248"/>
+      <point x="376" y="223"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="352" y="163"/>
-      <point x="292" y="208"/>
-      <point x="292" y="280" type="curve" smooth="yes"/>
-      <point x="292" y="321"/>
-      <point x="312" y="353"/>
-      <point x="346" y="373" type="curve"/>
-      <point x="323" y="388"/>
-      <point x="304" y="418"/>
-      <point x="304" y="450" type="curve" smooth="yes"/>
-      <point x="304" y="515"/>
-      <point x="358" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="494" y="557"/>
-      <point x="547" y="515"/>
-      <point x="547" y="450" type="curve" smooth="yes"/>
-      <point x="547" y="419"/>
-      <point x="527" y="388"/>
-      <point x="505" y="373" type="curve"/>
-      <point x="539" y="353"/>
-      <point x="559" y="321"/>
-      <point x="559" y="280" type="curve" smooth="yes"/>
-      <point x="559" y="206"/>
-      <point x="500" y="163"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="282" y="212"/>
+      <point x="282" y="272" type="curve" smooth="yes"/>
+      <point x="282" y="329"/>
+      <point x="318" y="365"/>
+      <point x="361" y="381" type="curve"/>
+      <point x="344" y="394"/>
+      <point x="325" y="420"/>
+      <point x="325" y="447" type="curve" smooth="yes"/>
+      <point x="325" y="515"/>
+      <point x="375" y="558"/>
+      <point x="462" y="558" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="568" y="521"/>
+      <point x="568" y="462" type="curve" smooth="yes"/>
+      <point x="568" y="420"/>
+      <point x="547" y="392"/>
+      <point x="513" y="372" type="curve"/>
+      <point x="538" y="357"/>
+      <point x="553" y="330"/>
+      <point x="553" y="296" type="curve" smooth="yes"/>
+      <point x="553" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="426" y="397" type="curve" smooth="yes"/>
-      <point x="458" y="397"/>
-      <point x="480" y="417"/>
-      <point x="480" y="447" type="curve" smooth="yes"/>
-      <point x="480" y="477"/>
-      <point x="458" y="498"/>
-      <point x="426" y="498" type="curve" smooth="yes"/>
-      <point x="394" y="498"/>
-      <point x="371" y="477"/>
-      <point x="371" y="447" type="curve" smooth="yes"/>
-      <point x="371" y="417"/>
-      <point x="394" y="397"/>
+      <point x="440" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="502" y="420"/>
+      <point x="502" y="452" type="curve" smooth="yes"/>
+      <point x="502" y="476"/>
+      <point x="485" y="499"/>
+      <point x="453" y="499" type="curve" smooth="yes"/>
+      <point x="415" y="499"/>
+      <point x="391" y="477"/>
+      <point x="391" y="444" type="curve" smooth="yes"/>
+      <point x="391" y="419"/>
+      <point x="410" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="356" y="163"/>
-      <point x="304" y="202"/>
-      <point x="292" y="267" type="curve"/>
-      <point x="356" y="280" type="line"/>
-      <point x="363" y="248"/>
-      <point x="388" y="222"/>
-      <point x="426" y="222" type="curve" smooth="yes"/>
-      <point x="465" y="222"/>
-      <point x="492" y="249"/>
-      <point x="492" y="294" type="curve" smooth="yes"/>
-      <point x="492" y="339"/>
-      <point x="465" y="365"/>
-      <point x="426" y="365" type="curve" smooth="yes"/>
-      <point x="397" y="365"/>
-      <point x="375" y="352"/>
-      <point x="361" y="330" type="curve"/>
-      <point x="305" y="353" type="line"/>
-      <point x="330" y="548" type="line"/>
-      <point x="537" y="548" type="line"/>
-      <point x="537" y="492" type="line"/>
-      <point x="382" y="492" type="line"/>
-      <point x="367" y="395" type="line"/>
-      <point x="381" y="411"/>
-      <point x="406" y="421"/>
-      <point x="436" y="421" type="curve" smooth="yes"/>
-      <point x="513" y="421"/>
-      <point x="558" y="371"/>
-      <point x="558" y="293" type="curve" smooth="yes"/>
-      <point x="558" y="218"/>
-      <point x="508" y="163"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="338" y="273" type="line"/>
+      <point x="344" y="239"/>
+      <point x="365" y="215"/>
+      <point x="405" y="215" type="curve" smooth="yes"/>
+      <point x="459" y="215"/>
+      <point x="481" y="251"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="334"/>
+      <point x="457" y="358"/>
+      <point x="423" y="358" type="curve" smooth="yes"/>
+      <point x="393" y="358"/>
+      <point x="370" y="344"/>
+      <point x="355" y="323" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="559" y="485" type="line"/>
+      <point x="406" y="485" type="line"/>
+      <point x="376" y="392" type="line"/>
+      <point x="393" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="548" y="366"/>
+      <point x="548" y="306" type="curve" smooth="yes"/>
+      <point x="548" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="331" y="305" type="line"/>
-      <point x="433" y="305" type="line"/>
-      <point x="433" y="450" type="line"/>
-      <point x="429" y="450" type="line"/>
+      <point x="337" y="309" type="line"/>
+      <point x="435" y="309" type="line"/>
+      <point x="460" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="433" y="171" type="line"/>
-      <point x="433" y="249" type="line"/>
-      <point x="256" y="249" type="line"/>
-      <point x="256" y="293" type="line"/>
-      <point x="437" y="549" type="line"/>
-      <point x="498" y="549" type="line"/>
-      <point x="498" y="305" type="line"/>
-      <point x="547" y="305" type="line"/>
-      <point x="547" y="249" type="line"/>
-      <point x="498" y="249" type="line"/>
-      <point x="498" y="171" type="line"/>
+      <point x="411" y="175" type="line"/>
+      <point x="425" y="253" type="line"/>
+      <point x="247" y="253" type="line"/>
+      <point x="255" y="297" type="line"/>
+      <point x="476" y="553" type="line"/>
+      <point x="542" y="553" type="line"/>
+      <point x="499" y="309" type="line"/>
+      <point x="548" y="309" type="line"/>
+      <point x="538" y="253" type="line"/>
+      <point x="490" y="253" type="line"/>
+      <point x="476" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="415" y="171" type="curve"/>
-      <point x="338" y="171" type="line"/>
-      <point x="371" y="218"/>
-      <point x="405" y="266"/>
-      <point x="438" y="313" type="curve"/>
-      <point x="432" y="310"/>
-      <point x="420" y="307"/>
-      <point x="406" y="307" type="curve" smooth="yes"/>
-      <point x="339" y="307"/>
-      <point x="289" y="361"/>
-      <point x="289" y="431" type="curve" smooth="yes"/>
-      <point x="289" y="503"/>
-      <point x="349" y="557"/>
-      <point x="421" y="557" type="curve" smooth="yes"/>
-      <point x="497" y="557"/>
-      <point x="555" y="504"/>
-      <point x="555" y="431" type="curve" smooth="yes"/>
-      <point x="555" y="383"/>
-      <point x="538" y="351"/>
-      <point x="513" y="313" type="curve"/>
-      <point x="480" y="266"/>
-      <point x="448" y="218"/>
+      <point x="364" y="161" type="curve"/>
+      <point x="344" y="210" type="line"/>
+      <point x="404" y="234"/>
+      <point x="477" y="284"/>
+      <point x="499" y="343" type="curve"/>
+      <point x="475" y="314"/>
+      <point x="440" y="303"/>
+      <point x="409" y="303" type="curve" smooth="yes"/>
+      <point x="346" y="303"/>
+      <point x="306" y="352"/>
+      <point x="306" y="410" type="curve" smooth="yes"/>
+      <point x="306" y="491"/>
+      <point x="370" y="553"/>
+      <point x="459" y="553" type="curve" smooth="yes"/>
+      <point x="522" y="553"/>
+      <point x="576" y="511"/>
+      <point x="576" y="415" type="curve" smooth="yes"/>
+      <point x="576" y="369"/>
+      <point x="555" y="304"/>
+      <point x="503" y="249" type="curve" smooth="yes"/>
+      <point x="469" y="213"/>
+      <point x="422" y="180"/>
     </contour>
     <contour>
-      <point x="422" y="363" type="curve" smooth="yes"/>
-      <point x="463" y="363"/>
-      <point x="488" y="393"/>
-      <point x="488" y="430" type="curve" smooth="yes"/>
-      <point x="488" y="467"/>
-      <point x="463" y="498"/>
-      <point x="422" y="498" type="curve" smooth="yes"/>
-      <point x="381" y="498"/>
-      <point x="356" y="467"/>
-      <point x="356" y="430" type="curve" smooth="yes"/>
-      <point x="356" y="393"/>
-      <point x="381" y="363"/>
+      <point x="433" y="359" type="curve" smooth="yes"/>
+      <point x="479" y="359"/>
+      <point x="508" y="392"/>
+      <point x="508" y="435" type="curve" smooth="yes"/>
+      <point x="508" y="466"/>
+      <point x="486" y="494"/>
+      <point x="450" y="494" type="curve" smooth="yes"/>
+      <point x="404" y="494"/>
+      <point x="374" y="460"/>
+      <point x="374" y="417" type="curve" smooth="yes"/>
+      <point x="374" y="387"/>
+      <point x="397" y="359"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406" y="171" type="line"/>
-      <point x="406" y="462" type="line"/>
-      <point x="317" y="398" type="line"/>
-      <point x="317" y="477" type="line"/>
-      <point x="415" y="549" type="line"/>
-      <point x="471" y="549" type="line"/>
-      <point x="471" y="171" type="line"/>
+      <point x="373" y="176" type="line"/>
+      <point x="423" y="464" type="line"/>
+      <point x="323" y="400" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="504" y="554" type="line"/>
+      <point x="438" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440" y="171" type="curve"/>
-      <point x="368" y="171" type="line"/>
-      <point x="368" y="324"/>
-      <point x="431" y="427"/>
-      <point x="489" y="490" type="curve"/>
-      <point x="306" y="490" type="line"/>
-      <point x="306" y="549" type="line"/>
-      <point x="561" y="549" type="line"/>
-      <point x="561" y="494" type="line"/>
-      <point x="477" y="414"/>
-      <point x="440" y="293"/>
+      <point x="400" y="164" type="curve"/>
+      <point x="328" y="164" type="line"/>
+      <point x="355" y="317"/>
+      <point x="431" y="425"/>
+      <point x="505" y="483" type="curve"/>
+      <point x="322" y="483" type="line"/>
+      <point x="332" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="578" y="487" type="line"/>
+      <point x="480" y="408"/>
+      <point x="419" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="222" type="curve" smooth="yes"/>
-      <point x="462" y="222"/>
-      <point x="487" y="253"/>
-      <point x="487" y="290" type="curve" smooth="yes"/>
-      <point x="487" y="327"/>
-      <point x="462" y="357"/>
-      <point x="421" y="357" type="curve" smooth="yes"/>
-      <point x="380" y="357"/>
-      <point x="355" y="327"/>
-      <point x="355" y="290" type="curve" smooth="yes"/>
-      <point x="355" y="253"/>
-      <point x="380" y="222"/>
+      <point x="420" y="230" type="curve" smooth="yes"/>
+      <point x="466" y="230"/>
+      <point x="496" y="264"/>
+      <point x="496" y="307" type="curve" smooth="yes"/>
+      <point x="496" y="337"/>
+      <point x="473" y="365"/>
+      <point x="437" y="365" type="curve" smooth="yes"/>
+      <point x="391" y="365"/>
+      <point x="362" y="332"/>
+      <point x="362" y="289" type="curve" smooth="yes"/>
+      <point x="362" y="258"/>
+      <point x="384" y="230"/>
     </contour>
     <contour>
-      <point x="422" y="163" type="curve" smooth="yes"/>
-      <point x="346" y="163"/>
-      <point x="288" y="216"/>
-      <point x="288" y="289" type="curve" smooth="yes"/>
-      <point x="288" y="337"/>
-      <point x="305" y="369"/>
-      <point x="330" y="407" type="curve"/>
-      <point x="363" y="455"/>
-      <point x="395" y="503"/>
-      <point x="428" y="549" type="curve"/>
-      <point x="505" y="549" type="line"/>
-      <point x="472" y="502"/>
-      <point x="438" y="454"/>
-      <point x="405" y="407" type="curve"/>
-      <point x="411" y="410"/>
-      <point x="423" y="413"/>
-      <point x="437" y="413" type="curve" smooth="yes"/>
-      <point x="504" y="413"/>
-      <point x="554" y="359"/>
-      <point x="554" y="289" type="curve" smooth="yes"/>
-      <point x="554" y="217"/>
-      <point x="494" y="163"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="294" y="213"/>
+      <point x="294" y="309" type="curve" smooth="yes"/>
+      <point x="294" y="355"/>
+      <point x="316" y="420"/>
+      <point x="367" y="475" type="curve" smooth="yes"/>
+      <point x="401" y="511"/>
+      <point x="448" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="526" y="514" type="line"/>
+      <point x="466" y="490"/>
+      <point x="393" y="440"/>
+      <point x="371" y="381" type="curve"/>
+      <point x="395" y="410"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="532" y="421"/>
+      <point x="564" y="372"/>
+      <point x="564" y="314" type="curve" smooth="yes"/>
+      <point x="564" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423" y="160" type="curve" smooth="yes"/>
-      <point x="353" y="160"/>
-      <point x="298" y="199"/>
-      <point x="288" y="273" type="curve"/>
-      <point x="352" y="284" type="line"/>
-      <point x="360" y="240"/>
-      <point x="387" y="219"/>
-      <point x="423" y="219" type="curve" smooth="yes"/>
-      <point x="460" y="219"/>
-      <point x="487" y="241"/>
-      <point x="487" y="279" type="curve" smooth="yes"/>
-      <point x="487" y="311"/>
-      <point x="461" y="335"/>
-      <point x="419" y="335" type="curve"/>
-      <point x="409" y="335.0"/>
-      <point x="398" y="335.0"/>
-      <point x="388" y="335" type="curve"/>
-      <point x="388" y="391" type="line"/>
-      <point x="396" y="391.0"/>
-      <point x="404" y="391.0"/>
-      <point x="412" y="391" type="curve"/>
-      <point x="447" y="391"/>
-      <point x="474" y="407"/>
-      <point x="474" y="446" type="curve" smooth="yes"/>
-      <point x="474" y="475"/>
-      <point x="454" y="495"/>
-      <point x="421" y="495" type="curve" smooth="yes"/>
-      <point x="387" y="495"/>
-      <point x="367" y="472"/>
-      <point x="359" y="447" type="curve"/>
-      <point x="296" y="458" type="line"/>
-      <point x="306" y="513"/>
-      <point x="350" y="554"/>
-      <point x="421" y="554" type="curve" smooth="yes"/>
-      <point x="492" y="554"/>
-      <point x="541" y="514"/>
-      <point x="541" y="453" type="curve" smooth="yes"/>
-      <point x="541" y="416"/>
-      <point x="522" y="387"/>
-      <point x="495" y="366" type="curve"/>
-      <point x="531" y="352"/>
-      <point x="553" y="324"/>
-      <point x="553" y="276" type="curve" smooth="yes"/>
-      <point x="553" y="205"/>
-      <point x="497" y="160"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="287" y="201"/>
+      <point x="279" y="275" type="curve"/>
+      <point x="343" y="286" type="line"/>
+      <point x="350" y="248"/>
+      <point x="372" y="221"/>
+      <point x="411" y="221" type="curve" smooth="yes"/>
+      <point x="455" y="221"/>
+      <point x="480" y="247"/>
+      <point x="480" y="284" type="curve" smooth="yes"/>
+      <point x="480" y="311"/>
+      <point x="458" y="337"/>
+      <point x="421" y="337" type="curve" smooth="yes"/>
+      <point x="411" y="337"/>
+      <point x="396" y="337"/>
+      <point x="390" y="337" type="curve"/>
+      <point x="400" y="393" type="line"/>
+      <point x="410" y="393"/>
+      <point x="419" y="393"/>
+      <point x="429" y="393" type="curve" smooth="yes"/>
+      <point x="479" y="393"/>
+      <point x="497" y="415"/>
+      <point x="497" y="449" type="curve" smooth="yes"/>
+      <point x="497" y="478"/>
+      <point x="476" y="497"/>
+      <point x="446" y="497" type="curve" smooth="yes"/>
+      <point x="409" y="497"/>
+      <point x="392" y="477"/>
+      <point x="381" y="449" type="curve"/>
+      <point x="320" y="460" type="line"/>
+      <point x="337" y="518"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="564" y="513"/>
+      <point x="564" y="459" type="curve" smooth="yes"/>
+      <point x="564" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="547" y="325"/>
+      <point x="547" y="291" type="curve" smooth="yes"/>
+      <point x="547" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306" y="171" type="line"/>
-      <point x="306" y="227" type="line"/>
-      <point x="372" y="277"/>
-      <point x="418" y="314"/>
-      <point x="447" y="348" type="curve" smooth="yes"/>
-      <point x="473" y="379"/>
-      <point x="485" y="408"/>
-      <point x="485" y="440" type="curve" smooth="yes"/>
-      <point x="485" y="478"/>
-      <point x="459" y="498"/>
-      <point x="427" y="498" type="curve" smooth="yes"/>
-      <point x="389" y="498"/>
-      <point x="369" y="470"/>
-      <point x="364" y="430" type="curve"/>
-      <point x="298" y="441" type="line"/>
-      <point x="304" y="512"/>
-      <point x="359" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="503" y="557"/>
-      <point x="551" y="513"/>
-      <point x="551" y="443" type="curve" smooth="yes"/>
-      <point x="551" y="392"/>
-      <point x="528" y="349"/>
-      <point x="492" y="309" type="curve" smooth="yes"/>
-      <point x="467" y="281"/>
-      <point x="436" y="255"/>
-      <point x="402" y="230" type="curve"/>
-      <point x="553" y="230" type="line"/>
-      <point x="553" y="171" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="291" y="233" type="line"/>
+      <point x="382" y="295"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="505" y="430"/>
+      <point x="505" y="454" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="485" y="504"/>
+      <point x="452" y="504" type="curve" smooth="yes"/>
+      <point x="420" y="504"/>
+      <point x="392" y="478"/>
+      <point x="385" y="436" type="curve"/>
+      <point x="321" y="447" type="line"/>
+      <point x="335" y="518"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="534" y="563"/>
+      <point x="571" y="518"/>
+      <point x="571" y="457" type="curve" smooth="yes"/>
+      <point x="571" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="439" y="269"/>
+      <point x="389" y="236" type="curve"/>
+      <point x="538" y="236" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="69.0" type="curve" smooth="yes"/>
-      <point x="268.0" y="69.0"/>
-      <point x="136.0" y="201.0"/>
-      <point x="136.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="136.0" y="518.0"/>
-      <point x="268.0" y="647.0"/>
-      <point x="425.0" y="647.0" type="curve" smooth="yes"/>
-      <point x="586.0" y="647.0"/>
-      <point x="714.0" y="518.0"/>
-      <point x="714.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="714.0" y="201.0"/>
-      <point x="586.0" y="69.0"/>
+      <point x="425" y="44" type="curve" smooth="yes"/>
+      <point x="254" y="44"/>
+      <point x="111" y="187"/>
+      <point x="111" y="358" type="curve" smooth="yes"/>
+      <point x="111" y="532"/>
+      <point x="254" y="672"/>
+      <point x="425" y="672" type="curve" smooth="yes"/>
+      <point x="600" y="672"/>
+      <point x="739" y="532"/>
+      <point x="739" y="358" type="curve" smooth="yes"/>
+      <point x="739" y="187"/>
+      <point x="600" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="182.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="330.0"/>
-      <point x="334.0" y="384.0"/>
-      <point x="334.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="496.0"/>
-      <point x="313.0" y="526.0"/>
-      <point x="289.0" y="538.0" type="curve"/>
-      <point x="329.0" y="558.0"/>
-      <point x="349.0" y="586.0"/>
-      <point x="349.0" y="628.0" type="curve" smooth="yes"/>
-      <point x="349.0" y="689.0"/>
-      <point x="310.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="724.0"/>
-      <point x="96.0" y="681.0"/>
-      <point x="96.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="96.0" y="586.0"/>
-      <point x="116.0" y="561.0"/>
-      <point x="137.0" y="547.0" type="curve"/>
-      <point x="94.0" y="531.0"/>
-      <point x="53.0" y="495.0"/>
-      <point x="53.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="378.0"/>
-      <point x="100.0" y="330.0"/>
+      <point x="182" y="330" type="curve" smooth="yes"/>
+      <point x="272" y="330"/>
+      <point x="329" y="381"/>
+      <point x="329" y="462" type="curve" smooth="yes"/>
+      <point x="329" y="496"/>
+      <point x="314" y="523"/>
+      <point x="289" y="538" type="curve"/>
+      <point x="323" y="558"/>
+      <point x="344" y="586"/>
+      <point x="344" y="628" type="curve" smooth="yes"/>
+      <point x="344" y="687"/>
+      <point x="302" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="151" y="724"/>
+      <point x="101" y="681"/>
+      <point x="101" y="613" type="curve" smooth="yes"/>
+      <point x="101" y="586"/>
+      <point x="120" y="560"/>
+      <point x="137" y="547" type="curve"/>
+      <point x="94" y="531"/>
+      <point x="58" y="495"/>
+      <point x="58" y="438" type="curve" smooth="yes"/>
+      <point x="58" y="378"/>
+      <point x="110" y="330"/>
     </contour>
     <contour>
-      <point x="188.0" y="399.0" type="curve" smooth="yes"/>
-      <point x="152.0" y="399.0"/>
-      <point x="138.0" y="421.0"/>
-      <point x="138.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="478.0"/>
-      <point x="158.0" y="500.0"/>
-      <point x="201.0" y="500.0" type="curve" smooth="yes"/>
-      <point x="237.0" y="500.0"/>
-      <point x="252.0" y="484.0"/>
-      <point x="252.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="252.0" y="424.0"/>
-      <point x="232.0" y="399.0"/>
+      <point x="188" y="389" type="curve" smooth="yes"/>
+      <point x="152" y="389"/>
+      <point x="126" y="414"/>
+      <point x="126" y="444" type="curve" smooth="yes"/>
+      <point x="126" y="485"/>
+      <point x="158" y="510"/>
+      <point x="201" y="510" type="curve" smooth="yes"/>
+      <point x="238" y="510"/>
+      <point x="261" y="489"/>
+      <point x="261" y="455" type="curve" smooth="yes"/>
+      <point x="261" y="415"/>
+      <point x="232" y="389"/>
     </contour>
     <contour>
-      <point x="215.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="185.0" y="568.0"/>
-      <point x="167.0" y="583.0"/>
-      <point x="167.0" y="608.0" type="curve" smooth="yes"/>
-      <point x="167.0" y="641.0"/>
-      <point x="191.0" y="655.0"/>
-      <point x="229.0" y="655.0" type="curve" smooth="yes"/>
-      <point x="261.0" y="655.0"/>
-      <point x="278.0" y="638.0"/>
-      <point x="278.0" y="614.0" type="curve" smooth="yes"/>
-      <point x="278.0" y="582.0"/>
-      <point x="254.0" y="568.0"/>
+      <point x="216" y="564" type="curve" smooth="yes"/>
+      <point x="186" y="564"/>
+      <point x="167" y="585"/>
+      <point x="167" y="610" type="curve" smooth="yes"/>
+      <point x="167" y="643"/>
+      <point x="191" y="665"/>
+      <point x="229" y="665" type="curve" smooth="yes"/>
+      <point x="261" y="665"/>
+      <point x="278" y="642"/>
+      <point x="278" y="618" type="curve" smooth="yes"/>
+      <point x="278" y="586"/>
+      <point x="255" y="564"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="427.0" y="231.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="231.0"/>
-      <point x="487.0" y="256.0"/>
-      <point x="487.0" y="287.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="319.0"/>
-      <point x="462.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="390.0" y="343.0"/>
-      <point x="365.0" y="320.0"/>
-      <point x="365.0" y="288.0" type="curve" smooth="yes"/>
-      <point x="365.0" y="255.0"/>
-      <point x="391.0" y="231.0"/>
+      <point x="412" y="223" type="curve" smooth="yes"/>
+      <point x="456" y="223"/>
+      <point x="485" y="249"/>
+      <point x="485" y="289" type="curve" smooth="yes"/>
+      <point x="485" y="323"/>
+      <point x="462" y="344"/>
+      <point x="425" y="344" type="curve" smooth="yes"/>
+      <point x="382" y="344"/>
+      <point x="350" y="319"/>
+      <point x="350" y="278" type="curve" smooth="yes"/>
+      <point x="350" y="248"/>
+      <point x="376" y="223"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="282" y="212"/>
+      <point x="282" y="272" type="curve" smooth="yes"/>
+      <point x="282" y="329"/>
+      <point x="318" y="365"/>
+      <point x="361" y="381" type="curve"/>
+      <point x="344" y="394"/>
+      <point x="325" y="420"/>
+      <point x="325" y="447" type="curve" smooth="yes"/>
+      <point x="325" y="515"/>
+      <point x="375" y="558"/>
+      <point x="462" y="558" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="568" y="521"/>
+      <point x="568" y="462" type="curve" smooth="yes"/>
+      <point x="568" y="420"/>
+      <point x="547" y="392"/>
+      <point x="513" y="372" type="curve"/>
+      <point x="538" y="357"/>
+      <point x="553" y="330"/>
+      <point x="553" y="296" type="curve" smooth="yes"/>
+      <point x="553" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="454.0" y="397.0"/>
-      <point x="473.0" y="415.0"/>
-      <point x="473.0" y="442.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="470.0"/>
-      <point x="453.0" y="489.0"/>
-      <point x="425.0" y="489.0" type="curve" smooth="yes"/>
-      <point x="396.0" y="489.0"/>
-      <point x="376.0" y="470.0"/>
-      <point x="376.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="376.0" y="415.0"/>
-      <point x="397.0" y="397.0"/>
+      <point x="440" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="502" y="420"/>
+      <point x="502" y="452" type="curve" smooth="yes"/>
+      <point x="502" y="476"/>
+      <point x="485" y="499"/>
+      <point x="453" y="499" type="curve" smooth="yes"/>
+      <point x="415" y="499"/>
+      <point x="391" y="477"/>
+      <point x="391" y="444" type="curve" smooth="yes"/>
+      <point x="391" y="419"/>
+      <point x="410" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="183.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="331.0"/>
-      <point x="338.0" y="388.0"/>
-      <point x="338.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="541.0"/>
-      <point x="294.0" y="589.0"/>
-      <point x="233.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="589.0"/>
-      <point x="176.0" y="580.0"/>
-      <point x="167.0" y="573.0" type="curve"/>
-      <point x="192.0" y="646.0" type="line"/>
-      <point x="343.0" y="646.0" type="line"/>
-      <point x="353.0" y="716.0" type="line"/>
-      <point x="132.0" y="716.0" type="line"/>
-      <point x="76.0" y="521.0" type="line"/>
-      <point x="141.0" y="488.0" type="line"/>
-      <point x="152.0" y="504.0"/>
-      <point x="177.0" y="523.0"/>
-      <point x="208.0" y="523.0" type="curve" smooth="yes"/>
-      <point x="238.0" y="523.0"/>
-      <point x="252.0" y="498.0"/>
-      <point x="252.0" y="465.0" type="curve" smooth="yes"/>
-      <point x="252.0" y="429.0"/>
-      <point x="243.0" y="402.0"/>
-      <point x="189.0" y="402.0" type="curve" smooth="yes"/>
-      <point x="149.0" y="402.0"/>
-      <point x="134.0" y="426.0"/>
-      <point x="129.0" y="454.0" type="curve"/>
-      <point x="54.0" y="441.0" type="line"/>
-      <point x="61.0" y="380.0"/>
-      <point x="109.0" y="331.0"/>
+      <point x="183" y="331" type="curve" smooth="yes"/>
+      <point x="274" y="331"/>
+      <point x="332" y="388"/>
+      <point x="332" y="481" type="curve" smooth="yes"/>
+      <point x="332" y="541"/>
+      <point x="294" y="589"/>
+      <point x="228" y="589" type="curve" smooth="yes"/>
+      <point x="198" y="589"/>
+      <point x="177" y="581"/>
+      <point x="160" y="567" type="curve"/>
+      <point x="190" y="660" type="line"/>
+      <point x="343" y="660" type="line"/>
+      <point x="353" y="716" type="line"/>
+      <point x="142" y="716" type="line"/>
+      <point x="86" y="521" type="line"/>
+      <point x="139" y="498" type="line"/>
+      <point x="154" y="519"/>
+      <point x="177" y="533"/>
+      <point x="207" y="533" type="curve" smooth="yes"/>
+      <point x="241" y="533"/>
+      <point x="265" y="509"/>
+      <point x="265" y="471" type="curve" smooth="yes"/>
+      <point x="265" y="426"/>
+      <point x="243" y="390"/>
+      <point x="189" y="390" type="curve" smooth="yes"/>
+      <point x="149" y="390"/>
+      <point x="128" y="414"/>
+      <point x="122" y="448" type="curve"/>
+      <point x="58" y="435" type="line"/>
+      <point x="67" y="370"/>
+      <point x="121" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="363.0" y="282.0" type="line"/>
-      <point x="370.0" y="253.0"/>
-      <point x="392.0" y="229.0"/>
-      <point x="427.0" y="229.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="229.0"/>
-      <point x="485.0" y="253.0"/>
-      <point x="485.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="334.0"/>
-      <point x="460.0" y="358.0"/>
-      <point x="425.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="398.0" y="358.0"/>
-      <point x="379.0" y="346.0"/>
-      <point x="366.0" y="326.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
-      <point x="537.0" y="548.0" type="line"/>
-      <point x="534.0" y="480.0" type="line"/>
-      <point x="379.0" y="480.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
-      <point x="508.0" y="163.0"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="338" y="273" type="line"/>
+      <point x="344" y="239"/>
+      <point x="365" y="215"/>
+      <point x="405" y="215" type="curve" smooth="yes"/>
+      <point x="459" y="215"/>
+      <point x="481" y="251"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="334"/>
+      <point x="457" y="358"/>
+      <point x="423" y="358" type="curve" smooth="yes"/>
+      <point x="393" y="358"/>
+      <point x="370" y="344"/>
+      <point x="355" y="323" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="559" y="485" type="line"/>
+      <point x="406" y="485" type="line"/>
+      <point x="376" y="392" type="line"/>
+      <point x="393" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="548" y="366"/>
+      <point x="548" y="306" type="curve" smooth="yes"/>
+      <point x="548" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="54.0" y="406.0" type="line"/>
-      <point x="345.0" y="406.0" type="line"/>
-      <point x="361.0" y="482.0" type="line"/>
-      <point x="165.0" y="482.0" type="line"/>
-      <point x="254.0" y="593.0" type="line"/>
-      <point x="257.0" y="593.0" type="line"/>
-      <point x="211.0" y="338.0" type="line"/>
-      <point x="297.0" y="338.0" type="line"/>
-      <point x="363.0" y="716.0" type="line"/>
-      <point x="277.0" y="716.0" type="line"/>
-      <point x="69.0" y="474.0" type="line"/>
+      <point x="57" y="416" type="line"/>
+      <point x="348" y="416" type="line"/>
+      <point x="358" y="472" type="line"/>
+      <point x="147" y="472" type="line"/>
+      <point x="266" y="617" type="line"/>
+      <point x="270" y="617" type="line"/>
+      <point x="221" y="338" type="line"/>
+      <point x="286" y="338" type="line"/>
+      <point x="352" y="716" type="line"/>
+      <point x="286" y="716" type="line"/>
+      <point x="65" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="338.0" y="308.0" type="line"/>
-      <point x="423.0" y="308.0" type="line"/>
-      <point x="420.0" y="430.0" type="line"/>
-      <point x="420.0" y="430.0" type="line"/>
+      <point x="337" y="309" type="line"/>
+      <point x="435" y="309" type="line"/>
+      <point x="460" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="423.0" y="171.0" type="line"/>
-      <point x="421.0" y="243.0" type="line"/>
-      <point x="254.0" y="243.0" type="line"/>
-      <point x="256.0" y="296.0" type="line"/>
-      <point x="433.0" y="549.0" type="line"/>
-      <point x="503.0" y="549.0" type="line"/>
-      <point x="503.0" y="308.0" type="line"/>
-      <point x="547.0" y="308.0" type="line"/>
-      <point x="545.0" y="243.0" type="line"/>
-      <point x="501.0" y="243.0" type="line"/>
-      <point x="503.0" y="171.0" type="line"/>
+      <point x="411" y="175" type="line"/>
+      <point x="425" y="253" type="line"/>
+      <point x="247" y="253" type="line"/>
+      <point x="255" y="297" type="line"/>
+      <point x="476" y="553" type="line"/>
+      <point x="542" y="553" type="line"/>
+      <point x="499" y="309" type="line"/>
+      <point x="548" y="309" type="line"/>
+      <point x="538" y="253" type="line"/>
+      <point x="490" y="253" type="line"/>
+      <point x="476" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="146.0" y="330.0" type="line"/>
-      <point x="204.0" y="349.0"/>
-      <point x="254.0" y="385.0"/>
-      <point x="288.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="474.0"/>
-      <point x="356.0" y="546.0"/>
-      <point x="356.0" y="586.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="682.0"/>
-      <point x="296.0" y="724.0"/>
-      <point x="233.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="136.0" y="724.0"/>
-      <point x="78.0" y="660.0"/>
-      <point x="78.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="78.0" y="512.0"/>
-      <point x="125.0" y="473.0"/>
-      <point x="180.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="211.0" y="473.0"/>
-      <point x="242.0" y="483.0"/>
-      <point x="262.0" y="509.0" type="curve"/>
-      <point x="246.0" y="456.0"/>
-      <point x="175.0" y="412.0"/>
-      <point x="115.0" y="388.0" type="curve"/>
+      <point x="141" y="332" type="line"/>
+      <point x="199" y="351"/>
+      <point x="246" y="384"/>
+      <point x="280" y="420" type="curve" smooth="yes"/>
+      <point x="332" y="475"/>
+      <point x="353" y="540"/>
+      <point x="353" y="586" type="curve" smooth="yes"/>
+      <point x="353" y="682"/>
+      <point x="299" y="724"/>
+      <point x="236" y="724" type="curve" smooth="yes"/>
+      <point x="147" y="724"/>
+      <point x="83" y="662"/>
+      <point x="83" y="581" type="curve" smooth="yes"/>
+      <point x="83" y="523"/>
+      <point x="123" y="474"/>
+      <point x="186" y="474" type="curve" smooth="yes"/>
+      <point x="217" y="474"/>
+      <point x="252" y="485"/>
+      <point x="276" y="514" type="curve"/>
+      <point x="254" y="455"/>
+      <point x="181" y="405"/>
+      <point x="121" y="381" type="curve"/>
     </contour>
     <contour>
-      <point x="211.0" y="539.0" type="curve" smooth="yes"/>
-      <point x="177.0" y="539.0"/>
-      <point x="156.0" y="558.0"/>
-      <point x="156.0" y="588.0" type="curve" smooth="yes"/>
-      <point x="156.0" y="631.0"/>
-      <point x="178.0" y="656.0"/>
-      <point x="224.0" y="656.0" type="curve" smooth="yes"/>
-      <point x="258.0" y="656.0"/>
-      <point x="274.0" y="634.0"/>
-      <point x="274.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="563.0"/>
-      <point x="250.0" y="539.0"/>
+      <point x="210" y="530" type="curve" smooth="yes"/>
+      <point x="174" y="530"/>
+      <point x="151" y="558"/>
+      <point x="151" y="588" type="curve" smooth="yes"/>
+      <point x="151" y="631"/>
+      <point x="181" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="263" y="665"/>
+      <point x="285" y="637"/>
+      <point x="285" y="606" type="curve" smooth="yes"/>
+      <point x="285" y="563"/>
+      <point x="256" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="419.0" y="168.0" type="curve"/>
-      <point x="333.0" y="176.0" type="line"/>
-      <point x="366.0" y="223.0"/>
-      <point x="400.0" y="271.0"/>
-      <point x="428.0" y="309.0" type="curve"/>
-      <point x="426.0" y="309.0"/>
-      <point x="420.0" y="307.0"/>
-      <point x="406.0" y="307.0" type="curve" smooth="yes"/>
-      <point x="339.0" y="307.0"/>
-      <point x="289.0" y="361.0"/>
-      <point x="289.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="503.0"/>
-      <point x="349.0" y="557.0"/>
-      <point x="421.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="497.0" y="557.0"/>
-      <point x="559.0" y="504.0"/>
-      <point x="559.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="383.0"/>
-      <point x="542.0" y="348.0"/>
-      <point x="517.0" y="310.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="263.0"/>
-      <point x="452.0" y="215.0"/>
+      <point x="364" y="161" type="curve"/>
+      <point x="344" y="210" type="line"/>
+      <point x="404" y="234"/>
+      <point x="477" y="284"/>
+      <point x="499" y="343" type="curve"/>
+      <point x="475" y="314"/>
+      <point x="440" y="303"/>
+      <point x="409" y="303" type="curve" smooth="yes"/>
+      <point x="346" y="303"/>
+      <point x="306" y="352"/>
+      <point x="306" y="410" type="curve" smooth="yes"/>
+      <point x="306" y="491"/>
+      <point x="370" y="553"/>
+      <point x="459" y="553" type="curve" smooth="yes"/>
+      <point x="522" y="553"/>
+      <point x="576" y="511"/>
+      <point x="576" y="415" type="curve" smooth="yes"/>
+      <point x="576" y="369"/>
+      <point x="555" y="304"/>
+      <point x="503" y="249" type="curve" smooth="yes"/>
+      <point x="469" y="213"/>
+      <point x="422" y="180"/>
     </contour>
     <contour>
-      <point x="423.0" y="369.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="369.0"/>
-      <point x="484.0" y="396.0"/>
-      <point x="484.0" y="429.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="463.0"/>
-      <point x="461.0" y="492.0"/>
-      <point x="422.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="383.0" y="492.0"/>
-      <point x="360.0" y="464.0"/>
-      <point x="360.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="360.0" y="396.0"/>
-      <point x="383.0" y="369.0"/>
+      <point x="433" y="359" type="curve" smooth="yes"/>
+      <point x="479" y="359"/>
+      <point x="508" y="392"/>
+      <point x="508" y="435" type="curve" smooth="yes"/>
+      <point x="508" y="466"/>
+      <point x="486" y="494"/>
+      <point x="450" y="494" type="curve" smooth="yes"/>
+      <point x="404" y="494"/>
+      <point x="374" y="460"/>
+      <point x="374" y="417" type="curve" smooth="yes"/>
+      <point x="374" y="387"/>
+      <point x="397" y="359"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="120.0" y="338.0" type="line"/>
-      <point x="210.0" y="338.0" type="line"/>
-      <point x="276.0" y="716.0" type="line"/>
-      <point x="183.0" y="716.0" type="line"/>
-      <point x="71.0" y="645.0" type="line"/>
-      <point x="67.0" y="539.0" type="line"/>
-      <point x="167.0" y="603.0" type="line"/>
+      <point x="135" y="338" type="line"/>
+      <point x="200" y="338" type="line"/>
+      <point x="266" y="716" type="line"/>
+      <point x="210" y="716" type="line"/>
+      <point x="100" y="644" type="line"/>
+      <point x="85" y="562" type="line"/>
+      <point x="185" y="626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="396.0" y="171.0" type="line"/>
-      <point x="393.0" y="439.0" type="line"/>
-      <point x="304.0" y="375.0" type="line"/>
-      <point x="296.0" y="468.0" type="line"/>
-      <point x="405.0" y="549.0" type="line"/>
-      <point x="481.0" y="549.0" type="line"/>
-      <point x="481.0" y="171.0" type="line"/>
+      <point x="373" y="176" type="line"/>
+      <point x="423" y="464" type="line"/>
+      <point x="323" y="400" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="504" y="554" type="line"/>
+      <point x="438" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -4,6 +4,6 @@
   <unicode hex="2780"/>
   <outline>
     <component base="one.numerator" xOffset="243" yOffset="-169"/>
-    <component base="SansSerifCircle" yOffset="1"/>
+    <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="192.0" y="336.0" type="line"/>
-      <point x="204.0" y="460.0"/>
-      <point x="251.0" y="565.0"/>
-      <point x="349.0" y="644.0" type="curve"/>
-      <point x="362.0" y="716.0" type="line"/>
-      <point x="107.0" y="716.0" type="line"/>
-      <point x="97.0" y="637.0" type="line"/>
-      <point x="256.0" y="637.0" type="line"/>
-      <point x="182.0" y="579.0"/>
-      <point x="131.0" y="502.0"/>
-      <point x="104.0" y="349.0" type="curve"/>
+      <point x="175" y="338" type="line"/>
+      <point x="194" y="466"/>
+      <point x="255" y="582"/>
+      <point x="353" y="661" type="curve"/>
+      <point x="362" y="716" type="line"/>
+      <point x="107" y="716" type="line"/>
+      <point x="97" y="657" type="line"/>
+      <point x="280" y="657" type="line"/>
+      <point x="206" y="599"/>
+      <point x="130" y="491"/>
+      <point x="103" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="358.0" y="178.0" type="line"/>
-      <point x="358.0" y="331.0"/>
-      <point x="411.0" y="417.0"/>
-      <point x="469.0" y="480.0" type="curve"/>
-      <point x="296.0" y="480.0" type="line"/>
-      <point x="299.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="400" y="164" type="curve"/>
+      <point x="328" y="164" type="line"/>
+      <point x="355" y="317"/>
+      <point x="431" y="425"/>
+      <point x="505" y="483" type="curve"/>
+      <point x="322" y="483" type="line"/>
+      <point x="332" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="578" y="487" type="line"/>
+      <point x="480" y="408"/>
+      <point x="419" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="176.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="330.0"/>
-      <point x="331.0" y="394.0"/>
-      <point x="331.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="331.0" y="542.0"/>
-      <point x="292.0" y="581.0"/>
-      <point x="231.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="581.0"/>
-      <point x="167.0" y="571.0"/>
-      <point x="146.0" y="545.0" type="curve"/>
-      <point x="162.0" y="598.0"/>
-      <point x="234.0" y="642.0"/>
-      <point x="294.0" y="666.0" type="curve"/>
-      <point x="263.0" y="724.0" type="line"/>
-      <point x="205.0" y="705.0"/>
-      <point x="156.0" y="670.0"/>
-      <point x="122.0" y="634.0" type="curve" smooth="yes"/>
-      <point x="71.0" y="579.0"/>
-      <point x="53.0" y="508.0"/>
-      <point x="53.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="372.0"/>
-      <point x="113.0" y="330.0"/>
+      <point x="176" y="330" type="curve" smooth="yes"/>
+      <point x="265" y="330"/>
+      <point x="329" y="392"/>
+      <point x="329" y="473" type="curve" smooth="yes"/>
+      <point x="329" y="531"/>
+      <point x="297" y="580"/>
+      <point x="228" y="580" type="curve" smooth="yes"/>
+      <point x="197" y="580"/>
+      <point x="160" y="569"/>
+      <point x="136" y="540" type="curve"/>
+      <point x="158" y="599"/>
+      <point x="231" y="649"/>
+      <point x="291" y="673" type="curve"/>
+      <point x="271" y="722" type="line"/>
+      <point x="213" y="703"/>
+      <point x="166" y="670"/>
+      <point x="132" y="634" type="curve" smooth="yes"/>
+      <point x="81" y="579"/>
+      <point x="59" y="514"/>
+      <point x="59" y="468" type="curve" smooth="yes"/>
+      <point x="59" y="372"/>
+      <point x="113" y="330"/>
     </contour>
     <contour>
-      <point x="185.0" y="398.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="398.0"/>
-      <point x="135.0" y="420.0"/>
-      <point x="135.0" y="448.0" type="curve" smooth="yes"/>
-      <point x="135.0" y="491.0"/>
-      <point x="159.0" y="515.0"/>
-      <point x="198.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="515.0"/>
-      <point x="253.0" y="496.0"/>
-      <point x="253.0" y="466.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="423.0"/>
-      <point x="231.0" y="398.0"/>
+      <point x="185" y="389" type="curve" smooth="yes"/>
+      <point x="149" y="389"/>
+      <point x="127" y="417"/>
+      <point x="127" y="448" type="curve" smooth="yes"/>
+      <point x="127" y="491"/>
+      <point x="156" y="524"/>
+      <point x="202" y="524" type="curve" smooth="yes"/>
+      <point x="238" y="524"/>
+      <point x="261" y="496"/>
+      <point x="261" y="466" type="curve" smooth="yes"/>
+      <point x="261" y="423"/>
+      <point x="231" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="422.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="228.0"/>
-      <point x="483.0" y="256.0"/>
-      <point x="483.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="483.0" y="323.0"/>
-      <point x="459.0" y="351.0"/>
-      <point x="420.0" y="351.0" type="curve" smooth="yes"/>
-      <point x="382.0" y="351.0"/>
-      <point x="359.0" y="324.0"/>
-      <point x="359.0" y="291.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="257.0"/>
-      <point x="383.0" y="228.0"/>
+      <point x="420" y="230" type="curve" smooth="yes"/>
+      <point x="466" y="230"/>
+      <point x="496" y="264"/>
+      <point x="496" y="307" type="curve" smooth="yes"/>
+      <point x="496" y="337"/>
+      <point x="473" y="365"/>
+      <point x="437" y="365" type="curve" smooth="yes"/>
+      <point x="391" y="365"/>
+      <point x="362" y="332"/>
+      <point x="362" y="289" type="curve" smooth="yes"/>
+      <point x="362" y="258"/>
+      <point x="384" y="230"/>
     </contour>
     <contour>
-      <point x="422.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="346.0" y="163.0"/>
-      <point x="284.0" y="216.0"/>
-      <point x="284.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="284.0" y="337.0"/>
-      <point x="300.0" y="373.0"/>
-      <point x="325.0" y="411.0" type="curve" smooth="yes"/>
-      <point x="358.0" y="459.0"/>
-      <point x="390.0" y="507.0"/>
-      <point x="423.0" y="553.0" type="curve"/>
-      <point x="510.0" y="545.0" type="line"/>
-      <point x="477.0" y="498.0"/>
-      <point x="443.0" y="450.0"/>
-      <point x="417.0" y="412.0" type="curve"/>
-      <point x="421.0" y="412.0"/>
-      <point x="427.0" y="413.0"/>
-      <point x="439.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="507.0" y="413.0"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="217.0"/>
-      <point x="494.0" y="163.0"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="294" y="213"/>
+      <point x="294" y="309" type="curve" smooth="yes"/>
+      <point x="294" y="355"/>
+      <point x="316" y="420"/>
+      <point x="367" y="475" type="curve" smooth="yes"/>
+      <point x="401" y="511"/>
+      <point x="448" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="526" y="514" type="line"/>
+      <point x="466" y="490"/>
+      <point x="393" y="440"/>
+      <point x="371" y="381" type="curve"/>
+      <point x="395" y="410"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="532" y="421"/>
+      <point x="564" y="372"/>
+      <point x="564" y="314" type="curve" smooth="yes"/>
+      <point x="564" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="189.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="330.0"/>
-      <point x="345.0" y="380.0"/>
-      <point x="345.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="345.0" y="493.0"/>
-      <point x="329.0" y="522.0"/>
-      <point x="305.0" y="534.0" type="curve"/>
-      <point x="348.0" y="557.0"/>
-      <point x="362.0" y="577.0"/>
-      <point x="362.0" y="627.0" type="curve" smooth="yes"/>
-      <point x="362.0" y="681.0"/>
-      <point x="315.0" y="724.0"/>
-      <point x="249.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="724.0"/>
-      <point x="120.0" y="686.0"/>
-      <point x="103.0" y="628.0" type="curve"/>
-      <point x="171.0" y="613.0" type="line"/>
-      <point x="183.0" y="642.0"/>
-      <point x="201.0" y="649.0"/>
-      <point x="225.0" y="649.0" type="curve" smooth="yes"/>
-      <point x="255.0" y="649.0"/>
-      <point x="268.0" y="629.0"/>
-      <point x="268.0" y="608.0" type="curve" smooth="yes"/>
-      <point x="268.0" y="589.0"/>
-      <point x="262.0" y="571.0"/>
-      <point x="212.0" y="571.0" type="curve" smooth="yes"/>
-      <point x="202.0" y="571.0"/>
-      <point x="193.0" y="571.0"/>
-      <point x="183.0" y="571.0" type="curve"/>
-      <point x="173.0" y="501.0" type="line"/>
-      <point x="179.0" y="501.0"/>
-      <point x="194.0" y="501.0"/>
-      <point x="204.0" y="501.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="501.0"/>
-      <point x="253.0" y="469.0"/>
-      <point x="253.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="426.0"/>
-      <point x="238.0" y="409.0"/>
-      <point x="201.0" y="409.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="409.0"/>
-      <point x="145.0" y="437.0"/>
-      <point x="141.0" y="462.0" type="curve"/>
-      <point x="62.0" y="443.0" type="line"/>
-      <point x="70.0" y="369.0"/>
-      <point x="128.0" y="330.0"/>
+      <point x="189" y="330" type="curve" smooth="yes"/>
+      <point x="275" y="330"/>
+      <point x="330" y="380"/>
+      <point x="330" y="459" type="curve" smooth="yes"/>
+      <point x="330" y="493"/>
+      <point x="314" y="522"/>
+      <point x="290" y="534" type="curve"/>
+      <point x="321" y="553"/>
+      <point x="347" y="577"/>
+      <point x="347" y="627" type="curve" smooth="yes"/>
+      <point x="347" y="681"/>
+      <point x="305" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="164" y="724"/>
+      <point x="120" y="686"/>
+      <point x="103" y="628" type="curve"/>
+      <point x="164" y="617" type="line"/>
+      <point x="175" y="645"/>
+      <point x="192" y="665"/>
+      <point x="229" y="665" type="curve" smooth="yes"/>
+      <point x="259" y="665"/>
+      <point x="280" y="646"/>
+      <point x="280" y="617" type="curve" smooth="yes"/>
+      <point x="280" y="583"/>
+      <point x="262" y="561"/>
+      <point x="212" y="561" type="curve" smooth="yes"/>
+      <point x="202" y="561.0"/>
+      <point x="193" y="561.0"/>
+      <point x="183" y="561" type="curve"/>
+      <point x="173" y="505" type="line"/>
+      <point x="179" y="505"/>
+      <point x="194" y="505.0"/>
+      <point x="204" y="505" type="curve" smooth="yes"/>
+      <point x="241" y="505"/>
+      <point x="263" y="479"/>
+      <point x="263" y="452" type="curve" smooth="yes"/>
+      <point x="263" y="415"/>
+      <point x="238" y="389"/>
+      <point x="194" y="389" type="curve" smooth="yes"/>
+      <point x="155" y="389"/>
+      <point x="133" y="416"/>
+      <point x="126" y="454" type="curve"/>
+      <point x="62" y="443" type="line"/>
+      <point x="70" y="369"/>
+      <point x="128" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="356.0" y="287.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="387.0" y="229.0"/>
-      <point x="420.0" y="229.0" type="curve" smooth="yes"/>
-      <point x="453.0" y="229.0"/>
-      <point x="477.0" y="248.0"/>
-      <point x="477.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="477.0" y="311.0"/>
-      <point x="461.0" y="331.0"/>
-      <point x="419.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="409.0" y="331.0"/>
-      <point x="398.0" y="331.0"/>
-      <point x="388.0" y="331.0" type="curve"/>
-      <point x="388.0" y="395.0" type="line"/>
-      <point x="395.0" y="395.0"/>
-      <point x="404.0" y="395.0"/>
-      <point x="411.0" y="395.0" type="curve"/>
-      <point x="442.0" y="395.0"/>
-      <point x="466.0" y="405.0"/>
-      <point x="466.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="466.0" y="466.0"/>
-      <point x="448.0" y="485.0"/>
-      <point x="418.0" y="485.0" type="curve" smooth="yes"/>
-      <point x="388.0" y="485.0"/>
-      <point x="370.0" y="464.0"/>
-      <point x="363.0" y="441.0" type="curve"/>
-      <point x="291.0" y="455.0" type="line"/>
-      <point x="301.0" y="510.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="287" y="201"/>
+      <point x="279" y="275" type="curve"/>
+      <point x="343" y="286" type="line"/>
+      <point x="350" y="248"/>
+      <point x="372" y="221"/>
+      <point x="411" y="221" type="curve" smooth="yes"/>
+      <point x="455" y="221"/>
+      <point x="480" y="247"/>
+      <point x="480" y="284" type="curve" smooth="yes"/>
+      <point x="480" y="311"/>
+      <point x="458" y="337"/>
+      <point x="421" y="337" type="curve" smooth="yes"/>
+      <point x="411" y="337"/>
+      <point x="396" y="337"/>
+      <point x="390" y="337" type="curve"/>
+      <point x="400" y="393" type="line"/>
+      <point x="410" y="393"/>
+      <point x="419" y="393"/>
+      <point x="429" y="393" type="curve" smooth="yes"/>
+      <point x="479" y="393"/>
+      <point x="497" y="415"/>
+      <point x="497" y="449" type="curve" smooth="yes"/>
+      <point x="497" y="478"/>
+      <point x="476" y="497"/>
+      <point x="446" y="497" type="curve" smooth="yes"/>
+      <point x="409" y="497"/>
+      <point x="392" y="477"/>
+      <point x="381" y="449" type="curve"/>
+      <point x="320" y="460" type="line"/>
+      <point x="337" y="518"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="564" y="513"/>
+      <point x="564" y="459" type="curve" smooth="yes"/>
+      <point x="564" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="547" y="325"/>
+      <point x="547" y="291" type="curve" smooth="yes"/>
+      <point x="547" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="49.0" y="338.0" type="line"/>
-      <point x="296.0" y="338.0" type="line"/>
-      <point x="311.0" y="417.0" type="line"/>
-      <point x="194.0" y="417.0" type="line"/>
-      <point x="244.0" y="450.0"/>
-      <point x="268.0" y="463.0"/>
-      <point x="302.0" y="501.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="536.0"/>
-      <point x="349.0" y="570.0"/>
-      <point x="349.0" y="618.0" type="curve" smooth="yes"/>
-      <point x="349.0" y="679.0"/>
-      <point x="311.0" y="724.0"/>
-      <point x="229.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="148.0" y="724.0"/>
-      <point x="98.0" y="683.0"/>
-      <point x="84.0" y="612.0" type="curve"/>
-      <point x="162.0" y="594.0" type="line"/>
-      <point x="169.0" y="627.0"/>
-      <point x="188.0" y="645.0"/>
-      <point x="212.0" y="645.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="645.0"/>
-      <point x="253.0" y="625.0"/>
-      <point x="253.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="591.0"/>
-      <point x="253.0" y="576.0"/>
-      <point x="229.0" y="549.0" type="curve" smooth="yes"/>
-      <point x="196.0" y="512.0"/>
-      <point x="154.0" y="476.0"/>
-      <point x="63.0" y="414.0" type="curve"/>
+      <point x="49" y="338" type="line"/>
+      <point x="296" y="338" type="line"/>
+      <point x="306" y="397" type="line"/>
+      <point x="157" y="397" type="line"/>
+      <point x="207" y="430"/>
+      <point x="253" y="463"/>
+      <point x="287" y="501" type="curve" smooth="yes"/>
+      <point x="319" y="536"/>
+      <point x="339" y="570"/>
+      <point x="339" y="618" type="curve" smooth="yes"/>
+      <point x="339" y="679"/>
+      <point x="302" y="724"/>
+      <point x="229" y="724" type="curve" smooth="yes"/>
+      <point x="148" y="724"/>
+      <point x="103" y="679"/>
+      <point x="89" y="608" type="curve"/>
+      <point x="153" y="597" type="line"/>
+      <point x="160" y="639"/>
+      <point x="188" y="665"/>
+      <point x="220" y="665" type="curve" smooth="yes"/>
+      <point x="253" y="665"/>
+      <point x="273" y="646"/>
+      <point x="273" y="615" type="curve" smooth="yes"/>
+      <point x="273" y="591"/>
+      <point x="263" y="566"/>
+      <point x="239" y="539" type="curve" smooth="yes"/>
+      <point x="206" y="502"/>
+      <point x="150" y="456"/>
+      <point x="59" y="394" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306.0" y="171.0" type="line"/>
-      <point x="308.0" y="242.0" type="line"/>
-      <point x="374.0" y="292.0"/>
-      <point x="419.0" y="331.0"/>
-      <point x="445.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="466.0" y="391.0"/>
-      <point x="474.0" y="411.0"/>
-      <point x="474.0" y="435.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="465.0"/>
-      <point x="452.0" y="481.0"/>
-      <point x="425.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="481.0"/>
-      <point x="377.0" y="458.0"/>
-      <point x="375.0" y="429.0" type="curve"/>
-      <point x="298.0" y="441.0" type="line"/>
-      <point x="304.0" y="512.0"/>
-      <point x="359.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="453.0" y="268.0"/>
-      <point x="419.0" y="243.0" type="curve"/>
-      <point x="564.0" y="243.0" type="line"/>
-      <point x="560.0" y="171.0" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="291" y="233" type="line"/>
+      <point x="382" y="295"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="505" y="430"/>
+      <point x="505" y="454" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="485" y="504"/>
+      <point x="452" y="504" type="curve" smooth="yes"/>
+      <point x="420" y="504"/>
+      <point x="392" y="478"/>
+      <point x="385" y="436" type="curve"/>
+      <point x="321" y="447" type="line"/>
+      <point x="335" y="518"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="534" y="563"/>
+      <point x="571" y="518"/>
+      <point x="571" y="457" type="curve" smooth="yes"/>
+      <point x="571" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="439" y="269"/>
+      <point x="389" y="236" type="curve"/>
+      <point x="538" y="236" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="238" type="curve" smooth="yes"/>
-      <point x="455" y="238"/>
-      <point x="478" y="258"/>
-      <point x="478" y="287" type="curve" smooth="yes"/>
-      <point x="478" y="316"/>
+      <point x="417" y="238" type="curve" smooth="yes"/>
+      <point x="453" y="238"/>
+      <point x="476" y="259"/>
+      <point x="476" y="293" type="curve" smooth="yes"/>
+      <point x="476" y="318"/>
       <point x="455" y="336"/>
-      <point x="426" y="336" type="curve" smooth="yes"/>
-      <point x="397" y="336"/>
-      <point x="374" y="316"/>
-      <point x="374" y="287" type="curve" smooth="yes"/>
-      <point x="374" y="258"/>
-      <point x="397" y="238"/>
+      <point x="429" y="336" type="curve" smooth="yes"/>
+      <point x="395" y="336"/>
+      <point x="370" y="315"/>
+      <point x="370" y="281" type="curve" smooth="yes"/>
+      <point x="370" y="257"/>
+      <point x="390" y="238"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="351" y="163"/>
-      <point x="286" y="205"/>
-      <point x="286" y="281" type="curve" smooth="yes"/>
-      <point x="286" y="323"/>
-      <point x="308" y="353"/>
-      <point x="338" y="372" type="curve"/>
-      <point x="313" y="388"/>
-      <point x="298" y="418"/>
-      <point x="298" y="446" type="curve" smooth="yes"/>
-      <point x="298" y="514"/>
-      <point x="357" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="495" y="557"/>
-      <point x="554" y="514"/>
-      <point x="554" y="446" type="curve" smooth="yes"/>
-      <point x="554" y="418"/>
-      <point x="539" y="388"/>
-      <point x="514" y="372" type="curve"/>
-      <point x="544" y="353"/>
-      <point x="566" y="323"/>
-      <point x="566" y="281" type="curve" smooth="yes"/>
-      <point x="566" y="204"/>
-      <point x="501" y="163"/>
+      <point x="410" y="163" type="curve" smooth="yes"/>
+      <point x="335" y="163"/>
+      <point x="280" y="211"/>
+      <point x="280" y="274" type="curve" smooth="yes"/>
+      <point x="280" y="327"/>
+      <point x="313" y="362"/>
+      <point x="353" y="379" type="curve"/>
+      <point x="337" y="394"/>
+      <point x="322" y="416"/>
+      <point x="322" y="442" type="curve" smooth="yes"/>
+      <point x="322" y="513"/>
+      <point x="380" y="557"/>
+      <point x="464" y="557" type="curve" smooth="yes"/>
+      <point x="532" y="557"/>
+      <point x="581" y="516"/>
+      <point x="581" y="459" type="curve" smooth="yes"/>
+      <point x="581" y="423"/>
+      <point x="558" y="390"/>
+      <point x="526" y="372" type="curve"/>
+      <point x="548" y="358"/>
+      <point x="564" y="331"/>
+      <point x="564" y="296" type="curve" smooth="yes"/>
+      <point x="564" y="212"/>
+      <point x="499" y="163"/>
     </contour>
     <contour>
-      <point x="426" y="404" type="curve" smooth="yes"/>
-      <point x="449" y="404"/>
-      <point x="468" y="420"/>
-      <point x="468" y="443" type="curve" smooth="yes"/>
-      <point x="468" y="465"/>
-      <point x="449" y="482"/>
-      <point x="426" y="482" type="curve" smooth="yes"/>
-      <point x="403" y="482"/>
-      <point x="384" y="467"/>
-      <point x="384" y="443" type="curve" smooth="yes"/>
-      <point x="384" y="419"/>
-      <point x="403" y="404"/>
+      <point x="446" y="404" type="curve" smooth="yes"/>
+      <point x="475" y="404"/>
+      <point x="494" y="420"/>
+      <point x="494" y="447" type="curve" smooth="yes"/>
+      <point x="494" y="468"/>
+      <point x="477" y="482"/>
+      <point x="457" y="482" type="curve" smooth="yes"/>
+      <point x="429" y="482"/>
+      <point x="408" y="468"/>
+      <point x="408" y="439" type="curve" smooth="yes"/>
+      <point x="408" y="420"/>
+      <point x="424" y="404"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -18,37 +18,37 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="358" y="163"/>
-      <point x="303" y="197"/>
-      <point x="288" y="268" type="curve"/>
-      <point x="369" y="285" type="line"/>
-      <point x="376" y="257"/>
-      <point x="397" y="240"/>
-      <point x="425" y="240" type="curve" smooth="yes"/>
-      <point x="459" y="240"/>
-      <point x="479" y="262"/>
-      <point x="479" y="296" type="curve" smooth="yes"/>
-      <point x="479" y="331"/>
-      <point x="458" y="352"/>
-      <point x="426" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="352"/>
-      <point x="383" y="339"/>
-      <point x="374" y="323" type="curve"/>
-      <point x="301" y="355" type="line"/>
-      <point x="324" y="548" type="line"/>
-      <point x="547" y="548" type="line"/>
-      <point x="547" y="476" type="line"/>
-      <point x="391" y="476" type="line"/>
-      <point x="380" y="406" type="line"/>
-      <point x="398" y="418"/>
-      <point x="417" y="423"/>
-      <point x="442" y="423" type="curve" smooth="yes"/>
-      <point x="512" y="423"/>
-      <point x="566" y="376"/>
-      <point x="566" y="294" type="curve" smooth="yes"/>
-      <point x="566" y="214"/>
-      <point x="505" y="163"/>
+      <point x="405" y="161" type="curve" smooth="yes"/>
+      <point x="338" y="161"/>
+      <point x="286" y="199"/>
+      <point x="272" y="266" type="curve"/>
+      <point x="358" y="283" type="line"/>
+      <point x="365" y="255"/>
+      <point x="388" y="238"/>
+      <point x="413" y="238" type="curve" smooth="yes"/>
+      <point x="447" y="238"/>
+      <point x="469" y="262"/>
+      <point x="469" y="302" type="curve" smooth="yes"/>
+      <point x="469" y="331"/>
+      <point x="450" y="350"/>
+      <point x="422" y="350" type="curve" smooth="yes"/>
+      <point x="399" y="350"/>
+      <point x="379" y="337"/>
+      <point x="367" y="321" type="curve"/>
+      <point x="300" y="353" type="line"/>
+      <point x="353" y="546" type="line"/>
+      <point x="580" y="546" type="line"/>
+      <point x="567" y="474" type="line"/>
+      <point x="411" y="474" type="line"/>
+      <point x="391" y="404" type="line"/>
+      <point x="406" y="415"/>
+      <point x="428" y="421"/>
+      <point x="453" y="421" type="curve" smooth="yes"/>
+      <point x="514" y="421"/>
+      <point x="557" y="373"/>
+      <point x="557" y="309" type="curve" smooth="yes"/>
+      <point x="557" y="212"/>
+      <point x="489" y="161"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="342" y="310" type="line"/>
-      <point x="427" y="310" type="line"/>
-      <point x="427" y="425" type="line"/>
-      <point x="419" y="425" type="line"/>
+      <point x="353" y="308" type="line"/>
+      <point x="434" y="308" type="line"/>
+      <point x="454" y="423" type="line"/>
+      <point x="446" y="423" type="line"/>
     </contour>
     <contour>
-      <point x="427" y="171" type="line"/>
-      <point x="427" y="236" type="line"/>
-      <point x="252" y="236" type="line"/>
-      <point x="252" y="300" type="line"/>
-      <point x="423" y="549" type="line"/>
-      <point x="513" y="549" type="line"/>
-      <point x="513" y="310" type="line"/>
-      <point x="565" y="310" type="line"/>
-      <point x="565" y="236" type="line"/>
-      <point x="513" y="236" type="line"/>
-      <point x="513" y="171" type="line"/>
+      <point x="410" y="169" type="line"/>
+      <point x="421" y="234" type="line"/>
+      <point x="246" y="234" type="line"/>
+      <point x="257" y="298" type="line"/>
+      <point x="467" y="547" type="line"/>
+      <point x="562" y="547" type="line"/>
+      <point x="520" y="308" type="line"/>
+      <point x="572" y="308" type="line"/>
+      <point x="559" y="234" type="line"/>
+      <point x="507" y="234" type="line"/>
+      <point x="496" y="169" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="171" type="curve"/>
-      <point x="316" y="171" type="line"/>
-      <point x="350" y="214"/>
-      <point x="384" y="257"/>
-      <point x="418" y="300" type="curve"/>
-      <point x="413" y="297"/>
-      <point x="405" y="296"/>
-      <point x="396" y="296" type="curve" smooth="yes"/>
-      <point x="334" y="296"/>
-      <point x="280" y="353"/>
-      <point x="280" y="424" type="curve" smooth="yes"/>
-      <point x="280" y="496"/>
-      <point x="338" y="557"/>
-      <point x="423" y="557" type="curve" smooth="yes"/>
-      <point x="510" y="557"/>
-      <point x="566" y="497"/>
-      <point x="566" y="422" type="curve" smooth="yes"/>
-      <point x="566" y="377"/>
-      <point x="548" y="344"/>
-      <point x="520" y="305" type="curve"/>
-      <point x="487" y="260"/>
-      <point x="454" y="216"/>
+      <point x="367" y="161" type="curve"/>
+      <point x="346" y="229" type="line"/>
+      <point x="403" y="244"/>
+      <point x="466" y="278"/>
+      <point x="493" y="321" type="curve"/>
+      <point x="469" y="301"/>
+      <point x="440" y="292"/>
+      <point x="413" y="292" type="curve" smooth="yes"/>
+      <point x="351" y="292"/>
+      <point x="305" y="342"/>
+      <point x="305" y="401" type="curve" smooth="yes"/>
+      <point x="305" y="486"/>
+      <point x="366" y="553"/>
+      <point x="464" y="553" type="curve" smooth="yes"/>
+      <point x="543" y="553"/>
+      <point x="594" y="505"/>
+      <point x="594" y="417" type="curve" smooth="yes"/>
+      <point x="594" y="355"/>
+      <point x="573" y="298"/>
+      <point x="531" y="252" type="curve" smooth="yes"/>
+      <point x="493" y="211"/>
+      <point x="438" y="179"/>
     </contour>
     <contour>
-      <point x="424" y="367" type="curve" smooth="yes"/>
-      <point x="456" y="367"/>
-      <point x="479" y="390"/>
-      <point x="479" y="424" type="curve" smooth="yes"/>
-      <point x="479" y="458"/>
-      <point x="456" y="481"/>
-      <point x="424" y="481" type="curve" smooth="yes"/>
-      <point x="392" y="481"/>
-      <point x="368" y="458"/>
-      <point x="368" y="424" type="curve" smooth="yes"/>
-      <point x="368" y="390"/>
-      <point x="392" y="367"/>
+      <point x="444" y="363" type="curve" smooth="yes"/>
+      <point x="480" y="363"/>
+      <point x="507" y="387"/>
+      <point x="507" y="428" type="curve" smooth="yes"/>
+      <point x="507" y="457"/>
+      <point x="485" y="477"/>
+      <point x="457" y="477" type="curve" smooth="yes"/>
+      <point x="419" y="477"/>
+      <point x="394" y="452"/>
+      <point x="394" y="413" type="curve" smooth="yes"/>
+      <point x="394" y="382"/>
+      <point x="416" y="363"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="394" y="171" type="line"/>
-      <point x="394" y="430" type="line"/>
-      <point x="302" y="363" type="line"/>
-      <point x="302" y="473" type="line"/>
-      <point x="402" y="549" type="line"/>
-      <point x="483" y="549" type="line"/>
-      <point x="483" y="171" type="line"/>
+      <point x="372" y="169" type="line"/>
+      <point x="416" y="423" type="line"/>
+      <point x="313" y="356" type="line"/>
+      <point x="333" y="471" type="line"/>
+      <point x="446" y="547" type="line"/>
+      <point x="527" y="547" type="line"/>
+      <point x="461" y="169" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="451" y="171" type="curve"/>
-      <point x="356" y="171" type="line"/>
-      <point x="356" y="298"/>
-      <point x="403" y="395"/>
-      <point x="469" y="468" type="curve"/>
-      <point x="304" y="468" type="line"/>
-      <point x="304" y="549" type="line"/>
-      <point x="565" y="549" type="line"/>
-      <point x="565" y="472" type="line"/>
-      <point x="486" y="382"/>
-      <point x="451" y="274"/>
+      <point x="417" y="164" type="curve"/>
+      <point x="322" y="164" type="line"/>
+      <point x="339" y="296"/>
+      <point x="414" y="402"/>
+      <point x="487" y="461" type="curve"/>
+      <point x="322" y="461" type="line"/>
+      <point x="336" y="542" type="line"/>
+      <point x="597" y="542" type="line"/>
+      <point x="584" y="465" type="line"/>
+      <point x="486" y="375"/>
+      <point x="432" y="276"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="239" type="curve" smooth="yes"/>
-      <point x="453" y="239"/>
-      <point x="477" y="262"/>
-      <point x="477" y="296" type="curve" smooth="yes"/>
-      <point x="477" y="330"/>
-      <point x="453" y="353"/>
-      <point x="421" y="353" type="curve" smooth="yes"/>
-      <point x="389" y="353"/>
-      <point x="366" y="330"/>
-      <point x="366" y="296" type="curve" smooth="yes"/>
-      <point x="366" y="262"/>
-      <point x="389" y="239"/>
+      <point x="427" y="242" type="curve" smooth="yes"/>
+      <point x="465" y="242"/>
+      <point x="490" y="267"/>
+      <point x="490" y="306" type="curve" smooth="yes"/>
+      <point x="490" y="337"/>
+      <point x="468" y="356"/>
+      <point x="440" y="356" type="curve" smooth="yes"/>
+      <point x="404" y="356"/>
+      <point x="377" y="332"/>
+      <point x="377" y="291" type="curve" smooth="yes"/>
+      <point x="377" y="262"/>
+      <point x="399" y="242"/>
     </contour>
     <contour>
-      <point x="422" y="163" type="curve" smooth="yes"/>
-      <point x="335" y="163"/>
-      <point x="279" y="223"/>
-      <point x="279" y="298" type="curve" smooth="yes"/>
-      <point x="279" y="343"/>
-      <point x="297" y="376"/>
-      <point x="325" y="415" type="curve"/>
-      <point x="358" y="460"/>
-      <point x="391" y="504"/>
-      <point x="424" y="549" type="curve"/>
-      <point x="529" y="549" type="line"/>
-      <point x="495" y="507"/>
-      <point x="461" y="464"/>
-      <point x="427" y="420" type="curve"/>
-      <point x="432" y="423"/>
-      <point x="440" y="424"/>
-      <point x="449" y="424" type="curve" smooth="yes"/>
-      <point x="511" y="424"/>
-      <point x="565" y="367"/>
-      <point x="565" y="296" type="curve" smooth="yes"/>
-      <point x="565" y="224"/>
-      <point x="507" y="163"/>
+      <point x="420" y="166" type="curve" smooth="yes"/>
+      <point x="341" y="166"/>
+      <point x="290" y="214"/>
+      <point x="290" y="302" type="curve" smooth="yes"/>
+      <point x="290" y="364"/>
+      <point x="311" y="421"/>
+      <point x="353" y="467" type="curve" smooth="yes"/>
+      <point x="391" y="508"/>
+      <point x="446" y="540"/>
+      <point x="517" y="558" type="curve"/>
+      <point x="538" y="490" type="line"/>
+      <point x="481" y="475"/>
+      <point x="418" y="441"/>
+      <point x="391" y="398" type="curve"/>
+      <point x="415" y="418"/>
+      <point x="451" y="427"/>
+      <point x="478" y="427" type="curve" smooth="yes"/>
+      <point x="544" y="427"/>
+      <point x="579" y="377"/>
+      <point x="579" y="318" type="curve" smooth="yes"/>
+      <point x="579" y="233"/>
+      <point x="518" y="166"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,51 +18,51 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="162" type="curve" smooth="yes"/>
-      <point x="348" y="162"/>
-      <point x="291" y="202"/>
-      <point x="278" y="280" type="curve"/>
-      <point x="365" y="297" type="line"/>
-      <point x="370" y="258"/>
-      <point x="394" y="239"/>
-      <point x="426" y="239" type="curve" smooth="yes"/>
-      <point x="458" y="239"/>
-      <point x="478" y="255"/>
-      <point x="478" y="286" type="curve" smooth="yes"/>
-      <point x="478" y="315"/>
-      <point x="453" y="331"/>
-      <point x="418" y="331" type="curve"/>
-      <point x="407" y="331.0"/>
-      <point x="397" y="331.0"/>
-      <point x="386" y="331" type="curve"/>
-      <point x="386" y="401" type="line"/>
-      <point x="396" y="401.0"/>
-      <point x="407" y="401.0"/>
-      <point x="417" y="401" type="curve" smooth="yes"/>
-      <point x="449" y="401"/>
-      <point x="468" y="415"/>
-      <point x="468" y="440" type="curve" smooth="yes"/>
-      <point x="468" y="465"/>
-      <point x="449" y="479"/>
-      <point x="422" y="479" type="curve" smooth="yes"/>
-      <point x="398" y="479"/>
-      <point x="378" y="465"/>
-      <point x="371" y="442" type="curve"/>
-      <point x="288" y="456" type="line"/>
-      <point x="300" y="514"/>
-      <point x="348" y="556"/>
-      <point x="424" y="556" type="curve" smooth="yes"/>
-      <point x="508" y="556"/>
-      <point x="555" y="511"/>
-      <point x="555" y="451" type="curve" smooth="yes"/>
-      <point x="555" y="414"/>
-      <point x="532" y="385"/>
-      <point x="508" y="371" type="curve"/>
-      <point x="538" y="359"/>
-      <point x="567" y="328"/>
-      <point x="567" y="283" type="curve" smooth="yes"/>
-      <point x="567" y="212"/>
-      <point x="507" y="162"/>
+      <point x="408" y="158" type="curve" smooth="yes"/>
+      <point x="341" y="158"/>
+      <point x="281" y="198"/>
+      <point x="271" y="276" type="curve"/>
+      <point x="355" y="293" type="line"/>
+      <point x="359" y="257"/>
+      <point x="380" y="235"/>
+      <point x="412" y="235" type="curve" smooth="yes"/>
+      <point x="446" y="235"/>
+      <point x="472" y="255"/>
+      <point x="472" y="284" type="curve" smooth="yes"/>
+      <point x="472" y="311"/>
+      <point x="453" y="327"/>
+      <point x="420" y="327" type="curve"/>
+      <point x="409" y="327"/>
+      <point x="399" y="327"/>
+      <point x="388" y="327" type="curve"/>
+      <point x="400" y="397" type="line"/>
+      <point x="410" y="397"/>
+      <point x="421" y="397"/>
+      <point x="431" y="397" type="curve" smooth="yes"/>
+      <point x="467" y="397"/>
+      <point x="488" y="411"/>
+      <point x="488" y="439" type="curve" smooth="yes"/>
+      <point x="488" y="460"/>
+      <point x="471" y="475"/>
+      <point x="445" y="475" type="curve" smooth="yes"/>
+      <point x="418" y="475"/>
+      <point x="398" y="463"/>
+      <point x="390" y="438" type="curve"/>
+      <point x="312" y="452" type="line"/>
+      <point x="327" y="517"/>
+      <point x="380" y="552"/>
+      <point x="458" y="552" type="curve" smooth="yes"/>
+      <point x="538" y="552"/>
+      <point x="578" y="505"/>
+      <point x="578" y="449" type="curve" smooth="yes"/>
+      <point x="578" y="407"/>
+      <point x="552" y="380"/>
+      <point x="517" y="367" type="curve"/>
+      <point x="542" y="356"/>
+      <point x="563" y="327"/>
+      <point x="563" y="293" type="curve" smooth="yes"/>
+      <point x="563" y="214"/>
+      <point x="510" y="158"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -18,35 +18,35 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="297" y="171" type="line"/>
-      <point x="297" y="234" type="line"/>
-      <point x="361" y="280"/>
-      <point x="402" y="315"/>
-      <point x="428" y="344" type="curve" smooth="yes"/>
-      <point x="457" y="377"/>
-      <point x="466" y="404"/>
-      <point x="466" y="433" type="curve" smooth="yes"/>
-      <point x="466" y="461"/>
-      <point x="449" y="478"/>
-      <point x="423" y="478" type="curve" smooth="yes"/>
-      <point x="397" y="478"/>
-      <point x="380" y="459"/>
-      <point x="376" y="428" type="curve"/>
-      <point x="291" y="443" type="line"/>
-      <point x="300" y="514"/>
-      <point x="350" y="557"/>
-      <point x="423" y="557" type="curve" smooth="yes"/>
-      <point x="506" y="557"/>
-      <point x="556" y="514"/>
-      <point x="556" y="433" type="curve" smooth="yes"/>
-      <point x="556" y="388"/>
-      <point x="537" y="351"/>
-      <point x="511" y="319" type="curve" smooth="yes"/>
-      <point x="489" y="292"/>
-      <point x="460" y="269"/>
-      <point x="433" y="250" type="curve"/>
-      <point x="558" y="250" type="line"/>
-      <point x="558" y="171" type="line"/>
+      <point x="279" y="170" type="line"/>
+      <point x="290" y="233" type="line"/>
+      <point x="376" y="292"/>
+      <point x="431" y="335"/>
+      <point x="462" y="370" type="curve" smooth="yes"/>
+      <point x="485" y="395"/>
+      <point x="495" y="417"/>
+      <point x="495" y="438" type="curve" smooth="yes"/>
+      <point x="495" y="462"/>
+      <point x="482" y="477"/>
+      <point x="456" y="477" type="curve" smooth="yes"/>
+      <point x="430" y="477"/>
+      <point x="408" y="461"/>
+      <point x="400" y="427" type="curve"/>
+      <point x="318" y="442" type="line"/>
+      <point x="334" y="518"/>
+      <point x="387" y="556"/>
+      <point x="466" y="556" type="curve" smooth="yes"/>
+      <point x="543" y="556"/>
+      <point x="585" y="511"/>
+      <point x="585" y="446" type="curve" smooth="yes"/>
+      <point x="585" y="400"/>
+      <point x="564" y="363"/>
+      <point x="531" y="328" type="curve" smooth="yes"/>
+      <point x="505" y="301"/>
+      <point x="472" y="275"/>
+      <point x="437" y="249" type="curve"/>
+      <point x="554" y="249" type="line"/>
+      <point x="540" y="170" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -17,18 +17,18 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="437" y="28" type="curve" smooth="yes"/>
-      <point x="257" y="28"/>
-      <point x="107" y="178"/>
-      <point x="107" y="358" type="curve" smooth="yes"/>
-      <point x="107" y="541"/>
-      <point x="257" y="688"/>
-      <point x="437" y="688" type="curve" smooth="yes"/>
-      <point x="621" y="688"/>
-      <point x="767" y="541"/>
-      <point x="767" y="358" type="curve" smooth="yes"/>
-      <point x="767" y="178"/>
-      <point x="621" y="28"/>
+      <point x="437" y="44" type="curve" smooth="yes"/>
+      <point x="266" y="44"/>
+      <point x="123" y="187"/>
+      <point x="123" y="358" type="curve" smooth="yes"/>
+      <point x="123" y="532"/>
+      <point x="266" y="672"/>
+      <point x="437" y="672" type="curve" smooth="yes"/>
+      <point x="612" y="672"/>
+      <point x="751" y="532"/>
+      <point x="751" y="358" type="curve" smooth="yes"/>
+      <point x="751" y="187"/>
+      <point x="612" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -5,12 +5,12 @@
     <contour>
       <point x="178" y="342" type="curve" smooth="yes"/>
       <point x="260" y="342"/>
-      <point x="324" y="390"/>
-      <point x="324" y="467" type="curve" smooth="yes"/>
-      <point x="324" y="499"/>
-      <point x="301" y="529"/>
-      <point x="268" y="543" type="curve"/>
-      <point x="303" y="554"/>
+      <point x="327" y="390"/>
+      <point x="327" y="467" type="curve" smooth="yes"/>
+      <point x="327" y="499"/>
+      <point x="313" y="526"/>
+      <point x="288" y="543" type="curve"/>
+      <point x="320" y="561"/>
       <point x="344" y="594"/>
       <point x="344" y="633" type="curve" smooth="yes"/>
       <point x="344" y="689"/>
@@ -20,41 +20,41 @@
       <point x="100" y="671"/>
       <point x="100" y="608" type="curve" smooth="yes"/>
       <point x="100" y="578"/>
-      <point x="128" y="554"/>
-      <point x="151" y="545" type="curve"/>
-      <point x="106" y="532"/>
-      <point x="62" y="492"/>
-      <point x="62" y="447" type="curve" smooth="yes"/>
-      <point x="62" y="387"/>
+      <point x="119" y="555"/>
+      <point x="133" y="545" type="curve"/>
+      <point x="92" y="528"/>
+      <point x="59" y="492"/>
+      <point x="59" y="447" type="curve" smooth="yes"/>
+      <point x="59" y="387"/>
       <point x="107" y="342"/>
     </contour>
     <contour>
-      <point x="189" y="389" type="curve" smooth="yes"/>
-      <point x="143" y="389"/>
-      <point x="114" y="410"/>
-      <point x="114" y="451" type="curve" smooth="yes"/>
-      <point x="114" y="498"/>
-      <point x="150" y="520"/>
-      <point x="198" y="520" type="curve" smooth="yes"/>
-      <point x="247" y="520"/>
-      <point x="273" y="501"/>
-      <point x="273" y="462" type="curve" smooth="yes"/>
-      <point x="273" y="412"/>
-      <point x="238" y="389"/>
+      <point x="189" y="401" type="curve" smooth="yes"/>
+      <point x="153" y="401"/>
+      <point x="126" y="420"/>
+      <point x="126" y="451" type="curve" smooth="yes"/>
+      <point x="126" y="489"/>
+      <point x="160" y="514"/>
+      <point x="198" y="514" type="curve" smooth="yes"/>
+      <point x="237" y="514"/>
+      <point x="261" y="492"/>
+      <point x="261" y="462" type="curve" smooth="yes"/>
+      <point x="261" y="422"/>
+      <point x="228" y="401"/>
     </contour>
     <contour>
-      <point x="214" y="564" type="curve" smooth="yes"/>
-      <point x="178" y="564"/>
-      <point x="157" y="581"/>
-      <point x="157" y="614" type="curve" smooth="yes"/>
-      <point x="157" y="656"/>
-      <point x="185" y="675"/>
-      <point x="227" y="675" type="curve" smooth="yes"/>
-      <point x="262" y="675"/>
-      <point x="287" y="658"/>
-      <point x="287" y="626" type="curve" smooth="yes"/>
-      <point x="287" y="586"/>
-      <point x="257" y="564"/>
+      <point x="214" y="568" type="curve" smooth="yes"/>
+      <point x="188" y="568"/>
+      <point x="167" y="584"/>
+      <point x="167" y="610" type="curve" smooth="yes"/>
+      <point x="167" y="642"/>
+      <point x="195" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="256" y="665"/>
+      <point x="277" y="647"/>
+      <point x="277" y="623" type="curve" smooth="yes"/>
+      <point x="277" y="587"/>
+      <point x="247" y="568"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -5,32 +5,32 @@
     <contour>
       <point x="177" y="343" type="curve" smooth="yes"/>
       <point x="261" y="343"/>
-      <point x="324" y="400"/>
-      <point x="324" y="485" type="curve" smooth="yes"/>
-      <point x="324" y="555"/>
-      <point x="280" y="595"/>
+      <point x="329" y="400"/>
+      <point x="329" y="485" type="curve" smooth="yes"/>
+      <point x="329" y="555"/>
+      <point x="285" y="595"/>
       <point x="224" y="595" type="curve" smooth="yes"/>
-      <point x="192" y="595"/>
-      <point x="161" y="580"/>
-      <point x="148" y="567" type="curve"/>
-      <point x="178" y="665" type="line"/>
-      <point x="340" y="665" type="line"/>
+      <point x="200" y="595"/>
+      <point x="175" y="587"/>
+      <point x="159" y="574" type="curve"/>
+      <point x="187" y="660" type="line"/>
+      <point x="339" y="660" type="line"/>
       <point x="348" y="716" type="line"/>
-      <point x="146" y="716" type="line"/>
-      <point x="88" y="527" type="line"/>
-      <point x="132" y="505" type="line"/>
-      <point x="146" y="530.0"/>
-      <point x="171" y="549"/>
-      <point x="208" y="549" type="curve" smooth="yes"/>
-      <point x="245" y="549"/>
-      <point x="271" y="527"/>
-      <point x="271.0" y="474" type="curve" smooth="yes"/>
-      <point x="271" y="422"/>
-      <point x="234" y="390"/>
-      <point x="183" y="390" type="curve" smooth="yes"/>
-      <point x="147" y="390"/>
-      <point x="113" y="405"/>
-      <point x="104" y="451" type="curve"/>
+      <point x="141" y="716" type="line"/>
+      <point x="83" y="527" type="line"/>
+      <point x="136" y="504" type="line"/>
+      <point x="154" y="528"/>
+      <point x="175" y="539"/>
+      <point x="203" y="539" type="curve" smooth="yes"/>
+      <point x="236" y="539"/>
+      <point x="261" y="517"/>
+      <point x="261" y="480" type="curve" smooth="yes"/>
+      <point x="261" y="437"/>
+      <point x="224" y="402"/>
+      <point x="183" y="402" type="curve" smooth="yes"/>
+      <point x="147" y="402"/>
+      <point x="125" y="423"/>
+      <point x="118" y="456" type="curve"/>
       <point x="56" y="434" type="line"/>
       <point x="66" y="369"/>
       <point x="124" y="343"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,15 +3,15 @@
   <advance width="342"/>
   <outline>
     <contour>
-      <point x="60" y="434" type="line"/>
-      <point x="345" y="434" type="line"/>
-      <point x="352" y="476" type="line"/>
-      <point x="128" y="476" type="line"/>
-      <point x="263" y="629" type="line"/>
-      <point x="269" y="629" type="line"/>
-      <point x="218" y="350" type="line"/>
-      <point x="271" y="350" type="line"/>
-      <point x="336" y="716" type="line"/>
+      <point x="58" y="424" type="line"/>
+      <point x="343" y="424" type="line"/>
+      <point x="353" y="480" type="line"/>
+      <point x="141" y="480" type="line"/>
+      <point x="258" y="612" type="line"/>
+      <point x="262" y="612" type="line"/>
+      <point x="216" y="350" type="line"/>
+      <point x="281" y="350" type="line"/>
+      <point x="346" y="716" type="line"/>
       <point x="285" y="716" type="line"/>
       <point x="65" y="468" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -5,40 +5,40 @@
     <contour>
       <point x="151" y="334" type="line"/>
       <point x="196" y="383"/>
-      <point x="243" y="432"/>
-      <point x="287" y="482" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="346" y="564"/>
-      <point x="346" y="614" type="curve" smooth="yes"/>
-      <point x="346" y="673"/>
+      <point x="241" y="432"/>
+      <point x="286" y="481" type="curve" smooth="yes"/>
+      <point x="335" y="534"/>
+      <point x="351" y="564"/>
+      <point x="351" y="614" type="curve" smooth="yes"/>
+      <point x="351" y="673"/>
       <point x="302" y="724"/>
       <point x="235" y="724" type="curve" smooth="yes"/>
       <point x="152" y="724"/>
-      <point x="88" y="664"/>
-      <point x="88" y="579" type="curve" smooth="yes"/>
-      <point x="88" y="525"/>
-      <point x="130" y="479"/>
-      <point x="193" y="479" type="curve" smooth="yes"/>
-      <point x="201" y="479"/>
-      <point x="228" y="483"/>
-      <point x="234" y="487" type="curve"/>
-      <point x="199" y="450"/>
-      <point x="150" y="401"/>
-      <point x="115" y="364" type="curve"/>
+      <point x="83" y="664"/>
+      <point x="83" y="579" type="curve" smooth="yes"/>
+      <point x="83" y="525"/>
+      <point x="123" y="474"/>
+      <point x="186" y="474" type="curve" smooth="yes"/>
+      <point x="194" y="474"/>
+      <point x="205" y="476"/>
+      <point x="212" y="480" type="curve"/>
+      <point x="177" y="443"/>
+      <point x="142" y="407"/>
+      <point x="107" y="370" type="curve"/>
     </contour>
     <contour>
-      <point x="208" y="520" type="curve" smooth="yes"/>
-      <point x="161" y="520"/>
-      <point x="141" y="546"/>
-      <point x="141" y="591" type="curve" smooth="yes"/>
-      <point x="141" y="641"/>
-      <point x="178" y="675"/>
-      <point x="226" y="675" type="curve" smooth="yes"/>
-      <point x="273" y="675"/>
-      <point x="295" y="650"/>
-      <point x="295" y="607" type="curve" smooth="yes"/>
-      <point x="295" y="556"/>
-      <point x="263" y="520"/>
+      <point x="208" y="530" type="curve" smooth="yes"/>
+      <point x="171" y="530"/>
+      <point x="151" y="556"/>
+      <point x="151" y="591" type="curve" smooth="yes"/>
+      <point x="151" y="631"/>
+      <point x="188" y="665"/>
+      <point x="226" y="665" type="curve" smooth="yes"/>
+      <point x="263" y="665"/>
+      <point x="285" y="640"/>
+      <point x="285" y="607" type="curve" smooth="yes"/>
+      <point x="285" y="566"/>
+      <point x="253" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -4,12 +4,12 @@
   <outline>
     <contour>
       <point x="135" y="350" type="line"/>
-      <point x="192" y="350" type="line"/>
-      <point x="257" y="716" type="line"/>
+      <point x="200" y="350" type="line"/>
+      <point x="265" y="716" type="line"/>
       <point x="209" y="716" type="line"/>
       <point x="97" y="637" type="line"/>
-      <point x="123" y="596" type="line"/>
-      <point x="187" y="640" type="line"/>
+      <point x="128" y="588" type="line"/>
+      <point x="184" y="629" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -9,11 +9,11 @@
       <point x="343" y="661" type="curve"/>
       <point x="353" y="716" type="line"/>
       <point x="105" y="716" type="line"/>
-      <point x="97" y="667" type="line"/>
-      <point x="288" y="667" type="line"/>
-      <point x="219" y="571"/>
-      <point x="140" y="460"/>
-      <point x="70" y="364" type="curve"/>
+      <point x="95" y="657" type="line"/>
+      <point x="270" y="657" type="line"/>
+      <point x="201" y="561"/>
+      <point x="131" y="465"/>
+      <point x="62" y="369" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -5,40 +5,40 @@
     <contour>
       <point x="177" y="342" type="curve" smooth="yes"/>
       <point x="260" y="342"/>
-      <point x="324" y="402"/>
-      <point x="324" y="487" type="curve" smooth="yes"/>
-      <point x="324" y="541"/>
-      <point x="282" y="587"/>
-      <point x="219" y="587" type="curve" smooth="yes"/>
-      <point x="211" y="587"/>
-      <point x="184" y="583"/>
-      <point x="178" y="579" type="curve"/>
-      <point x="213" y="616"/>
-      <point x="262" y="665"/>
-      <point x="297" y="702" type="curve"/>
+      <point x="329" y="402"/>
+      <point x="329" y="487" type="curve" smooth="yes"/>
+      <point x="329" y="541"/>
+      <point x="289" y="592"/>
+      <point x="226" y="592" type="curve" smooth="yes"/>
+      <point x="218" y="592"/>
+      <point x="207" y="590"/>
+      <point x="201" y="586" type="curve"/>
+      <point x="236" y="623"/>
+      <point x="270" y="659"/>
+      <point x="305" y="696" type="curve"/>
       <point x="261" y="732" type="line"/>
       <point x="216" y="683"/>
-      <point x="169" y="634"/>
+      <point x="170" y="633"/>
       <point x="125" y="584" type="curve" smooth="yes"/>
-      <point x="79" y="532"/>
-      <point x="66" y="502"/>
-      <point x="66" y="452" type="curve" smooth="yes"/>
-      <point x="66" y="393"/>
+      <point x="78" y="533"/>
+      <point x="61" y="502"/>
+      <point x="61" y="452" type="curve" smooth="yes"/>
+      <point x="61" y="393"/>
       <point x="110" y="342"/>
     </contour>
     <contour>
-      <point x="186" y="391" type="curve" smooth="yes"/>
-      <point x="139" y="391"/>
-      <point x="117" y="416"/>
-      <point x="117" y="459" type="curve" smooth="yes"/>
-      <point x="117" y="510"/>
-      <point x="149" y="546"/>
-      <point x="204" y="546" type="curve" smooth="yes"/>
-      <point x="251" y="546"/>
-      <point x="271" y="520"/>
-      <point x="271" y="475" type="curve" smooth="yes"/>
-      <point x="271" y="425"/>
-      <point x="234" y="391"/>
+      <point x="186" y="401" type="curve" smooth="yes"/>
+      <point x="149" y="401"/>
+      <point x="127" y="426"/>
+      <point x="127" y="459" type="curve" smooth="yes"/>
+      <point x="127" y="500"/>
+      <point x="159" y="536"/>
+      <point x="204" y="536" type="curve" smooth="yes"/>
+      <point x="241" y="536"/>
+      <point x="261" y="510"/>
+      <point x="261" y="475" type="curve" smooth="yes"/>
+      <point x="261" y="435"/>
+      <point x="224" y="401"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,48 +3,48 @@
   <advance width="321"/>
   <outline>
     <contour>
-      <point x="189" y="342.0" type="curve" smooth="yes"/>
-      <point x="260" y="342"/>
-      <point x="321" y="394"/>
-      <point x="321" y="464" type="curve" smooth="yes"/>
-      <point x="321" y="501"/>
-      <point x="297" y="528"/>
-      <point x="268" y="542" type="curve"/>
-      <point x="305" y="555"/>
-      <point x="339" y="592"/>
-      <point x="339" y="633" type="curve" smooth="yes"/>
-      <point x="339" y="685"/>
+      <point x="180" y="342" type="curve" smooth="yes"/>
+      <point x="263" y="342"/>
+      <point x="325" y="394"/>
+      <point x="325" y="464" type="curve" smooth="yes"/>
+      <point x="325" y="501"/>
+      <point x="304" y="528"/>
+      <point x="275" y="542" type="curve"/>
+      <point x="309" y="555"/>
+      <point x="342" y="592"/>
+      <point x="342" y="633" type="curve" smooth="yes"/>
+      <point x="342" y="685"/>
       <point x="298" y="724"/>
       <point x="234" y="724" type="curve" smooth="yes"/>
       <point x="172" y="724"/>
       <point x="123" y="691"/>
       <point x="105" y="643" type="curve"/>
-      <point x="151" y="624" type="line"/>
-      <point x="162" y="644"/>
-      <point x="185" y="676"/>
-      <point x="226" y="676" type="curve" smooth="yes"/>
-      <point x="264" y="676"/>
-      <point x="285" y="657"/>
-      <point x="285" y="623" type="curve" smooth="yes"/>
-      <point x="285" y="591"/>
-      <point x="252" y="564"/>
-      <point x="208" y="564" type="curve" smooth="yes"/>
-      <point x="196" y="564"/>
-      <point x="184" y="564.0"/>
-      <point x="172" y="564" type="curve"/>
-      <point x="164" y="518" type="line"/>
-      <point x="175" y="518.0"/>
-      <point x="185" y="518"/>
-      <point x="196" y="518" type="curve" smooth="yes"/>
-      <point x="243" y="518"/>
-      <point x="268" y="495"/>
-      <point x="268" y="462" type="curve" smooth="yes"/>
-      <point x="268" y="417"/>
-      <point x="236" y="391"/>
-      <point x="187" y="391" type="curve" smooth="yes"/>
-      <point x="153" y="391"/>
-      <point x="119" y="406"/>
-      <point x="108" y="459" type="curve"/>
+      <point x="159" y="620" type="line"/>
+      <point x="170" y="640"/>
+      <point x="189" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="253" y="665"/>
+      <point x="274" y="650"/>
+      <point x="274" y="623" type="curve" smooth="yes"/>
+      <point x="274" y="591"/>
+      <point x="245" y="568"/>
+      <point x="209" y="568" type="curve" smooth="yes"/>
+      <point x="197" y="568.0"/>
+      <point x="185" y="568.0"/>
+      <point x="173" y="568" type="curve"/>
+      <point x="163" y="512" type="line"/>
+      <point x="174" y="512.0"/>
+      <point x="184" y="512.0"/>
+      <point x="195" y="512" type="curve" smooth="yes"/>
+      <point x="234" y="512"/>
+      <point x="258" y="495"/>
+      <point x="258" y="462" type="curve" smooth="yes"/>
+      <point x="258" y="427"/>
+      <point x="226" y="401"/>
+      <point x="187" y="401" type="curve" smooth="yes"/>
+      <point x="153" y="401"/>
+      <point x="129" y="420"/>
+      <point x="118" y="463" type="curve"/>
       <point x="58" y="441" type="line"/>
       <point x="69" y="373"/>
       <point x="124" y="342"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -5,33 +5,33 @@
     <contour>
       <point x="43" y="350" type="line"/>
       <point x="289" y="350" type="line"/>
-      <point x="298" y="399" type="line"/>
-      <point x="116" y="399" type="line"/>
-      <point x="116" y="399"/>
-      <point x="227" y="488"/>
-      <point x="253" y="510" type="curve" smooth="yes"/>
-      <point x="296" y="546"/>
-      <point x="330" y="573"/>
-      <point x="330" y="627" type="curve" smooth="yes"/>
-      <point x="330" y="683"/>
+      <point x="300" y="409" type="line"/>
+      <point x="139" y="409" type="line"/>
+      <point x="139" y="409"/>
+      <point x="228" y="483"/>
+      <point x="254" y="505" type="curve" smooth="yes"/>
+      <point x="297" y="541"/>
+      <point x="335" y="573"/>
+      <point x="335" y="627" type="curve" smooth="yes"/>
+      <point x="335" y="683"/>
       <point x="289" y="724"/>
       <point x="223" y="724" type="curve" smooth="yes"/>
       <point x="162" y="724"/>
       <point x="108" y="690"/>
       <point x="90" y="629" type="curve"/>
-      <point x="135" y="608" type="line"/>
-      <point x="149.0" y="646.0"/>
-      <point x="180" y="673"/>
-      <point x="215" y="673.0" type="curve" smooth="yes"/>
-      <point x="251.0" y="673.0"/>
-      <point x="272.0" y="656.0"/>
-      <point x="272" y="620" type="curve" smooth="yes"/>
-      <point x="272" y="589"/>
-      <point x="237" y="562"/>
+      <point x="145" y="604" type="line"/>
+      <point x="161" y="646"/>
+      <point x="186" y="665"/>
+      <point x="217" y="665" type="curve" smooth="yes"/>
+      <point x="245" y="665"/>
+      <point x="267" y="649"/>
+      <point x="267" y="620" type="curve" smooth="yes"/>
+      <point x="267" y="589"/>
+      <point x="238" y="560"/>
       <point x="215" y="542" type="curve" smooth="yes"/>
-      <point x="204" y="532"/>
-      <point x="51" y="398"/>
-      <point x="51" y="398" type="curve"/>
+      <point x="204" y="533"/>
+      <point x="53" y="405"/>
+      <point x="53" y="405" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -17,18 +17,18 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="437.0" y="69" type="curve" smooth="yes"/>
-      <point x="280" y="69"/>
-      <point x="148" y="201"/>
-      <point x="148" y="358.0" type="curve" smooth="yes"/>
-      <point x="148" y="518"/>
-      <point x="280" y="647"/>
-      <point x="437.0" y="647" type="curve" smooth="yes"/>
-      <point x="598.0" y="647"/>
-      <point x="726" y="518"/>
-      <point x="726" y="358.0" type="curve" smooth="yes"/>
-      <point x="726" y="201"/>
-      <point x="598.0" y="69"/>
+      <point x="437" y="44" type="curve" smooth="yes"/>
+      <point x="266" y="44"/>
+      <point x="123" y="187"/>
+      <point x="123" y="358" type="curve" smooth="yes"/>
+      <point x="123" y="532"/>
+      <point x="266" y="672"/>
+      <point x="437" y="672" type="curve" smooth="yes"/>
+      <point x="612" y="672"/>
+      <point x="751" y="532"/>
+      <point x="751" y="358" type="curve" smooth="yes"/>
+      <point x="751" y="187"/>
+      <point x="612" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -4,57 +4,57 @@
   <outline>
     <contour>
       <point x="178" y="342" type="curve" smooth="yes"/>
-      <point x="273" y="342"/>
-      <point x="332.0" y="393.0"/>
-      <point x="332.0" y="462" type="curve" smooth="yes"/>
-      <point x="332" y="499"/>
-      <point x="312" y="529"/>
+      <point x="260" y="342"/>
+      <point x="327" y="390"/>
+      <point x="327" y="467" type="curve" smooth="yes"/>
+      <point x="327" y="499"/>
+      <point x="313" y="526"/>
       <point x="288" y="543" type="curve"/>
-      <point x="326" y="561"/>
-      <point x="349" y="594"/>
-      <point x="349" y="633" type="curve" smooth="yes"/>
-      <point x="349.0" y="691.0"/>
-      <point x="301.0" y="724.0"/>
+      <point x="320" y="561"/>
+      <point x="344" y="594"/>
+      <point x="344" y="633" type="curve" smooth="yes"/>
+      <point x="344" y="689"/>
+      <point x="293" y="724"/>
       <point x="236" y="724" type="curve" smooth="yes"/>
-      <point x="146" y="724"/>
-      <point x="95" y="671"/>
-      <point x="95.0" y="614" type="curve" smooth="yes"/>
-      <point x="95" y="578"/>
-      <point x="115" y="556"/>
+      <point x="156" y="724"/>
+      <point x="100" y="671"/>
+      <point x="100" y="608" type="curve" smooth="yes"/>
+      <point x="100" y="578"/>
+      <point x="119" y="555"/>
       <point x="133" y="545" type="curve"/>
       <point x="92" y="528"/>
-      <point x="54" y="492"/>
-      <point x="54" y="440" type="curve" smooth="yes"/>
-      <point x="54" y="387"/>
-      <point x="97" y="342"/>
+      <point x="59" y="492"/>
+      <point x="59" y="447" type="curve" smooth="yes"/>
+      <point x="59" y="387"/>
+      <point x="107" y="342"/>
     </contour>
     <contour>
-      <point x="189" y="411" type="curve" smooth="yes"/>
-      <point x="153" y="411"/>
-      <point x="138" y="427"/>
-      <point x="138.0" y="453" type="curve" smooth="yes"/>
-      <point x="138" y="482"/>
-      <point x="160" y="504"/>
-      <point x="198" y="504" type="curve" smooth="yes"/>
-      <point x="236" y="504"/>
-      <point x="252" y="487"/>
-      <point x="252.0" y="462" type="curve" smooth="yes"/>
-      <point x="252" y="431"/>
-      <point x="228" y="411"/>
+      <point x="189" y="401" type="curve" smooth="yes"/>
+      <point x="153" y="401"/>
+      <point x="126" y="420"/>
+      <point x="126" y="451" type="curve" smooth="yes"/>
+      <point x="126" y="489"/>
+      <point x="160" y="514"/>
+      <point x="198" y="514" type="curve" smooth="yes"/>
+      <point x="237" y="514"/>
+      <point x="261" y="492"/>
+      <point x="261" y="462" type="curve" smooth="yes"/>
+      <point x="261" y="422"/>
+      <point x="228" y="401"/>
     </contour>
     <contour>
-      <point x="213" y="572" type="curve" smooth="yes"/>
-      <point x="187" y="572"/>
-      <point x="167" y="582"/>
-      <point x="167" y="608" type="curve" smooth="yes"/>
-      <point x="167" y="640"/>
-      <point x="195" y="655"/>
-      <point x="227" y="655" type="curve" smooth="yes"/>
-      <point x="256" y="655"/>
-      <point x="277" y="643"/>
-      <point x="277" y="619" type="curve" smooth="yes"/>
-      <point x="277" y="583"/>
-      <point x="246" y="572"/>
+      <point x="214" y="568" type="curve" smooth="yes"/>
+      <point x="188" y="568"/>
+      <point x="167" y="584"/>
+      <point x="167" y="610" type="curve" smooth="yes"/>
+      <point x="167" y="642"/>
+      <point x="195" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="256" y="665"/>
+      <point x="277" y="647"/>
+      <point x="277" y="623" type="curve" smooth="yes"/>
+      <point x="277" y="587"/>
+      <point x="247" y="568"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,18 +18,18 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="414" y="237" type="curve" smooth="yes"/>
-      <point x="450" y="237"/>
-      <point x="480" y="257"/>
-      <point x="480" y="293" type="curve" smooth="yes"/>
-      <point x="480" y="321"/>
-      <point x="458" y="341"/>
+      <point x="413" y="228" type="curve" smooth="yes"/>
+      <point x="452" y="228"/>
+      <point x="485" y="249"/>
+      <point x="485" y="289" type="curve" smooth="yes"/>
+      <point x="485" y="319"/>
+      <point x="461" y="341"/>
       <point x="422" y="341" type="curve" smooth="yes"/>
-      <point x="387" y="341"/>
-      <point x="356" y="318"/>
-      <point x="356" y="283" type="curve" smooth="yes"/>
-      <point x="356" y="255"/>
-      <point x="381" y="237"/>
+      <point x="384" y="341"/>
+      <point x="350" y="316"/>
+      <point x="350" y="278" type="curve" smooth="yes"/>
+      <point x="350" y="247"/>
+      <point x="377" y="228"/>
     </contour>
     <contour>
       <point x="402" y="169" type="curve" smooth="yes"/>
@@ -59,17 +59,17 @@
     </contour>
     <contour>
       <point x="438" y="395" type="curve" smooth="yes"/>
-      <point x="467" y="395"/>
-      <point x="494" y="412"/>
-      <point x="494" y="445" type="curve" smooth="yes"/>
-      <point x="494" y="467"/>
-      <point x="475" y="483"/>
-      <point x="450" y="483" type="curve" smooth="yes"/>
-      <point x="421" y="483"/>
-      <point x="396" y="462"/>
-      <point x="396" y="433" type="curve" smooth="yes"/>
-      <point x="396" y="409"/>
-      <point x="415" y="395"/>
+      <point x="471" y="395"/>
+      <point x="501" y="414"/>
+      <point x="501" y="450" type="curve" smooth="yes"/>
+      <point x="501" y="474"/>
+      <point x="480" y="492"/>
+      <point x="451" y="492" type="curve" smooth="yes"/>
+      <point x="419" y="492"/>
+      <point x="391" y="469"/>
+      <point x="391" y="437" type="curve" smooth="yes"/>
+      <point x="391" y="411"/>
+      <point x="412" y="395"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -4,36 +4,36 @@
   <outline>
     <contour>
       <point x="177" y="343" type="curve" smooth="yes"/>
-      <point x="272" y="343"/>
-      <point x="335" y="400"/>
-      <point x="335" y="485" type="curve" smooth="yes"/>
-      <point x="335" y="555"/>
+      <point x="261" y="343"/>
+      <point x="329" y="400"/>
+      <point x="329" y="485" type="curve" smooth="yes"/>
+      <point x="329" y="555"/>
       <point x="285" y="595"/>
-      <point x="229" y="595.0" type="curve" smooth="yes"/>
+      <point x="224" y="595" type="curve" smooth="yes"/>
       <point x="200" y="595"/>
-      <point x="174" y="586"/>
-      <point x="166" y="580" type="curve"/>
-      <point x="189" y="646" type="line"/>
-      <point x="339" y="646" type="line"/>
+      <point x="175" y="587"/>
+      <point x="159" y="574" type="curve"/>
+      <point x="187" y="660" type="line"/>
+      <point x="339" y="660" type="line"/>
       <point x="348" y="716" type="line"/>
-      <point x="131" y="716" type="line"/>
-      <point x="73" y="527" type="line"/>
-      <point x="138" y="494" type="line"/>
-      <point x="152" y="513"/>
-      <point x="175" y="529"/>
-      <point x="204" y="529.0" type="curve" smooth="yes"/>
-      <point x="233" y="529"/>
-      <point x="248" y="506"/>
-      <point x="248.0" y="474" type="curve" smooth="yes"/>
-      <point x="248.0" y="440"/>
-      <point x="224" y="414"/>
-      <point x="183" y="414" type="curve" smooth="yes"/>
-      <point x="147" y="414"/>
-      <point x="131" y="435"/>
-      <point x="125" y="462" type="curve"/>
-      <point x="52" y="440" type="line"/>
-      <point x="60.0" y="379"/>
-      <point x="112.0" y="343"/>
+      <point x="141" y="716" type="line"/>
+      <point x="83" y="527" type="line"/>
+      <point x="136" y="504" type="line"/>
+      <point x="154" y="528"/>
+      <point x="175" y="539"/>
+      <point x="203" y="539" type="curve" smooth="yes"/>
+      <point x="236" y="539"/>
+      <point x="261" y="517"/>
+      <point x="261" y="480" type="curve" smooth="yes"/>
+      <point x="261" y="437"/>
+      <point x="224" y="402"/>
+      <point x="183" y="402" type="curve" smooth="yes"/>
+      <point x="147" y="402"/>
+      <point x="125" y="423"/>
+      <point x="118" y="456" type="curve"/>
+      <point x="56" y="434" type="line"/>
+      <point x="66" y="369"/>
+      <point x="124" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -22,24 +22,24 @@
       <point x="343" y="168"/>
       <point x="285" y="194"/>
       <point x="275" y="259" type="curve"/>
-      <point x="344" y="283" type="line"/>
-      <point x="351" y="253"/>
-      <point x="370" y="234"/>
-      <point x="403" y="234" type="curve" smooth="yes"/>
-      <point x="439" y="234"/>
-      <point x="473" y="266"/>
-      <point x="473" y="304" type="curve" smooth="yes"/>
-      <point x="473" y="337"/>
-      <point x="450" y="357"/>
-      <point x="421" y="357" type="curve" smooth="yes"/>
-      <point x="395" y="357"/>
-      <point x="377" y="347"/>
-      <point x="360" y="325" type="curve"/>
+      <point x="337" y="281" type="line"/>
+      <point x="344" y="248"/>
+      <point x="366" y="227"/>
+      <point x="402" y="227" type="curve" smooth="yes"/>
+      <point x="443" y="227"/>
+      <point x="480" y="262"/>
+      <point x="480" y="305" type="curve" smooth="yes"/>
+      <point x="480" y="342"/>
+      <point x="455" y="364"/>
+      <point x="422" y="364" type="curve" smooth="yes"/>
+      <point x="394" y="364"/>
+      <point x="373" y="353"/>
+      <point x="355" y="329" type="curve"/>
       <point x="302" y="352" type="line"/>
       <point x="360" y="541" type="line"/>
       <point x="567" y="541" type="line"/>
-      <point x="555" y="473" type="line"/>
-      <point x="403" y="473" type="line"/>
+      <point x="558" y="485" type="line"/>
+      <point x="406" y="485" type="line"/>
       <point x="378" y="399" type="line"/>
       <point x="394" y="412"/>
       <point x="419" y="420"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="342"/>
   <outline>
     <contour>
-      <point x="55" y="414" type="line"/>
-      <point x="340" y="414" type="line"/>
-      <point x="356" y="490" type="line"/>
-      <point x="159" y="490" type="line"/>
-      <point x="246" y="588" type="line"/>
-      <point x="249" y="588" type="line"/>
-      <point x="206" y="350" type="line"/>
-      <point x="292" y="350" type="line"/>
-      <point x="357" y="716" type="line"/>
-      <point x="276" y="716" type="line"/>
-      <point x="69" y="482" type="line"/>
+      <point x="58" y="424" type="line"/>
+      <point x="343" y="424" type="line"/>
+      <point x="353" y="480" type="line"/>
+      <point x="141" y="480" type="line"/>
+      <point x="258" y="612" type="line"/>
+      <point x="262" y="612" type="line"/>
+      <point x="216" y="350" type="line"/>
+      <point x="281" y="350" type="line"/>
+      <point x="346" y="716" type="line"/>
+      <point x="285" y="716" type="line"/>
+      <point x="65" y="468" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="343" y="308" type="line"/>
-      <point x="424" y="308" type="line"/>
-      <point x="444" y="417" type="line"/>
-      <point x="444" y="417" type="line"/>
+      <point x="336" y="305" type="line"/>
+      <point x="434" y="305" type="line"/>
+      <point x="457" y="437" type="line"/>
+      <point x="453" y="437" type="line"/>
     </contour>
     <contour>
-      <point x="401" y="175" type="line"/>
-      <point x="412" y="243" type="line"/>
-      <point x="251" y="243" type="line"/>
-      <point x="260" y="296" type="line"/>
-      <point x="476" y="541" type="line"/>
-      <point x="546" y="541" type="line"/>
-      <point x="504" y="308" type="line"/>
-      <point x="548" y="308" type="line"/>
-      <point x="536" y="243" type="line"/>
-      <point x="492" y="243" type="line"/>
-      <point x="481" y="175" type="line"/>
+      <point x="411" y="175" type="line"/>
+      <point x="424" y="249" type="line"/>
+      <point x="253" y="249" type="line"/>
+      <point x="260" y="293" type="line"/>
+      <point x="480" y="541" type="line"/>
+      <point x="541" y="541" type="line"/>
+      <point x="499" y="305" type="line"/>
+      <point x="548" y="305" type="line"/>
+      <point x="538" y="249" type="line"/>
+      <point x="489" y="249" type="line"/>
+      <point x="476" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="315"/>
   <outline>
     <contour>
-      <point x="156" y="332" type="line"/>
-      <point x="201" y="381"/>
-      <point x="249" y="433"/>
-      <point x="294" y="482" type="curve" smooth="yes"/>
-      <point x="341" y="533"/>
-      <point x="354" y="570"/>
-      <point x="354" y="614" type="curve" smooth="yes"/>
-      <point x="354" y="673"/>
-      <point x="299" y="724"/>
-      <point x="232" y="724" type="curve" smooth="yes"/>
-      <point x="141.0" y="724.0"/>
-      <point x="78.0" y="662.0"/>
-      <point x="78" y="579" type="curve" smooth="yes"/>
-      <point x="78" y="514"/>
-      <point x="125.0" y="473.0"/>
-      <point x="180.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="188" y="473"/>
-      <point x="195" y="474"/>
-      <point x="198" y="475" type="curve"/>
-      <point x="169" y="444"/>
-      <point x="136" y="414"/>
-      <point x="101" y="377" type="curve"/>
+      <point x="151" y="334" type="line"/>
+      <point x="196" y="383"/>
+      <point x="241" y="432"/>
+      <point x="286" y="481" type="curve" smooth="yes"/>
+      <point x="335" y="534"/>
+      <point x="351" y="564"/>
+      <point x="351" y="614" type="curve" smooth="yes"/>
+      <point x="351" y="673"/>
+      <point x="302" y="724"/>
+      <point x="235" y="724" type="curve" smooth="yes"/>
+      <point x="152" y="724"/>
+      <point x="83" y="664"/>
+      <point x="83" y="579" type="curve" smooth="yes"/>
+      <point x="83" y="525"/>
+      <point x="123" y="474"/>
+      <point x="186" y="474" type="curve" smooth="yes"/>
+      <point x="194" y="474"/>
+      <point x="205" y="476"/>
+      <point x="212" y="480" type="curve"/>
+      <point x="177" y="443"/>
+      <point x="142" y="407"/>
+      <point x="107" y="370" type="curve"/>
     </contour>
     <contour>
-      <point x="209" y="539" type="curve" smooth="yes"/>
-      <point x="174" y="539"/>
-      <point x="156" y="556"/>
-      <point x="156" y="591" type="curve" smooth="yes"/>
-      <point x="156" y="631"/>
-      <point x="185" y="656"/>
-      <point x="223" y="656" type="curve" smooth="yes"/>
-      <point x="258" y="656"/>
-      <point x="274" y="637"/>
-      <point x="274" y="607" type="curve" smooth="yes"/>
-      <point x="274" y="566"/>
-      <point x="247" y="539"/>
+      <point x="208" y="530" type="curve" smooth="yes"/>
+      <point x="171" y="530"/>
+      <point x="151" y="556"/>
+      <point x="151" y="591" type="curve" smooth="yes"/>
+      <point x="151" y="631"/>
+      <point x="188" y="665"/>
+      <point x="226" y="665" type="curve" smooth="yes"/>
+      <point x="263" y="665"/>
+      <point x="285" y="640"/>
+      <point x="285" y="607" type="curve" smooth="yes"/>
+      <point x="285" y="566"/>
+      <point x="253" y="530"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,12 +18,12 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="381" y="158" type="curve"/>
-      <point x="328" y="202" type="line"/>
-      <point x="363" y="239"/>
-      <point x="398" y="275"/>
-      <point x="428" y="303" type="curve"/>
-      <point x="425" y="302"/>
+      <point x="377" y="161" type="curve"/>
+      <point x="333" y="197" type="line"/>
+      <point x="368" y="234"/>
+      <point x="403" y="270"/>
+      <point x="438" y="307" type="curve"/>
+      <point x="431" y="303"/>
       <point x="420" y="301"/>
       <point x="412" y="301" type="curve" smooth="yes"/>
       <point x="349" y="301"/>
@@ -33,27 +33,27 @@
       <point x="378" y="551"/>
       <point x="461" y="551" type="curve" smooth="yes"/>
       <point x="528" y="551"/>
-      <point x="581" y="500"/>
-      <point x="581" y="441" type="curve" smooth="yes"/>
-      <point x="581" y="391"/>
-      <point x="565" y="358"/>
-      <point x="516" y="305" type="curve" smooth="yes"/>
-      <point x="471" y="256"/>
-      <point x="426" y="207"/>
+      <point x="577" y="500"/>
+      <point x="577" y="441" type="curve" smooth="yes"/>
+      <point x="577" y="391"/>
+      <point x="561" y="361"/>
+      <point x="512" y="308" type="curve" smooth="yes"/>
+      <point x="467" y="259"/>
+      <point x="422" y="210"/>
     </contour>
     <contour>
-      <point x="435" y="363" type="curve" smooth="yes"/>
-      <point x="477" y="363"/>
-      <point x="507" y="396"/>
-      <point x="507" y="433" type="curve" smooth="yes"/>
-      <point x="507" y="463"/>
-      <point x="487" y="486"/>
-      <point x="452" y="486" type="curve" smooth="yes"/>
-      <point x="416" y="486"/>
-      <point x="381" y="455"/>
-      <point x="381" y="419" type="curve" smooth="yes"/>
-      <point x="381" y="386"/>
-      <point x="399" y="363"/>
+      <point x="434" y="357" type="curve" smooth="yes"/>
+      <point x="479" y="357"/>
+      <point x="511" y="393"/>
+      <point x="511" y="434" type="curve" smooth="yes"/>
+      <point x="511" y="467"/>
+      <point x="489" y="492"/>
+      <point x="452" y="492" type="curve" smooth="yes"/>
+      <point x="414" y="492"/>
+      <point x="377" y="458"/>
+      <point x="377" y="418" type="curve" smooth="yes"/>
+      <point x="377" y="383"/>
+      <point x="397" y="357"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="239"/>
   <outline>
     <contour>
-      <point x="120" y="350" type="line"/>
-      <point x="210" y="350" type="line"/>
-      <point x="275" y="716" type="line"/>
-      <point x="182" y="716" type="line"/>
-      <point x="68" y="638" type="line"/>
-      <point x="110" y="565" type="line"/>
-      <point x="166" y="606" type="line"/>
+      <point x="135" y="350" type="line"/>
+      <point x="200" y="350" type="line"/>
+      <point x="265" y="716" type="line"/>
+      <point x="209" y="716" type="line"/>
+      <point x="97" y="637" type="line"/>
+      <point x="128" y="588" type="line"/>
+      <point x="184" y="629" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="359" y="176" type="line"/>
-      <point x="405" y="432" type="line"/>
-      <point x="349" y="391" type="line"/>
-      <point x="310" y="454" type="line"/>
-      <point x="433" y="542" type="line"/>
-      <point x="509" y="542" type="line"/>
-      <point x="444" y="176" type="line"/>
+      <point x="369" y="176" type="line"/>
+      <point x="418" y="455" type="line"/>
+      <point x="362" y="414" type="line"/>
+      <point x="331" y="463" type="line"/>
+      <point x="443" y="542" type="line"/>
+      <point x="499" y="542" type="line"/>
+      <point x="434" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="297"/>
   <outline>
     <contour>
-      <point x="127" y="333" type="line"/>
-      <point x="198" y="438"/>
-      <point x="261" y="535"/>
-      <point x="339" y="644" type="curve"/>
+      <point x="110" y="335" type="line"/>
+      <point x="188" y="444"/>
+      <point x="265" y="552"/>
+      <point x="343" y="661" type="curve"/>
       <point x="353" y="716" type="line"/>
       <point x="105" y="716" type="line"/>
-      <point x="95" y="637" type="line"/>
-      <point x="246" y="637" type="line"/>
-      <point x="177" y="541"/>
-      <point x="132" y="476"/>
-      <point x="63" y="380" type="curve"/>
+      <point x="95" y="657" type="line"/>
+      <point x="270" y="657" type="line"/>
+      <point x="201" y="561"/>
+      <point x="131" y="465"/>
+      <point x="62" y="369" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -19,12 +19,12 @@
     </contour>
     <contour>
       <point x="345" y="161" type="curve"/>
-      <point x="287" y="202" type="line"/>
-      <point x="356" y="298"/>
-      <point x="416" y="377"/>
-      <point x="485" y="473" type="curve"/>
-      <point x="320" y="473" type="line"/>
-      <point x="333" y="542" type="line"/>
+      <point x="297" y="195" type="line"/>
+      <point x="366" y="291"/>
+      <point x="436" y="387"/>
+      <point x="505" y="483" type="curve"/>
+      <point x="330" y="483" type="line"/>
+      <point x="340" y="542" type="line"/>
       <point x="588" y="542" type="line"/>
       <point x="578" y="487" type="line"/>
       <point x="500" y="378"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -4,41 +4,41 @@
   <outline>
     <contour>
       <point x="177" y="342" type="curve" smooth="yes"/>
-      <point x="268.0" y="342.0"/>
-      <point x="331.0" y="404.0"/>
-      <point x="331" y="487" type="curve" smooth="yes"/>
-      <point x="331" y="552"/>
-      <point x="284" y="593.0"/>
-      <point x="229" y="593.0" type="curve" smooth="yes"/>
-      <point x="221" y="593"/>
-      <point x="214" y="592"/>
-      <point x="211" y="591" type="curve"/>
-      <point x="240" y="622"/>
-      <point x="273" y="652"/>
-      <point x="308" y="689" type="curve"/>
-      <point x="253" y="734" type="line"/>
-      <point x="208" y="685"/>
-      <point x="160" y="633"/>
-      <point x="115" y="584" type="curve" smooth="yes"/>
-      <point x="68" y="533"/>
-      <point x="55" y="496"/>
-      <point x="55" y="452" type="curve" smooth="yes"/>
-      <point x="55" y="393"/>
+      <point x="260" y="342"/>
+      <point x="329" y="402"/>
+      <point x="329" y="487" type="curve" smooth="yes"/>
+      <point x="329" y="541"/>
+      <point x="289" y="592"/>
+      <point x="226" y="592" type="curve" smooth="yes"/>
+      <point x="218" y="592"/>
+      <point x="207" y="590"/>
+      <point x="201" y="586" type="curve"/>
+      <point x="236" y="623"/>
+      <point x="270" y="659"/>
+      <point x="305" y="696" type="curve"/>
+      <point x="261" y="732" type="line"/>
+      <point x="216" y="683"/>
+      <point x="170" y="633"/>
+      <point x="125" y="584" type="curve" smooth="yes"/>
+      <point x="78" y="533"/>
+      <point x="61" y="502"/>
+      <point x="61" y="452" type="curve" smooth="yes"/>
+      <point x="61" y="393"/>
       <point x="110" y="342"/>
     </contour>
     <contour>
-      <point x="186" y="410" type="curve" smooth="yes"/>
-      <point x="151" y="410"/>
-      <point x="135" y="429"/>
-      <point x="135" y="459" type="curve" smooth="yes"/>
-      <point x="135" y="500"/>
-      <point x="162" y="527"/>
-      <point x="200" y="527" type="curve" smooth="yes"/>
-      <point x="235" y="527"/>
-      <point x="253" y="510"/>
-      <point x="253" y="475" type="curve" smooth="yes"/>
-      <point x="253" y="435"/>
-      <point x="224" y="410"/>
+      <point x="186" y="401" type="curve" smooth="yes"/>
+      <point x="149" y="401"/>
+      <point x="127" y="426"/>
+      <point x="127" y="459" type="curve" smooth="yes"/>
+      <point x="127" y="500"/>
+      <point x="159" y="536"/>
+      <point x="204" y="536" type="curve" smooth="yes"/>
+      <point x="241" y="536"/>
+      <point x="261" y="510"/>
+      <point x="261" y="475" type="curve" smooth="yes"/>
+      <point x="261" y="435"/>
+      <point x="224" y="401"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,38 +18,38 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="422" y="236" type="curve" smooth="yes"/>
-      <point x="457" y="236"/>
-      <point x="492" y="267"/>
-      <point x="492" y="303" type="curve" smooth="yes"/>
-      <point x="492" y="335"/>
-      <point x="473" y="359"/>
-      <point x="438" y="359" type="curve" smooth="yes"/>
-      <point x="396" y="359"/>
-      <point x="366" y="326"/>
-      <point x="366" y="289" type="curve" smooth="yes"/>
-      <point x="366" y="259"/>
-      <point x="387" y="236"/>
+      <point x="421" y="230" type="curve" smooth="yes"/>
+      <point x="459" y="230"/>
+      <point x="496" y="264"/>
+      <point x="496" y="304" type="curve" smooth="yes"/>
+      <point x="496" y="339"/>
+      <point x="476" y="365"/>
+      <point x="439" y="365" type="curve" smooth="yes"/>
+      <point x="394" y="365"/>
+      <point x="362" y="329"/>
+      <point x="362" y="288" type="curve" smooth="yes"/>
+      <point x="362" y="255"/>
+      <point x="384" y="230"/>
     </contour>
     <contour>
       <point x="412" y="171" type="curve" smooth="yes"/>
       <point x="345" y="171"/>
-      <point x="292" y="222"/>
-      <point x="292" y="281" type="curve" smooth="yes"/>
-      <point x="292" y="331"/>
-      <point x="308" y="366"/>
-      <point x="355" y="417" type="curve" smooth="yes"/>
-      <point x="400" y="466"/>
-      <point x="446" y="516"/>
-      <point x="491" y="565" type="curve"/>
-      <point x="545" y="521" type="line"/>
-      <point x="510" y="484"/>
-      <point x="476" y="448"/>
-      <point x="448" y="420" type="curve"/>
-      <point x="452" y="421"/>
-      <point x="457" y="421"/>
-      <point x="463" y="421" type="curve" smooth="yes"/>
-      <point x="527" y="421"/>
+      <point x="296" y="222"/>
+      <point x="296" y="281" type="curve" smooth="yes"/>
+      <point x="296" y="331"/>
+      <point x="313" y="362"/>
+      <point x="360" y="413" type="curve" smooth="yes"/>
+      <point x="405" y="462"/>
+      <point x="451" y="512"/>
+      <point x="496" y="561" type="curve"/>
+      <point x="540" y="525" type="line"/>
+      <point x="505" y="488"/>
+      <point x="471" y="452"/>
+      <point x="436" y="415" type="curve"/>
+      <point x="442" y="419"/>
+      <point x="453" y="421"/>
+      <point x="461" y="421" type="curve" smooth="yes"/>
+      <point x="524" y="421"/>
       <point x="564" y="370"/>
       <point x="564" y="316" type="curve" smooth="yes"/>
       <point x="564" y="231"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -5,46 +5,46 @@
     <contour>
       <point x="180" y="342" type="curve" smooth="yes"/>
       <point x="263" y="342"/>
-      <point x="340" y="394"/>
-      <point x="340" y="464" type="curve" smooth="yes"/>
-      <point x="340" y="501"/>
-      <point x="319" y="528"/>
-      <point x="290" y="542" type="curve"/>
-      <point x="336" y="559"/>
-      <point x="357" y="592"/>
-      <point x="357" y="633" type="curve" smooth="yes"/>
-      <point x="357" y="685"/>
-      <point x="308" y="724"/>
-      <point x="245" y="724.0" type="curve" smooth="yes"/>
+      <point x="325" y="394"/>
+      <point x="325" y="464" type="curve" smooth="yes"/>
+      <point x="325" y="501"/>
+      <point x="304" y="528"/>
+      <point x="275" y="542" type="curve"/>
+      <point x="309" y="555"/>
+      <point x="342" y="592"/>
+      <point x="342" y="633" type="curve" smooth="yes"/>
+      <point x="342" y="685"/>
+      <point x="298" y="724"/>
+      <point x="234" y="724" type="curve" smooth="yes"/>
       <point x="172" y="724"/>
       <point x="123" y="691"/>
       <point x="105" y="643" type="curve"/>
-      <point x="166" y="616" type="line"/>
-      <point x="178" y="637"/>
-      <point x="198" y="649"/>
-      <point x="223" y="649.0" type="curve" smooth="yes"/>
-      <point x="249" y="649"/>
-      <point x="262" y="633"/>
-      <point x="262.0" y="614" type="curve" smooth="yes"/>
-      <point x="262" y="597"/>
-      <point x="245" y="578"/>
-      <point x="209" y="578" type="curve" smooth="yes"/>
-      <point x="197" y="578.0"/>
-      <point x="185" y="578.0"/>
-      <point x="173" y="578" type="curve"/>
-      <point x="163" y="508" type="line"/>
-      <point x="174" y="508.0"/>
-      <point x="184" y="508.0"/>
-      <point x="195" y="508" type="curve" smooth="yes"/>
-      <point x="234" y="508"/>
-      <point x="248" y="485"/>
-      <point x="248" y="462" type="curve" smooth="yes"/>
-      <point x="248" y="438"/>
-      <point x="226" y="421"/>
-      <point x="194" y="421.0" type="curve" smooth="yes"/>
-      <point x="153" y="421"/>
-      <point x="141" y="441"/>
-      <point x="133" y="471" type="curve"/>
+      <point x="159" y="620" type="line"/>
+      <point x="170" y="640"/>
+      <point x="189" y="665"/>
+      <point x="227" y="665" type="curve" smooth="yes"/>
+      <point x="253" y="665"/>
+      <point x="274" y="650"/>
+      <point x="274" y="623" type="curve" smooth="yes"/>
+      <point x="274" y="591"/>
+      <point x="245" y="568"/>
+      <point x="209" y="568" type="curve" smooth="yes"/>
+      <point x="197" y="568.0"/>
+      <point x="185" y="568.0"/>
+      <point x="173" y="568" type="curve"/>
+      <point x="163" y="512" type="line"/>
+      <point x="174" y="512.0"/>
+      <point x="184" y="512.0"/>
+      <point x="195" y="512" type="curve" smooth="yes"/>
+      <point x="234" y="512"/>
+      <point x="258" y="495"/>
+      <point x="258" y="462" type="curve" smooth="yes"/>
+      <point x="258" y="427"/>
+      <point x="226" y="401"/>
+      <point x="187" y="401" type="curve" smooth="yes"/>
+      <point x="153" y="401"/>
+      <point x="129" y="420"/>
+      <point x="118" y="463" type="curve"/>
       <point x="58" y="441" type="line"/>
       <point x="69" y="373"/>
       <point x="124" y="342"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -22,34 +22,34 @@
       <point x="344" y="166"/>
       <point x="289" y="197"/>
       <point x="278" y="265" type="curve"/>
-      <point x="342" y="290.0" type="line"/>
-      <point x="352" y="252.0"/>
-      <point x="373" y="235.0"/>
-      <point x="404" y="235.0" type="curve" smooth="yes"/>
-      <point x="439" y="235.0"/>
-      <point x="468" y="258.0"/>
-      <point x="468" y="289.0" type="curve" smooth="yes"/>
-      <point x="468" y="319.0"/>
-      <point x="454" y="332"/>
-      <point x="415" y="332" type="curve" smooth="yes"/>
-      <point x="404" y="332.0"/>
-      <point x="394" y="332.0"/>
-      <point x="383" y="332" type="curve"/>
-      <point x="393" y="396" type="line"/>
-      <point x="404" y="396"/>
-      <point x="417" y="396"/>
-      <point x="428" y="396" type="curve"/>
-      <point x="460" y="396"/>
-      <point x="486" y="413"/>
-      <point x="486" y="441" type="curve" smooth="yes"/>
-      <point x="486" y="465"/>
-      <point x="467" y="479"/>
-      <point x="444" y="479" type="curve" smooth="yes"/>
-      <point x="410" y="479"/>
-      <point x="393" y="456"/>
-      <point x="383" y="438" type="curve"/>
-      <point x="320" y="464" type="line"/>
-      <point x="338" y="512"/>
+      <point x="338" y="287" type="line"/>
+      <point x="349" y="244"/>
+      <point x="373" y="225"/>
+      <point x="407" y="225" type="curve" smooth="yes"/>
+      <point x="446" y="225"/>
+      <point x="478" y="251"/>
+      <point x="478" y="286" type="curve" smooth="yes"/>
+      <point x="478" y="319"/>
+      <point x="454" y="336"/>
+      <point x="415" y="336" type="curve" smooth="yes"/>
+      <point x="404" y="336.0"/>
+      <point x="394" y="336.0"/>
+      <point x="383" y="336" type="curve"/>
+      <point x="393" y="392" type="line"/>
+      <point x="405" y="392.0"/>
+      <point x="417" y="392.0"/>
+      <point x="429" y="392" type="curve"/>
+      <point x="465" y="392"/>
+      <point x="494" y="415"/>
+      <point x="494" y="447" type="curve" smooth="yes"/>
+      <point x="494" y="474"/>
+      <point x="473" y="489"/>
+      <point x="447" y="489" type="curve" smooth="yes"/>
+      <point x="409" y="489"/>
+      <point x="390" y="464"/>
+      <point x="379" y="444" type="curve"/>
+      <point x="325" y="467" type="line"/>
+      <point x="343" y="515"/>
       <point x="392" y="548"/>
       <point x="454" y="548" type="curve" smooth="yes"/>
       <point x="518" y="548"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -5,33 +5,33 @@
     <contour>
       <point x="43" y="350" type="line"/>
       <point x="289" y="350" type="line"/>
-      <point x="305" y="429" type="line"/>
-      <point x="176" y="429" type="line"/>
-      <point x="176" y="429"/>
-      <point x="243" y="483"/>
-      <point x="269" y="505" type="curve"/>
-      <point x="312" y="541"/>
-      <point x="345" y="573"/>
-      <point x="345" y="627" type="curve" smooth="yes"/>
-      <point x="345" y="683"/>
-      <point x="298" y="724"/>
+      <point x="300" y="409" type="line"/>
+      <point x="139" y="409" type="line"/>
+      <point x="139" y="409"/>
+      <point x="228" y="483"/>
+      <point x="254" y="505" type="curve" smooth="yes"/>
+      <point x="297" y="541"/>
+      <point x="335" y="573"/>
+      <point x="335" y="627" type="curve" smooth="yes"/>
+      <point x="335" y="683"/>
+      <point x="289" y="724"/>
       <point x="223" y="724" type="curve" smooth="yes"/>
       <point x="162" y="724"/>
-      <point x="103" y="694"/>
-      <point x="85" y="633" type="curve"/>
-      <point x="154" y="601" type="line"/>
-      <point x="170" y="634"/>
-      <point x="186" y="645"/>
-      <point x="209" y="645.0" type="curve" smooth="yes"/>
-      <point x="236" y="645"/>
-      <point x="247" y="628"/>
-      <point x="247.0" y="611" type="curve" smooth="yes"/>
-      <point x="247" y="589"/>
-      <point x="228" y="570"/>
-      <point x="205" y="552" type="curve" smooth="yes"/>
-      <point x="194" y="543"/>
-      <point x="57" y="425"/>
-      <point x="57" y="425" type="curve"/>
+      <point x="108" y="690"/>
+      <point x="90" y="629" type="curve"/>
+      <point x="145" y="604" type="line"/>
+      <point x="161" y="646"/>
+      <point x="186" y="665"/>
+      <point x="217" y="665" type="curve" smooth="yes"/>
+      <point x="245" y="665"/>
+      <point x="267" y="649"/>
+      <point x="267" y="620" type="curve" smooth="yes"/>
+      <point x="267" y="589"/>
+      <point x="238" y="560"/>
+      <point x="215" y="542" type="curve" smooth="yes"/>
+      <point x="204" y="533"/>
+      <point x="53" y="405"/>
+      <point x="53" y="405" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,19 +19,19 @@
     </contour>
     <contour>
       <point x="282" y="178" type="line"/>
-      <point x="294" y="248" type="line"/>
-      <point x="294" y="248"/>
-      <point x="444" y="378"/>
-      <point x="452" y="385" type="curve" smooth="yes"/>
-      <point x="470" y="400"/>
-      <point x="495" y="420"/>
-      <point x="495" y="443" type="curve" smooth="yes"/>
-      <point x="495" y="464"/>
-      <point x="477" y="476"/>
-      <point x="454" y="476" type="curve" smooth="yes"/>
-      <point x="429" y="476"/>
-      <point x="408" y="462"/>
-      <point x="395" y="431" type="curve"/>
+      <point x="292" y="233" type="line"/>
+      <point x="292" y="233"/>
+      <point x="443" y="361"/>
+      <point x="454" y="370" type="curve" smooth="yes"/>
+      <point x="477" y="388"/>
+      <point x="506" y="417"/>
+      <point x="506" y="448" type="curve" smooth="yes"/>
+      <point x="506" y="477"/>
+      <point x="484" y="493"/>
+      <point x="456" y="493" type="curve" smooth="yes"/>
+      <point x="425" y="493"/>
+      <point x="400" y="474"/>
+      <point x="384" y="432" type="curve"/>
       <point x="329" y="457" type="line"/>
       <point x="347" y="518"/>
       <point x="401" y="552"/>
@@ -43,10 +43,10 @@
       <point x="536" y="369"/>
       <point x="493" y="333" type="curve" smooth="yes"/>
       <point x="467" y="311"/>
-      <point x="395" y="250"/>
-      <point x="395" y="250" type="curve"/>
-      <point x="550" y="250" type="line"/>
-      <point x="535" y="178" type="line"/>
+      <point x="378" y="237"/>
+      <point x="378" y="237" type="curve"/>
+      <point x="539" y="237" type="line"/>
+      <point x="528" y="178" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="436" y="244" type="curve" smooth="yes"/>
-      <point x="461" y="244"/>
-      <point x="486" y="262"/>
-      <point x="486" y="289" type="curve" smooth="yes"/>
-      <point x="486" y="315"/>
-      <point x="461" y="334"/>
-      <point x="436" y="334" type="curve" smooth="yes"/>
-      <point x="410" y="334"/>
-      <point x="386" y="316"/>
-      <point x="386" y="289" type="curve" smooth="yes"/>
-      <point x="386" y="262"/>
-      <point x="409" y="244"/>
+      <point x="411" y="244" type="curve" smooth="yes"/>
+      <point x="440" y="244"/>
+      <point x="468" y="260"/>
+      <point x="468" y="294" type="curve" smooth="yes"/>
+      <point x="468" y="318"/>
+      <point x="449" y="334"/>
+      <point x="423" y="334" type="curve" smooth="yes"/>
+      <point x="392" y="334"/>
+      <point x="366" y="313"/>
+      <point x="366" y="282" type="curve" smooth="yes"/>
+      <point x="366" y="258"/>
+      <point x="386" y="244"/>
     </contour>
     <contour>
-      <point x="436" y="169" type="curve" smooth="yes"/>
-      <point x="366" y="169"/>
-      <point x="298" y="210"/>
-      <point x="298" y="283" type="curve" smooth="yes"/>
-      <point x="298" y="320"/>
-      <point x="320" y="352"/>
-      <point x="353" y="370" type="curve"/>
-      <point x="326" y="386"/>
-      <point x="310" y="415"/>
-      <point x="310" y="442" type="curve" smooth="yes"/>
-      <point x="310" y="509"/>
-      <point x="368" y="551"/>
-      <point x="436" y="551" type="curve" smooth="yes"/>
-      <point x="504" y="551"/>
-      <point x="562" y="509"/>
-      <point x="562" y="442" type="curve" smooth="yes"/>
-      <point x="562" y="415"/>
-      <point x="546" y="386"/>
-      <point x="519" y="370" type="curve"/>
-      <point x="552" y="352"/>
-      <point x="574" y="320"/>
-      <point x="574" y="283" type="curve" smooth="yes"/>
-      <point x="574" y="209"/>
-      <point x="505" y="169"/>
+      <point x="403" y="169" type="curve" smooth="yes"/>
+      <point x="331" y="169"/>
+      <point x="276" y="210"/>
+      <point x="276" y="272" type="curve" smooth="yes"/>
+      <point x="276" y="316"/>
+      <point x="307" y="355"/>
+      <point x="350" y="373" type="curve"/>
+      <point x="333" y="385"/>
+      <point x="317" y="407"/>
+      <point x="317" y="435" type="curve" smooth="yes"/>
+      <point x="317" y="499"/>
+      <point x="376" y="551"/>
+      <point x="459" y="551" type="curve" smooth="yes"/>
+      <point x="520" y="551"/>
+      <point x="572" y="513"/>
+      <point x="572" y="457" type="curve" smooth="yes"/>
+      <point x="572" y="414"/>
+      <point x="547" y="386"/>
+      <point x="515" y="369" type="curve"/>
+      <point x="537" y="354"/>
+      <point x="556" y="328"/>
+      <point x="556" y="293" type="curve" smooth="yes"/>
+      <point x="556" y="220"/>
+      <point x="491" y="169"/>
     </contour>
     <contour>
-      <point x="436" y="402" type="curve" smooth="yes"/>
-      <point x="456" y="402"/>
-      <point x="476" y="417"/>
-      <point x="476" y="439" type="curve" smooth="yes"/>
-      <point x="476" y="460"/>
-      <point x="459" y="476"/>
-      <point x="436" y="476" type="curve" smooth="yes"/>
-      <point x="413" y="476"/>
-      <point x="396" y="462"/>
-      <point x="396" y="439" type="curve" smooth="yes"/>
-      <point x="396" y="416"/>
-      <point x="415" y="402"/>
+      <point x="439" y="402" type="curve" smooth="yes"/>
+      <point x="464" y="402"/>
+      <point x="485" y="418"/>
+      <point x="485" y="444" type="curve" smooth="yes"/>
+      <point x="485" y="463"/>
+      <point x="468" y="476"/>
+      <point x="448" y="476" type="curve" smooth="yes"/>
+      <point x="426" y="476"/>
+      <point x="403" y="461"/>
+      <point x="403" y="435" type="curve" smooth="yes"/>
+      <point x="403" y="415"/>
+      <point x="419" y="402"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -18,37 +18,37 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="436" y="169" type="curve" smooth="yes"/>
-      <point x="379" y="169"/>
-      <point x="320" y="194"/>
-      <point x="300" y="260" type="curve"/>
-      <point x="379" y="291" type="line"/>
-      <point x="385" y="263"/>
-      <point x="407" y="246"/>
-      <point x="435" y="246" type="curve" smooth="yes"/>
-      <point x="464" y="246"/>
-      <point x="485" y="268"/>
-      <point x="485" y="298" type="curve" smooth="yes"/>
-      <point x="485" y="329"/>
-      <point x="464" y="350"/>
-      <point x="436" y="350" type="curve" smooth="yes"/>
-      <point x="412" y="350"/>
-      <point x="395" y="338"/>
-      <point x="384" y="321" type="curve"/>
-      <point x="311" y="353" type="line"/>
-      <point x="334" y="542" type="line"/>
-      <point x="553" y="542" type="line"/>
-      <point x="553" y="470" type="line"/>
-      <point x="401" y="470" type="line"/>
-      <point x="387" y="392" type="line"/>
-      <point x="401" y="411"/>
-      <point x="428" y="421"/>
-      <point x="453" y="421" type="curve" smooth="yes"/>
-      <point x="516" y="421"/>
-      <point x="573" y="374"/>
-      <point x="573" y="296" type="curve" smooth="yes"/>
-      <point x="573" y="219"/>
-      <point x="508" y="169"/>
+      <point x="400" y="169" type="curve" smooth="yes"/>
+      <point x="337" y="169"/>
+      <point x="289" y="198"/>
+      <point x="272" y="260" type="curve"/>
+      <point x="350" y="289" type="line"/>
+      <point x="356" y="263"/>
+      <point x="376" y="246"/>
+      <point x="406" y="246" type="curve" smooth="yes"/>
+      <point x="437" y="246"/>
+      <point x="465" y="269"/>
+      <point x="465" y="305" type="curve" smooth="yes"/>
+      <point x="465" y="334"/>
+      <point x="445" y="350"/>
+      <point x="421" y="350" type="curve" smooth="yes"/>
+      <point x="396" y="350"/>
+      <point x="379" y="338"/>
+      <point x="366" y="321" type="curve"/>
+      <point x="299" y="353" type="line"/>
+      <point x="355" y="542" type="line"/>
+      <point x="574" y="542" type="line"/>
+      <point x="562" y="470" type="line"/>
+      <point x="408" y="470" type="line"/>
+      <point x="386" y="404" type="line"/>
+      <point x="402" y="415"/>
+      <point x="422" y="421"/>
+      <point x="446" y="421" type="curve" smooth="yes"/>
+      <point x="504" y="421"/>
+      <point x="553" y="385"/>
+      <point x="553" y="313" type="curve" smooth="yes"/>
+      <point x="553" y="229"/>
+      <point x="483" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="352" y="316" type="line"/>
-      <point x="436" y="316" type="line"/>
-      <point x="436" y="423" type="line"/>
-      <point x="428" y="423" type="line"/>
+      <point x="346" y="314" type="line"/>
+      <point x="426" y="314" type="line"/>
+      <point x="445" y="418" type="line"/>
+      <point x="437" y="418" type="line"/>
     </contour>
     <contour>
-      <point x="436" y="177" type="line"/>
-      <point x="436" y="242" type="line"/>
-      <point x="264" y="242" type="line"/>
-      <point x="264" y="306" type="line"/>
-      <point x="435" y="543" type="line"/>
-      <point x="522" y="543" type="line"/>
-      <point x="522" y="316" type="line"/>
-      <point x="570" y="316" type="line"/>
-      <point x="570" y="242" type="line"/>
-      <point x="522" y="242" type="line"/>
-      <point x="522" y="177" type="line"/>
+      <point x="401" y="175" type="line"/>
+      <point x="413" y="240" type="line"/>
+      <point x="241" y="240" type="line"/>
+      <point x="252" y="304" type="line"/>
+      <point x="465" y="541" type="line"/>
+      <point x="552" y="541" type="line"/>
+      <point x="512" y="314" type="line"/>
+      <point x="559" y="314" type="line"/>
+      <point x="546" y="240" type="line"/>
+      <point x="499" y="240" type="line"/>
+      <point x="487" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="419" y="161" type="curve"/>
-      <point x="352" y="210" type="line"/>
-      <point x="377" y="242"/>
-      <point x="402" y="274"/>
-      <point x="429" y="306" type="curve"/>
-      <point x="424" y="303"/>
-      <point x="415" y="302"/>
-      <point x="409" y="302" type="curve" smooth="yes"/>
-      <point x="352" y="302"/>
-      <point x="296" y="354"/>
-      <point x="296" y="424" type="curve" smooth="yes"/>
-      <point x="296" y="493"/>
-      <point x="357" y="551"/>
-      <point x="433" y="551" type="curve" smooth="yes"/>
-      <point x="513" y="551"/>
-      <point x="570" y="491"/>
-      <point x="570" y="422" type="curve" smooth="yes"/>
-      <point x="570" y="379"/>
-      <point x="551" y="344"/>
-      <point x="527" y="311" type="curve"/>
-      <point x="492" y="261"/>
-      <point x="456" y="211"/>
+      <point x="385" y="161" type="curve"/>
+      <point x="326" y="210" type="line"/>
+      <point x="356" y="242"/>
+      <point x="387" y="274"/>
+      <point x="417" y="306" type="curve"/>
+      <point x="411" y="303"/>
+      <point x="401" y="302"/>
+      <point x="396" y="302" type="curve" smooth="yes"/>
+      <point x="349" y="302"/>
+      <point x="306" y="347"/>
+      <point x="306" y="406" type="curve" smooth="yes"/>
+      <point x="306" y="489"/>
+      <point x="374" y="551"/>
+      <point x="461" y="551" type="curve" smooth="yes"/>
+      <point x="538" y="551"/>
+      <point x="584" y="498"/>
+      <point x="584" y="438" type="curve" smooth="yes"/>
+      <point x="584" y="389"/>
+      <point x="565" y="356"/>
+      <point x="521" y="309" type="curve" smooth="yes"/>
+      <point x="476" y="260"/>
+      <point x="430" y="210"/>
     </contour>
     <contour>
-      <point x="434" y="373" type="curve" smooth="yes"/>
-      <point x="463" y="373"/>
-      <point x="484" y="397"/>
-      <point x="484" y="424" type="curve" smooth="yes"/>
-      <point x="484" y="452"/>
-      <point x="464" y="475"/>
-      <point x="434" y="475" type="curve" smooth="yes"/>
-      <point x="404" y="475"/>
-      <point x="384" y="452"/>
-      <point x="384" y="424" type="curve" smooth="yes"/>
-      <point x="384" y="397"/>
-      <point x="404" y="373"/>
+      <point x="439" y="373" type="curve" smooth="yes"/>
+      <point x="472" y="373"/>
+      <point x="496" y="400"/>
+      <point x="496" y="430" type="curve" smooth="yes"/>
+      <point x="496" y="457"/>
+      <point x="479" y="475"/>
+      <point x="452" y="475" type="curve" smooth="yes"/>
+      <point x="420" y="475"/>
+      <point x="395" y="450"/>
+      <point x="395" y="418" type="curve" smooth="yes"/>
+      <point x="395" y="393"/>
+      <point x="412" y="373"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="404" y="177" type="line"/>
-      <point x="404" y="432" type="line"/>
-      <point x="354" y="389" type="line"/>
-      <point x="305" y="455" type="line"/>
-      <point x="412" y="543" type="line"/>
-      <point x="493" y="543" type="line"/>
-      <point x="493" y="177" type="line"/>
+      <point x="368" y="176" type="line"/>
+      <point x="413" y="427" type="line"/>
+      <point x="360" y="389" type="line"/>
+      <point x="319" y="454" type="line"/>
+      <point x="441" y="542" type="line"/>
+      <point x="522" y="542" type="line"/>
+      <point x="457" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="404" y="162" type="curve"/>
-      <point x="325" y="202" type="line"/>
-      <point x="374" y="289"/>
-      <point x="423" y="375"/>
-      <point x="472" y="462" type="curve"/>
-      <point x="314" y="462" type="line"/>
-      <point x="314" y="543" type="line"/>
-      <point x="574" y="543" type="line"/>
-      <point x="574" y="466" type="line"/>
-      <point x="517" y="365"/>
-      <point x="461" y="263"/>
+      <point x="354" y="161" type="curve"/>
+      <point x="287" y="209" type="line"/>
+      <point x="349" y="293"/>
+      <point x="411" y="377"/>
+      <point x="473" y="461" type="curve"/>
+      <point x="317" y="461" type="line"/>
+      <point x="331" y="542" type="line"/>
+      <point x="592" y="542" type="line"/>
+      <point x="579" y="465" type="line"/>
+      <point x="504" y="364"/>
+      <point x="429" y="262"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="431" y="245" type="curve" smooth="yes"/>
-      <point x="461" y="245"/>
-      <point x="481" y="268"/>
-      <point x="481" y="296" type="curve" smooth="yes"/>
-      <point x="481" y="323"/>
-      <point x="461" y="347"/>
-      <point x="431" y="347" type="curve" smooth="yes"/>
-      <point x="402" y="347"/>
-      <point x="381" y="323"/>
-      <point x="381" y="296" type="curve" smooth="yes"/>
-      <point x="381" y="268"/>
-      <point x="401" y="245"/>
+      <point x="421" y="248" type="curve" smooth="yes"/>
+      <point x="453" y="248"/>
+      <point x="479" y="273"/>
+      <point x="479" y="305" type="curve" smooth="yes"/>
+      <point x="479" y="330"/>
+      <point x="462" y="350"/>
+      <point x="435" y="350" type="curve" smooth="yes"/>
+      <point x="401" y="350"/>
+      <point x="377" y="323"/>
+      <point x="377" y="293" type="curve" smooth="yes"/>
+      <point x="377" y="266"/>
+      <point x="395" y="248"/>
     </contour>
     <contour>
-      <point x="432" y="169" type="curve" smooth="yes"/>
-      <point x="352" y="169"/>
-      <point x="295" y="229"/>
-      <point x="295" y="298" type="curve" smooth="yes"/>
-      <point x="295" y="341"/>
-      <point x="314" y="376"/>
-      <point x="338" y="409" type="curve"/>
-      <point x="375" y="459"/>
-      <point x="411" y="509"/>
-      <point x="446" y="559" type="curve"/>
-      <point x="513" y="510" type="line"/>
-      <point x="487" y="478"/>
-      <point x="462" y="446"/>
-      <point x="436" y="414" type="curve"/>
-      <point x="441" y="417"/>
-      <point x="450" y="418"/>
-      <point x="456" y="418" type="curve" smooth="yes"/>
-      <point x="513" y="418"/>
-      <point x="569" y="366"/>
-      <point x="569" y="296" type="curve" smooth="yes"/>
-      <point x="569" y="227"/>
-      <point x="508" y="169"/>
+      <point x="412" y="172" type="curve" smooth="yes"/>
+      <point x="336" y="172"/>
+      <point x="290" y="225"/>
+      <point x="290" y="285" type="curve" smooth="yes"/>
+      <point x="290" y="334"/>
+      <point x="309" y="366"/>
+      <point x="353" y="414" type="curve" smooth="yes"/>
+      <point x="398" y="463"/>
+      <point x="443" y="513"/>
+      <point x="488" y="562" type="curve"/>
+      <point x="547" y="513" type="line"/>
+      <point x="517" y="481"/>
+      <point x="487" y="449"/>
+      <point x="457" y="417" type="curve"/>
+      <point x="462" y="420"/>
+      <point x="472" y="421"/>
+      <point x="477" y="421" type="curve" smooth="yes"/>
+      <point x="524" y="421"/>
+      <point x="568" y="376"/>
+      <point x="568" y="317" type="curve" smooth="yes"/>
+      <point x="568" y="234"/>
+      <point x="499" y="172"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,51 +18,51 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="435" y="168" type="curve" smooth="yes"/>
-      <point x="371" y="168"/>
-      <point x="311" y="199"/>
-      <point x="294" y="268" type="curve"/>
-      <point x="377" y="298" type="line"/>
-      <point x="384" y="259"/>
-      <point x="410" y="245"/>
-      <point x="435" y="245" type="curve" smooth="yes"/>
-      <point x="461" y="245"/>
-      <point x="483" y="262"/>
-      <point x="483" y="289" type="curve" smooth="yes"/>
-      <point x="483" y="315"/>
-      <point x="460" y="330"/>
-      <point x="427" y="330" type="curve" smooth="yes"/>
-      <point x="414" y="330.0"/>
-      <point x="401" y="330.0"/>
-      <point x="388" y="330" type="curve"/>
-      <point x="388" y="401" type="line"/>
-      <point x="400" y="401.0"/>
-      <point x="411" y="401.0"/>
-      <point x="423" y="401" type="curve"/>
-      <point x="453" y="401"/>
-      <point x="473" y="414"/>
-      <point x="473" y="439" type="curve" smooth="yes"/>
-      <point x="473" y="460"/>
-      <point x="455" y="474"/>
-      <point x="433" y="474" type="curve" smooth="yes"/>
-      <point x="403" y="474"/>
-      <point x="388" y="454"/>
-      <point x="382" y="435" type="curve"/>
-      <point x="306" y="466" type="line"/>
-      <point x="323" y="514"/>
-      <point x="365" y="550"/>
-      <point x="435" y="550" type="curve" smooth="yes"/>
-      <point x="510" y="550"/>
-      <point x="560" y="505"/>
-      <point x="560" y="448" type="curve" smooth="yes"/>
-      <point x="560" y="411"/>
-      <point x="537" y="382"/>
-      <point x="507" y="369" type="curve"/>
-      <point x="547" y="353"/>
-      <point x="573" y="321"/>
-      <point x="573" y="285" type="curve" smooth="yes"/>
-      <point x="573" y="211"/>
-      <point x="507" y="168"/>
+      <point x="402" y="165" type="curve" smooth="yes"/>
+      <point x="339" y="165"/>
+      <point x="283" y="200"/>
+      <point x="271" y="266" type="curve"/>
+      <point x="349" y="294" type="line"/>
+      <point x="359" y="257"/>
+      <point x="380" y="242"/>
+      <point x="409" y="242" type="curve" smooth="yes"/>
+      <point x="437" y="242"/>
+      <point x="465" y="259"/>
+      <point x="465" y="289" type="curve" smooth="yes"/>
+      <point x="465" y="314"/>
+      <point x="444" y="328"/>
+      <point x="411" y="328" type="curve" smooth="yes"/>
+      <point x="399" y="328.0"/>
+      <point x="388" y="328.0"/>
+      <point x="376" y="328" type="curve"/>
+      <point x="389" y="398" type="line"/>
+      <point x="400" y="398.0"/>
+      <point x="412" y="398.0"/>
+      <point x="423" y="398" type="curve" smooth="yes"/>
+      <point x="454" y="398"/>
+      <point x="480" y="412"/>
+      <point x="480" y="438" type="curve" smooth="yes"/>
+      <point x="480" y="458"/>
+      <point x="461" y="470"/>
+      <point x="442" y="470" type="curve" smooth="yes"/>
+      <point x="412" y="470"/>
+      <point x="395" y="452"/>
+      <point x="387" y="434" type="curve"/>
+      <point x="314" y="466" type="line"/>
+      <point x="337" y="514"/>
+      <point x="385" y="547"/>
+      <point x="455" y="547" type="curve" smooth="yes"/>
+      <point x="522" y="547"/>
+      <point x="570" y="507"/>
+      <point x="570" y="454" type="curve" smooth="yes"/>
+      <point x="570" y="412"/>
+      <point x="544" y="383"/>
+      <point x="509" y="366" type="curve"/>
+      <point x="536" y="352"/>
+      <point x="554" y="325"/>
+      <point x="554" y="293" type="curve" smooth="yes"/>
+      <point x="554" y="218"/>
+      <point x="490" y="165"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -18,35 +18,35 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="304" y="177" type="line"/>
-      <point x="304" y="240" type="line"/>
-      <point x="304" y="240"/>
-      <point x="421" y="357"/>
-      <point x="432" y="369" type="curve" smooth="yes"/>
-      <point x="456" y="392"/>
-      <point x="473" y="410"/>
-      <point x="473" y="436" type="curve" smooth="yes"/>
-      <point x="473" y="455"/>
-      <point x="456" y="472"/>
-      <point x="432" y="472" type="curve" smooth="yes"/>
-      <point x="407" y="472"/>
-      <point x="387" y="456"/>
-      <point x="381" y="422" type="curve"/>
-      <point x="300" y="453" type="line"/>
-      <point x="315" y="513"/>
-      <point x="367" y="551"/>
-      <point x="432" y="551" type="curve" smooth="yes"/>
-      <point x="507" y="551"/>
-      <point x="564" y="507"/>
-      <point x="564" y="443" type="curve" smooth="yes"/>
-      <point x="564" y="395"/>
-      <point x="524" y="353"/>
-      <point x="501" y="330" type="curve" smooth="yes"/>
-      <point x="481" y="310"/>
-      <point x="426" y="256"/>
-      <point x="426" y="256" type="curve"/>
-      <point x="566" y="256" type="line"/>
-      <point x="566" y="177" type="line"/>
+      <point x="275" y="177" type="line"/>
+      <point x="286" y="240" type="line"/>
+      <point x="286" y="240"/>
+      <point x="422" y="356"/>
+      <point x="437" y="369" type="curve" smooth="yes"/>
+      <point x="455" y="384"/>
+      <point x="486" y="409"/>
+      <point x="486" y="436" type="curve" smooth="yes"/>
+      <point x="486" y="458"/>
+      <point x="470" y="472"/>
+      <point x="447" y="472" type="curve" smooth="yes"/>
+      <point x="421" y="472"/>
+      <point x="403" y="456"/>
+      <point x="393" y="424" type="curve"/>
+      <point x="318" y="453" type="line"/>
+      <point x="336" y="514"/>
+      <point x="389" y="551"/>
+      <point x="460" y="551" type="curve" smooth="yes"/>
+      <point x="534" y="551"/>
+      <point x="579" y="508"/>
+      <point x="579" y="450" type="curve" smooth="yes"/>
+      <point x="579" y="400"/>
+      <point x="552" y="371"/>
+      <point x="503" y="330" type="curve" smooth="yes"/>
+      <point x="477" y="308"/>
+      <point x="433" y="270"/>
+      <point x="416" y="256" type="curve"/>
+      <point x="550" y="256" type="line"/>
+      <point x="536" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Closes https://github.com/googlefonts/googlesans/issues/269.

Note that GRAD for these has been removed upstream.