### PR TITLE
Optimize GPOS table at optimization level = 5 with fontTools v4.25.0 update

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -26,7 +26,7 @@ PYTHON3_EXE=python3
 #    NOTE: this builds from a venv install to support
 #          pinned dependency versions
 # --------------------------------------------------------
-FONTMAKE_EXE=fontmake --verbose WARNING
+FONTMAKE_EXE=FONTTOOLS_GPOS_COMPACT_MODE=5 fontmake --verbose WARNING
 
 # --------------------------------------------------------
 #  Source file path definitions


### PR DESCRIPTION
This is to make sure that the CI still runs when using directly my work-in-progress branch from fonttools to build the fonts.

TODO:
- [x] Rebase once the Georgian regression tests are sorted out as part of the Georgian merge (@madig please notify me when this is solved)
- [x] Make sure file size changes reported by the CI here indicate the expected savings
- [x] Make sure shaping tests still good (indicating no functional changes, only binary layout)
- [x] ~~Copy-paste the fonttools code into this repository for future-proof builds of v5.000~~
- [x] If PR https://github.com/fonttools/fonttools/pull/2326 is released in time, delete the fonttools code from here and update requirements to point at new release. (update: we will use the fonttools lib repo directly rather than vendored sources in this project repo)

---

@chrissimpkins edit below

This is a file size optimization of the GPOS table that reduces our overall static and variable font file sizes by ~ 25% and requires fontTools lib >=4.25.0.  We are merging this with the intent to include these updates in the Google Sans v5.000 release.