### PR TITLE
Separate outline checks from Google Sans profile

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -54,6 +54,8 @@ excluded_check_ids = (
     "com.google.fonts/check/varfont/regular_opsz_coord",  # we do want our opsz definition
     # "com.google.fonts/check/os2_metrics_match_hhea",
     # "com.google.fonts/check/unwanted_tables",
+    "com.google.fonts/check/outline_jaggy_segments",  # too many unactionable warnings
+    "com.google.fonts/check/outline_semi_vertical",  # design rather than QA problem
 )
 
 ATTRIBUTES = {

--- a/qa/check-outlines.py
+++ b/qa/check-outlines.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from fontbakery.checkrunner import Section
+from fontbakery.fonts_profile import profile_factory
+
+profile_imports = ("fontbakery.profiles.universal",)
+profile = profile_factory(default_section=Section("Google Sans Outline Checks"))
+
+OUTLINE_PROFILE_CHECKS = [
+    "com.google.fonts/check/outline_jaggy_segments",
+    "com.google.fonts/check/outline_semi_vertical",
+]
+
+
+def check_skip_filter(checkid, font=None, **iterargs):
+    if font and checkid not in OUTLINE_PROFILE_CHECKS:
+        return False, ("Check skipped in Google Sans outline profile")
+    return True, None
+
+
+profile.check_skip_filter = check_skip_filter
+profile.auto_register(globals())
+profile.test_expected_checks(OUTLINE_PROFILE_CHECKS)


### PR DESCRIPTION
Skip outline checks for QA purposes, as especially the statics produce a lot of unactionable warnings.