### PR TITLE
Import new Berlow two and circled numbers

### DIFF
--- a/scripts/gs-merge-designspace.py
+++ b/scripts/gs-merge-designspace.py
@@ -121,6 +121,22 @@ if skip_export_glyphs_target:
 # Whether any of the sources to be imported is ungraded.
 import_is_ungraded = False
 
+
+def canonical_location(
+    location: Dict[str, float], designspace: DesignSpaceDocument
+) -> Dict[str, float]:
+    """Returns a canonical location from a raw Designspace location.
+
+    Vendor sources are inconsistent, so using user values and tags to match
+    source axes is hopefully more reliable.
+    """
+    name_to_axis = {a.name: a for a in designspace.axes}
+    name_to_tag = {a.name: a.tag for a in designspace.axes}
+    return {
+        name_to_tag[k]: name_to_axis[k].map_backward(v) for k, v in location.items()
+    }
+
+
 # Actually import now.
 for import_source in designspace_import.sources:
     if import_source.layerName is not None:
@@ -131,9 +147,10 @@ for import_source in designspace_import.sources:
         import_is_ungraded = True
 
     # Fill in the defaults if the import DS does not have e.g. a GRAD axis.
+    # Match axes by tags because those are more consistent across vendor sources.
     import_source_location = {
-        **designspace_target.default.location,
-        **import_source.location,
+        **canonical_location(designspace_target.default.location, designspace_target),
+        **canonical_location(import_source.location, designspace_import),
     }
 
     # Match import to target UFO.
@@ -141,7 +158,10 @@ for import_source in designspace_import.sources:
         target_source = next(
             s
             for s in designspace_target.sources
-            if s.location == import_source_location
+            if (
+                canonical_location(s.location, designspace_target)
+                == import_source_location
+            )
         )
     except StopIteration:
         try:

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-14.0" type="curve" smooth="yes"/>
-      <point x="630.0" y="-14.0"/>
-      <point x="797.0" y="153.0"/>
-      <point x="797.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="797.0" y="563.0"/>
-      <point x="630.0" y="730.0"/>
-      <point x="425.0" y="730.0" type="curve" smooth="yes"/>
-      <point x="220.0" y="730.0"/>
-      <point x="53.0" y="563.0"/>
-      <point x="53.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="153.0"/>
-      <point x="220.0" y="-14.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="34.0" type="curve" smooth="yes"/>
-      <point x="249.0" y="34.0"/>
-      <point x="101.0" y="182.0"/>
-      <point x="101.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="101.0" y="538.0"/>
-      <point x="249.0" y="682.0"/>
-      <point x="425.0" y="682.0" type="curve" smooth="yes"/>
-      <point x="606.0" y="682.0"/>
-      <point x="749.0" y="538.0"/>
-      <point x="749.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="749.0" y="182.0"/>
-      <point x="606.0" y="34.0"/>
+      <point x="425.0" y="35" type="curve" smooth="yes"/>
+      <point x="249" y="35"/>
+      <point x="102" y="182"/>
+      <point x="102" y="358.0" type="curve" smooth="yes"/>
+      <point x="102" y="537"/>
+      <point x="249" y="681"/>
+      <point x="425.0" y="681" type="curve" smooth="yes"/>
+      <point x="606" y="681"/>
+      <point x="748" y="537"/>
+      <point x="748" y="358.0" type="curve" smooth="yes"/>
+      <point x="748" y="182"/>
+      <point x="606" y="35"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="330.0"/>
-      <point x="288.0" y="373.0"/>
-      <point x="288.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="488.0"/>
-      <point x="264.0" y="527.0"/>
-      <point x="217.0" y="540.0" type="curve"/>
-      <point x="251.0" y="549.0"/>
-      <point x="276.0" y="578.0"/>
-      <point x="276.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="276.0" y="682.0"/>
-      <point x="235.0" y="724.0"/>
-      <point x="162.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="90.0" y="724.0"/>
-      <point x="47.0" y="682.0"/>
-      <point x="47.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="47.0" y="580.0"/>
-      <point x="70.0" y="550.0"/>
-      <point x="105.0" y="540.0" type="curve"/>
-      <point x="59.0" y="523.0"/>
-      <point x="35.0" y="488.0"/>
-      <point x="35.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="35.0" y="375.0"/>
-      <point x="84.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="295" y="373"/>
+      <point x="295" y="447" type="curve" smooth="yes"/>
+      <point x="295" y="488"/>
+      <point x="270" y="523"/>
+      <point x="232" y="540" type="curve"/>
+      <point x="264" y="553"/>
+      <point x="283" y="586"/>
+      <point x="283" y="617" type="curve" smooth="yes"/>
+      <point x="283" y="682"/>
+      <point x="230" y="724"/>
+      <point x="162" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="40" y="682"/>
+      <point x="40" y="617" type="curve" smooth="yes"/>
+      <point x="40" y="585"/>
+      <point x="59" y="557"/>
+      <point x="91" y="541" type="curve"/>
+      <point x="50" y="522"/>
+      <point x="28" y="488"/>
+      <point x="28" y="447" type="curve" smooth="yes"/>
+      <point x="28" y="375"/>
+      <point x="88" y="330"/>
     </contour>
     <contour>
-      <point x="162.0" y="374.0" type="curve" smooth="yes"/>
-      <point x="109.0" y="374.0"/>
-      <point x="82.0" y="404.0"/>
-      <point x="82.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="82.0" y="486.0"/>
-      <point x="110.0" y="516.0"/>
-      <point x="162.0" y="516.0" type="curve" smooth="yes"/>
-      <point x="216.0" y="516.0"/>
-      <point x="241.0" y="485.0"/>
-      <point x="241.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="405.0"/>
-      <point x="218.0" y="374.0"/>
+      <point x="162" y="379" type="curve" smooth="yes"/>
+      <point x="117" y="379"/>
+      <point x="84" y="408"/>
+      <point x="84" y="449" type="curve" smooth="yes"/>
+      <point x="84" y="489"/>
+      <point x="117" y="518"/>
+      <point x="162" y="518" type="curve" smooth="yes"/>
+      <point x="207" y="518"/>
+      <point x="239" y="488"/>
+      <point x="239" y="449" type="curve" smooth="yes"/>
+      <point x="239" y="409"/>
+      <point x="207" y="379"/>
     </contour>
     <contour>
-      <point x="162.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="556.0"/>
-      <point x="97.0" y="584.0"/>
-      <point x="97.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="97.0" y="656.0"/>
-      <point x="123.0" y="680.0"/>
-      <point x="162.0" y="680.0" type="curve" smooth="yes"/>
-      <point x="203.0" y="680.0"/>
-      <point x="226.0" y="655.0"/>
-      <point x="226.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="226.0" y="584.0"/>
-      <point x="204.0" y="556.0"/>
+      <point x="162" y="557" type="curve" smooth="yes"/>
+      <point x="125" y="557"/>
+      <point x="98" y="580"/>
+      <point x="98" y="614" type="curve" smooth="yes"/>
+      <point x="98" y="648"/>
+      <point x="125" y="672"/>
+      <point x="162" y="672" type="curve" smooth="yes"/>
+      <point x="199" y="672"/>
+      <point x="225" y="648"/>
+      <point x="225" y="614" type="curve" smooth="yes"/>
+      <point x="225" y="580"/>
+      <point x="199" y="557"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,72 +4,72 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="426" y="231" type="curve" smooth="yes"/>
-      <point x="462" y="231"/>
-      <point x="487" y="255"/>
-      <point x="487" y="287" type="curve" smooth="yes"/>
-      <point x="487" y="319"/>
-      <point x="462" y="343"/>
-      <point x="426" y="343" type="curve" smooth="yes"/>
-      <point x="390" y="343"/>
-      <point x="364" y="320"/>
-      <point x="364" y="287" type="curve" smooth="yes"/>
-      <point x="364" y="254"/>
-      <point x="390" y="231"/>
+      <point x="426" y="199.0" type="curve" smooth="yes"/>
+      <point x="481" y="199"/>
+      <point x="516" y="232.0"/>
+      <point x="516" y="278.0" type="curve" smooth="yes"/>
+      <point x="516.0" y="319.0"/>
+      <point x="483" y="352"/>
+      <point x="426" y="352.0" type="curve" smooth="yes"/>
+      <point x="369.0" y="352"/>
+      <point x="335" y="323"/>
+      <point x="335" y="277.0" type="curve" smooth="yes"/>
+      <point x="335.0" y="227.0"/>
+      <point x="371.0" y="199.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="426" y="163.0" type="curve" smooth="yes"/>
+      <point x="353" y="163.0"/>
+      <point x="295" y="208"/>
+      <point x="295" y="277.0" type="curve"/>
+      <point x="295" y="317"/>
+      <point x="321.0" y="356.0"/>
+      <point x="366" y="373.0" type="curve"/>
+      <point x="328" y="388.0"/>
+      <point x="309" y="418.0"/>
+      <point x="309" y="450.0" type="curve" smooth="yes"/>
+      <point x="309" y="515.0"/>
+      <point x="359" y="557.0"/>
+      <point x="426" y="557.0" type="curve" smooth="yes"/>
+      <point x="493" y="557.0"/>
+      <point x="542" y="515.0"/>
+      <point x="542" y="450.0" type="curve" smooth="yes"/>
+      <point x="542" y="419.0"/>
+      <point x="518" y="388.0"/>
+      <point x="479" y="373.0" type="curve"/>
+      <point x="531" y="356.0"/>
+      <point x="556.0" y="321.0"/>
+      <point x="556.0" y="278.0" type="curve" smooth="yes"/>
+      <point x="556.0" y="206.0"/>
+      <point x="499" y="163.0"/>
     </contour>
     <contour>
-      <point x="426" y="399" type="curve" smooth="yes"/>
-      <point x="455" y="399"/>
-      <point x="475" y="417"/>
-      <point x="475" y="445" type="curve" smooth="yes"/>
-      <point x="475" y="472"/>
-      <point x="455" y="491"/>
-      <point x="426" y="491" type="curve" smooth="yes"/>
-      <point x="397" y="491"/>
-      <point x="376" y="472"/>
-      <point x="376" y="445" type="curve" smooth="yes"/>
-      <point x="376" y="417"/>
-      <point x="397" y="399"/>
+      <point x="426" y="383.0" type="curve" smooth="yes"/>
+      <point x="468" y="383.0"/>
+      <point x="499" y="410.0"/>
+      <point x="499" y="451.0" type="curve" smooth="yes"/>
+      <point x="499" y="492.0"/>
+      <point x="468" y="521.0"/>
+      <point x="426" y="521.0" type="curve" smooth="yes"/>
+      <point x="383" y="521.0"/>
+      <point x="352" y="492.0"/>
+      <point x="352" y="451.0" type="curve" smooth="yes"/>
+      <point x="352" y="410.0"/>
+      <point x="383" y="383.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,32 +4,32 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="248.0"/>
-      <point x="492.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="465.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="343.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="247.0"/>
-      <point x="387.0" y="222.0"/>
+      <point x="426" y="231" type="curve" smooth="yes"/>
+      <point x="462" y="231"/>
+      <point x="487" y="255"/>
+      <point x="487" y="287" type="curve" smooth="yes"/>
+      <point x="487" y="319"/>
+      <point x="462" y="343"/>
+      <point x="426" y="343" type="curve" smooth="yes"/>
+      <point x="390" y="343"/>
+      <point x="364" y="320"/>
+      <point x="364" y="287" type="curve" smooth="yes"/>
+      <point x="364" y="254"/>
+      <point x="390" y="231"/>
     </contour>
     <contour>
       <point x="426.0" y="163.0" type="curve" smooth="yes"/>
@@ -58,18 +58,18 @@
       <point x="500.0" y="163.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="458.0" y="397.0"/>
-      <point x="480.0" y="417.0"/>
-      <point x="480.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="477.0"/>
-      <point x="458.0" y="498.0"/>
-      <point x="426.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="498.0"/>
-      <point x="371.0" y="477.0"/>
-      <point x="371.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="417.0"/>
-      <point x="394.0" y="397.0"/>
+      <point x="426" y="399" type="curve" smooth="yes"/>
+      <point x="455" y="399"/>
+      <point x="475" y="417"/>
+      <point x="475" y="445" type="curve" smooth="yes"/>
+      <point x="475" y="472"/>
+      <point x="455" y="491"/>
+      <point x="426" y="491" type="curve" smooth="yes"/>
+      <point x="397" y="491"/>
+      <point x="376" y="472"/>
+      <point x="376" y="445" type="curve" smooth="yes"/>
+      <point x="376" y="417"/>
+      <point x="397" y="399"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="eight.numerator" xOffset="264" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>eight.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="162.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="331.0"/>
-      <point x="289.0" y="386.0"/>
-      <point x="289.0" y="461.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="539.0"/>
-      <point x="249.0" y="589.0"/>
-      <point x="178.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="133.0" y="589.0"/>
-      <point x="100.0" y="570.0"/>
-      <point x="84.0" y="548.0" type="curve"/>
-      <point x="101.0" y="673.0" type="line"/>
-      <point x="268.0" y="673.0" type="line"/>
-      <point x="268.0" y="716.0" type="line"/>
-      <point x="71.0" y="716.0" type="line"/>
-      <point x="46.0" y="521.0" type="line"/>
-      <point x="85.0" y="504.0" type="line"/>
-      <point x="104.0" y="531.0"/>
-      <point x="130.0" y="546.0"/>
-      <point x="165.0" y="546.0" type="curve" smooth="yes"/>
-      <point x="212.0" y="546.0"/>
-      <point x="241.0" y="517.0"/>
-      <point x="241.0" y="462.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="406.0"/>
-      <point x="215.0" y="375.0"/>
-      <point x="165.0" y="375.0" type="curve" smooth="yes"/>
-      <point x="119.0" y="375.0"/>
-      <point x="84.0" y="405.0"/>
-      <point x="76.0" y="443.0" type="curve"/>
-      <point x="33.0" y="436.0" type="line"/>
-      <point x="45.0" y="371.0"/>
-      <point x="92.0" y="331.0"/>
+      <point x="162" y="331" type="curve" smooth="yes"/>
+      <point x="238" y="331"/>
+      <point x="290" y="386"/>
+      <point x="290.0" y="465" type="curve" smooth="yes"/>
+      <point x="290" y="539"/>
+      <point x="249" y="589"/>
+      <point x="172" y="589" type="curve" smooth="yes"/>
+      <point x="142" y="589"/>
+      <point x="107" y="570"/>
+      <point x="93" y="554" type="curve"/>
+      <point x="108" y="667" type="line"/>
+      <point x="273" y="667" type="line"/>
+      <point x="273" y="716" type="line"/>
+      <point x="66" y="716" type="line"/>
+      <point x="41" y="521" type="line"/>
+      <point x="92" y="502" type="line"/>
+      <point x="107" y="526"/>
+      <point x="133" y="543"/>
+      <point x="162" y="543" type="curve" smooth="yes"/>
+      <point x="204" y="543"/>
+      <point x="233" y="519.0"/>
+      <point x="233" y="462" type="curve" smooth="yes"/>
+      <point x="233" y="405"/>
+      <point x="204" y="379"/>
+      <point x="162" y="379" type="curve" smooth="yes"/>
+      <point x="121" y="379"/>
+      <point x="89" y="412"/>
+      <point x="82" y="447" type="curve"/>
+      <point x="32" y="435" type="line"/>
+      <point x="43" y="374"/>
+      <point x="92" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,50 +4,50 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="426.0" y="163.0" type="curve" smooth="yes"/>
       <point x="356.0" y="163.0"/>
       <point x="304.0" y="202.0"/>
       <point x="292.0" y="267.0" type="curve"/>
-      <point x="356.0" y="280.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="388.0" y="222.0"/>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="249.0"/>
-      <point x="492.0" y="294.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="339.0"/>
-      <point x="465.0" y="365.0"/>
-      <point x="426.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="397.0" y="365.0"/>
-      <point x="375.0" y="352.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
+      <point x="362" y="283.0" type="line"/>
+      <point x="368" y="256.0"/>
+      <point x="391" y="233.0"/>
+      <point x="426" y="233.0" type="curve" smooth="yes"/>
+      <point x="461" y="233.0"/>
+      <point x="486" y="257.0"/>
+      <point x="486" y="296.0" type="curve" smooth="yes"/>
+      <point x="486" y="336.0"/>
+      <point x="461" y="359.0"/>
+      <point x="426" y="359.0" type="curve" smooth="yes"/>
+      <point x="399" y="359.0"/>
+      <point x="379" y="347.0"/>
+      <point x="366" y="328.0" type="curve"/>
       <point x="305.0" y="353.0" type="line"/>
       <point x="330.0" y="548.0" type="line"/>
       <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="492.0" type="line"/>
-      <point x="382.0" y="492.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
+      <point x="537.0" y="482.0" type="line"/>
+      <point x="382.0" y="482.0" type="line"/>
+      <point x="369.0" y="400.0" type="line"/>
+      <point x="383.0" y="416.0"/>
+      <point x="406" y="425"/>
+      <point x="436.0" y="425.0" type="curve" smooth="yes"/>
+      <point x="515.0" y="425.0"/>
+      <point x="561" y="375"/>
+      <point x="561.0" y="296.0" type="curve" smooth="yes"/>
+      <point x="561" y="218"/>
       <point x="508.0" y="163.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,51 +4,51 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="362" y="283.0" type="line"/>
-      <point x="368" y="256.0"/>
-      <point x="391" y="233.0"/>
-      <point x="426" y="233.0" type="curve" smooth="yes"/>
-      <point x="461" y="233.0"/>
-      <point x="486" y="257.0"/>
-      <point x="486" y="296.0" type="curve" smooth="yes"/>
-      <point x="486" y="336.0"/>
-      <point x="461" y="359.0"/>
-      <point x="426" y="359.0" type="curve" smooth="yes"/>
-      <point x="399" y="359.0"/>
-      <point x="379" y="347.0"/>
-      <point x="366" y="328.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
+      <point x="429" y="163" type="curve" smooth="yes"/>
+      <point x="356" y="163"/>
+      <point x="312.0" y="208.0"/>
+      <point x="301.0" y="268.0" type="curve"/>
+      <point x="339.0" y="277" type="line"/>
+      <point x="349.0" y="227"/>
+      <point x="380" y="202"/>
+      <point x="429" y="202.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="202"/>
+      <point x="512" y="236"/>
+      <point x="512.0" y="292" type="curve" smooth="yes"/>
+      <point x="512.0" y="352.0"/>
+      <point x="478" y="384.0"/>
+      <point x="426.0" y="384" type="curve" smooth="yes"/>
+      <point x="391" y="384"/>
+      <point x="361.0" y="360"/>
+      <point x="348.0" y="336" type="curve"/>
+      <point x="315.0" y="348.0" type="line"/>
+      <point x="340.0" y="548.0" type="line"/>
       <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="482.0" type="line"/>
-      <point x="382.0" y="482.0" type="line"/>
-      <point x="369.0" y="400.0" type="line"/>
-      <point x="383.0" y="416.0"/>
-      <point x="406" y="425"/>
-      <point x="436.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="515.0" y="425.0"/>
-      <point x="561" y="375"/>
-      <point x="561.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="561" y="218"/>
-      <point x="508.0" y="163.0"/>
+      <point x="537.0" y="507.0" type="line"/>
+      <point x="367.0" y="507.0" type="line"/>
+      <point x="351.0" y="380.0" type="line"/>
+      <point x="369.0" y="403.0"/>
+      <point x="406" y="419"/>
+      <point x="441" y="419.0" type="curve" smooth="yes"/>
+      <point x="503.0" y="419.0"/>
+      <point x="552.0" y="371.0"/>
+      <point x="552.0" y="293.0" type="curve" smooth="yes"/>
+      <point x="552.0" y="218.0"/>
+      <point x="502.0" y="163.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="five.numerator" xOffset="265" yOffset="-168"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>five.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="30.0" y="423.0" type="line"/>
-      <point x="321.0" y="423.0" type="line"/>
-      <point x="321.0" y="466.0" type="line"/>
-      <point x="93.0" y="466.0" type="line"/>
-      <point x="215.0" y="644.0" type="line"/>
-      <point x="219.0" y="644.0" type="line"/>
-      <point x="219.0" y="338.0" type="line"/>
-      <point x="264.0" y="338.0" type="line"/>
-      <point x="264.0" y="716.0" type="line"/>
-      <point x="216.0" y="716.0" type="line"/>
-      <point x="30.0" y="455.0" type="line"/>
+      <point x="30" y="426" type="line"/>
+      <point x="321" y="426" type="line"/>
+      <point x="321" y="472" type="line"/>
+      <point x="88" y="472" type="line"/>
+      <point x="205" y="630" type="line"/>
+      <point x="211" y="630" type="line"/>
+      <point x="211" y="338" type="line"/>
+      <point x="265" y="338" type="line"/>
+      <point x="265" y="716" type="line"/>
+      <point x="214" y="716" type="line"/>
+      <point x="30" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="331.0" y="305.0" type="line"/>
-      <point x="433.0" y="305.0" type="line"/>
-      <point x="433.0" y="450.0" type="line"/>
-      <point x="429.0" y="450.0" type="line"/>
+      <point x="339.0" y="309.0" type="line"/>
+      <point x="428.0" y="309.0" type="line"/>
+      <point x="428.0" y="443.0" type="line"/>
+      <point x="426.0" y="443.0" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="171.0" type="line"/>
-      <point x="433.0" y="249.0" type="line"/>
-      <point x="256.0" y="249.0" type="line"/>
-      <point x="256.0" y="293.0" type="line"/>
-      <point x="437.0" y="549.0" type="line"/>
-      <point x="498.0" y="549.0" type="line"/>
-      <point x="498.0" y="305.0" type="line"/>
-      <point x="547.0" y="305.0" type="line"/>
-      <point x="547.0" y="249.0" type="line"/>
-      <point x="498.0" y="249.0" type="line"/>
-      <point x="498.0" y="171.0" type="line"/>
+      <point x="428.0" y="171.0" type="line"/>
+      <point x="428.0" y="244.0" type="line"/>
+      <point x="256.0" y="244.0" type="line"/>
+      <point x="256.0" y="300.0" type="line"/>
+      <point x="427.0" y="549.0" type="line"/>
+      <point x="505.0" y="549.0" type="line"/>
+      <point x="505.0" y="309.0" type="line"/>
+      <point x="547.0" y="309.0" type="line"/>
+      <point x="547.0" y="244.0" type="line"/>
+      <point x="505.0" y="244.0" type="line"/>
+      <point x="505.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="339.0" y="309.0" type="line"/>
-      <point x="428.0" y="309.0" type="line"/>
-      <point x="428.0" y="443.0" type="line"/>
-      <point x="426.0" y="443.0" type="line"/>
+      <point x="316.0" y="300.0" type="line"/>
+      <point x="438.0" y="300.0" type="line"/>
+      <point x="438.0" y="465.0" type="line"/>
+      <point x="429.0" y="465.0" type="line"/>
     </contour>
     <contour>
-      <point x="428.0" y="171.0" type="line"/>
-      <point x="428.0" y="244.0" type="line"/>
-      <point x="256.0" y="244.0" type="line"/>
-      <point x="256.0" y="300.0" type="line"/>
-      <point x="427.0" y="549.0" type="line"/>
-      <point x="505.0" y="549.0" type="line"/>
-      <point x="505.0" y="309.0" type="line"/>
-      <point x="547.0" y="309.0" type="line"/>
-      <point x="547.0" y="244.0" type="line"/>
-      <point x="505.0" y="244.0" type="line"/>
-      <point x="505.0" y="171.0" type="line"/>
+      <point x="438.0" y="171.0" type="line"/>
+      <point x="438.0" y="259.0" type="line"/>
+      <point x="256.0" y="259.0" type="line"/>
+      <point x="256.0" y="288.0" type="line"/>
+      <point x="442.0" y="549.0" type="line"/>
+      <point x="488.0" y="549.0" type="line"/>
+      <point x="488.0" y="300.0" type="line"/>
+      <point x="547.0" y="300.0" type="line"/>
+      <point x="547.0" y="259.0" type="line"/>
+      <point x="488.0" y="259.0" type="line"/>
+      <point x="488.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="four.numerator" xOffset="230" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>four.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="322"/>
   <outline>
     <contour>
-      <point x="130.0" y="332.0" type="line"/>
-      <point x="174.0" y="351.0"/>
-      <point x="215.0" y="383.0"/>
-      <point x="244.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="462.0"/>
-      <point x="293.0" y="509.0"/>
-      <point x="293.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="293.0" y="670.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="158.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="88.0" y="724.0"/>
-      <point x="30.0" y="670.0"/>
-      <point x="30.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="529.0"/>
-      <point x="64.0" y="474.0"/>
-      <point x="138.0" y="474.0" type="curve" smooth="yes"/>
-      <point x="187.0" y="474.0"/>
-      <point x="239.0" y="499.0"/>
-      <point x="263.0" y="534.0" type="curve"/>
-      <point x="229.0" y="451.0"/>
-      <point x="179.0" y="404.0"/>
-      <point x="114.0" y="372.0" type="curve"/>
+      <point x="131" y="332" type="line"/>
+      <point x="173" y="349"/>
+      <point x="216" y="385"/>
+      <point x="246" y="425" type="curve" smooth="yes"/>
+      <point x="275" y="464"/>
+      <point x="293" y="514"/>
+      <point x="293" y="568" type="curve" smooth="yes"/>
+      <point x="293" y="670"/>
+      <point x="236" y="724"/>
+      <point x="160" y="724" type="curve" smooth="yes"/>
+      <point x="88" y="724"/>
+      <point x="28" y="670"/>
+      <point x="28" y="598" type="curve" smooth="yes"/>
+      <point x="28" y="529"/>
+      <point x="72" y="474"/>
+      <point x="139" y="474" type="curve" smooth="yes"/>
+      <point x="178" y="474"/>
+      <point x="221" y="491"/>
+      <point x="238" y="520" type="curve"/>
+      <point x="231" y="467"/>
+      <point x="172" y="401"/>
+      <point x="109" y="371" type="curve"/>
     </contour>
     <contour>
-      <point x="159.0" y="514.0" type="curve" smooth="yes"/>
-      <point x="107.0" y="514.0"/>
-      <point x="74.0" y="551.0"/>
-      <point x="74.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="74.0" y="642.0"/>
-      <point x="107.0" y="681.0"/>
-      <point x="159.0" y="681.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="681.0"/>
-      <point x="245.0" y="642.0"/>
-      <point x="245.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="551.0"/>
-      <point x="213.0" y="514.0"/>
+      <point x="161" y="520" type="curve" smooth="yes"/>
+      <point x="114" y="520"/>
+      <point x="85" y="554"/>
+      <point x="85" y="597" type="curve" smooth="yes"/>
+      <point x="85" y="640"/>
+      <point x="114" y="675"/>
+      <point x="161" y="675" type="curve" smooth="yes"/>
+      <point x="208" y="675"/>
+      <point x="237" y="640"/>
+      <point x="237" y="597" type="curve" smooth="yes"/>
+      <point x="237" y="554"/>
+      <point x="208" y="520"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="396.0" y="159.0" type="curve"/>
-      <point x="367.0" y="206.0" type="line"/>
-      <point x="432.0" y="238.0"/>
-      <point x="484.0" y="285.0"/>
-      <point x="497.0" y="345.0" type="curve"/>
-      <point x="478.0" y="316.0"/>
-      <point x="443.0" y="301.0"/>
-      <point x="404.0" y="301.0" type="curve" smooth="yes"/>
-      <point x="337.0" y="301.0"/>
-      <point x="293.0" y="356.0"/>
-      <point x="293.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="293.0" y="497.0"/>
-      <point x="353.0" y="551.0"/>
-      <point x="425.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="501.0" y="551.0"/>
-      <point x="561.0" y="497.0"/>
-      <point x="561.0" y="395.0" type="curve" smooth="yes"/>
-      <point x="561.0" y="336.0"/>
-      <point x="541.0" y="289.0"/>
-      <point x="512.0" y="250.0" type="curve" smooth="yes"/>
-      <point x="482.0" y="210.0"/>
-      <point x="440.0" y="178.0"/>
+      <point x="395.0" y="158.0" type="curve"/>
+      <point x="360.0" y="214.0" type="line"/>
+      <point x="425.0" y="246.0"/>
+      <point x="471.0" y="285.0"/>
+      <point x="486.0" y="333.0" type="curve"/>
+      <point x="466.0" y="307.0"/>
+      <point x="442.0" y="300.0"/>
+      <point x="403.0" y="300.0" type="curve" smooth="yes"/>
+      <point x="336.0" y="300.0"/>
+      <point x="289.0" y="355.0"/>
+      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="496.0"/>
+      <point x="352.0" y="550.0"/>
+      <point x="424.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="500.0" y="550.0"/>
+      <point x="563.0" y="496.0"/>
+      <point x="563.0" y="394.0" type="curve" smooth="yes"/>
+      <point x="563.0" y="335.0"/>
+      <point x="540.0" y="288.0"/>
+      <point x="511.0" y="249.0" type="curve" smooth="yes"/>
+      <point x="481.0" y="209.0"/>
+      <point x="439.0" y="177.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="357.0"/>
-      <point x="492.0" y="387.0"/>
-      <point x="492.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="461.0"/>
-      <point x="467.0" y="492.0"/>
-      <point x="426.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="385.0" y="492.0"/>
-      <point x="360.0" y="461.0"/>
-      <point x="360.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="360.0" y="387.0"/>
-      <point x="385.0" y="357.0"/>
+      <point x="425.0" y="363.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="363.0"/>
+      <point x="486.0" y="390.0"/>
+      <point x="486.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="486.0" y="456.0"/>
+      <point x="463.0" y="484.0"/>
+      <point x="425.0" y="484.0" type="curve" smooth="yes"/>
+      <point x="387.0" y="484.0"/>
+      <point x="364.0" y="456.0"/>
+      <point x="364.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="364.0" y="390.0"/>
+      <point x="387.0" y="363.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="395.0" y="158.0" type="curve"/>
-      <point x="360.0" y="214.0" type="line"/>
-      <point x="425.0" y="246.0"/>
-      <point x="471.0" y="285.0"/>
-      <point x="486.0" y="333.0" type="curve"/>
-      <point x="466.0" y="307.0"/>
-      <point x="442.0" y="300.0"/>
-      <point x="403.0" y="300.0" type="curve" smooth="yes"/>
-      <point x="336.0" y="300.0"/>
-      <point x="289.0" y="355.0"/>
-      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="496.0"/>
-      <point x="352.0" y="550.0"/>
-      <point x="424.0" y="550.0" type="curve" smooth="yes"/>
-      <point x="500.0" y="550.0"/>
-      <point x="563.0" y="496.0"/>
-      <point x="563.0" y="394.0" type="curve" smooth="yes"/>
-      <point x="563.0" y="335.0"/>
-      <point x="540.0" y="288.0"/>
-      <point x="511.0" y="249.0" type="curve" smooth="yes"/>
-      <point x="481.0" y="209.0"/>
-      <point x="439.0" y="177.0"/>
+      <point x="393.0" y="162.0" type="curve"/>
+      <point x="372.0" y="195.0" type="line"/>
+      <point x="443.0" y="225.0"/>
+      <point x="505.0" y="294.0"/>
+      <point x="518.0" y="363.0" type="curve"/>
+      <point x="501.0" y="333.0"/>
+      <point x="455.0" y="301.0"/>
+      <point x="403.0" y="301.0" type="curve" smooth="yes"/>
+      <point x="336.0" y="301.0"/>
+      <point x="292.0" y="356.0"/>
+      <point x="292.0" y="425.0" type="curve" smooth="yes"/>
+      <point x="292.0" y="497.0"/>
+      <point x="352.0" y="551.0"/>
+      <point x="424.0" y="551.0" type="curve" smooth="yes"/>
+      <point x="500.0" y="551.0"/>
+      <point x="560.0" y="497.0"/>
+      <point x="560.0" y="395.0" type="curve" smooth="yes"/>
+      <point x="560.0" y="336.0"/>
+      <point x="537.0" y="293.0"/>
+      <point x="508.0" y="254.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="214.0"/>
+      <point x="434.0" y="180.0"/>
     </contour>
     <contour>
-      <point x="425.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="363.0"/>
-      <point x="486.0" y="390.0"/>
-      <point x="486.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="486.0" y="456.0"/>
-      <point x="463.0" y="484.0"/>
-      <point x="425.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="484.0"/>
-      <point x="364.0" y="456.0"/>
-      <point x="364.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="364.0" y="390.0"/>
-      <point x="387.0" y="363.0"/>
+      <point x="425.0" y="339.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="339.0"/>
+      <point x="510.0" y="377.0"/>
+      <point x="510.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="510.0" y="471.0"/>
+      <point x="478.0" y="510.0"/>
+      <point x="425.0" y="510.0" type="curve" smooth="yes"/>
+      <point x="372.0" y="510.0"/>
+      <point x="340.0" y="471.0"/>
+      <point x="340.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="340.0" y="377.0"/>
+      <point x="372.0" y="339.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="nine.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>nine.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="131.0" y="338.0" type="line"/>
-      <point x="178.0" y="338.0" type="line"/>
-      <point x="178.0" y="716.0" type="line"/>
-      <point x="130.0" y="716.0" type="line"/>
-      <point x="32.0" y="644.0" type="line"/>
-      <point x="24.0" y="576.0" type="line"/>
-      <point x="131.0" y="651.0" type="line"/>
+      <point x="125" y="338" type="line"/>
+      <point x="182" y="338" type="line"/>
+      <point x="182" y="716" type="line"/>
+      <point x="133" y="716" type="line"/>
+      <point x="32" y="631" type="line"/>
+      <point x="32" y="565" type="line"/>
+      <point x="125" y="649" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="396.0" y="171.0" type="line"/>
-      <point x="396.0" y="452.0" type="line"/>
-      <point x="307.0" y="388.0" type="line"/>
-      <point x="307.0" y="477.0" type="line"/>
-      <point x="405.0" y="549.0" type="line"/>
-      <point x="481.0" y="549.0" type="line"/>
-      <point x="481.0" y="171.0" type="line"/>
+      <point x="410.0" y="171.0" type="line"/>
+      <point x="410.0" y="484.0" type="line"/>
+      <point x="317.0" y="412.0" type="line"/>
+      <point x="317.0" y="469.0" type="line"/>
+      <point x="422.0" y="549.0" type="line"/>
+      <point x="461.0" y="549.0" type="line"/>
+      <point x="461.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="406.0" y="171.0" type="line"/>
-      <point x="406.0" y="462.0" type="line"/>
-      <point x="317.0" y="398.0" type="line"/>
-      <point x="317.0" y="477.0" type="line"/>
-      <point x="415.0" y="549.0" type="line"/>
-      <point x="471.0" y="549.0" type="line"/>
-      <point x="471.0" y="171.0" type="line"/>
+      <point x="396.0" y="171.0" type="line"/>
+      <point x="396.0" y="452.0" type="line"/>
+      <point x="307.0" y="388.0" type="line"/>
+      <point x="307.0" y="477.0" type="line"/>
+      <point x="405.0" y="549.0" type="line"/>
+      <point x="481.0" y="549.0" type="line"/>
+      <point x="481.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="one.numerator" xOffset="285" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>one.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="162.0" y="338.0" type="line"/>
-      <point x="159.0" y="461.0"/>
-      <point x="199.0" y="596.0"/>
-      <point x="283.0" y="676.0" type="curve"/>
-      <point x="283.0" y="716.0" type="line"/>
-      <point x="28.0" y="716.0" type="line"/>
-      <point x="28.0" y="672.0" type="line"/>
-      <point x="233.0" y="672.0" type="line"/>
-      <point x="176.0" y="609.0"/>
-      <point x="103.0" y="484.0"/>
-      <point x="106.0" y="330.0" type="curve"/>
+      <point x="152" y="338" type="line"/>
+      <point x="152" y="460"/>
+      <point x="199" y="588"/>
+      <point x="283" y="668" type="curve"/>
+      <point x="283" y="716" type="line"/>
+      <point x="28" y="716" type="line"/>
+      <point x="28" y="667" type="line"/>
+      <point x="221" y="667" type="line"/>
+      <point x="169" y="612"/>
+      <point x="94" y="491"/>
+      <point x="94" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="368.0" y="171.0" type="line"/>
-      <point x="368.0" y="324.0"/>
-      <point x="431.0" y="427.0"/>
-      <point x="489.0" y="490.0" type="curve"/>
-      <point x="306.0" y="490.0" type="line"/>
+      <point x="444.0" y="171.0" type="curve"/>
+      <point x="362.0" y="171.0" type="line"/>
+      <point x="362.0" y="324.0"/>
+      <point x="425.0" y="413.0"/>
+      <point x="483.0" y="476.0" type="curve"/>
+      <point x="306.0" y="476.0" type="line"/>
       <point x="306.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="565.0" y="549.0" type="line"/>
+      <point x="565.0" y="489.0" type="line"/>
+      <point x="483.0" y="409.0"/>
+      <point x="444.0" y="293.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="444.0" y="171.0" type="curve"/>
-      <point x="362.0" y="171.0" type="line"/>
-      <point x="362.0" y="324.0"/>
-      <point x="425.0" y="413.0"/>
-      <point x="483.0" y="476.0" type="curve"/>
-      <point x="306.0" y="476.0" type="line"/>
+      <point x="435.0" y="171.0" type="curve"/>
+      <point x="383.0" y="171.0" type="line"/>
+      <point x="383.0" y="324.0"/>
+      <point x="451.0" y="442.0"/>
+      <point x="509.0" y="505.0" type="curve"/>
+      <point x="306.0" y="505.0" type="line"/>
       <point x="306.0" y="549.0" type="line"/>
-      <point x="565.0" y="549.0" type="line"/>
-      <point x="565.0" y="489.0" type="line"/>
-      <point x="483.0" y="409.0"/>
-      <point x="444.0" y="293.0"/>
+      <point x="561.0" y="549.0" type="line"/>
+      <point x="561.0" y="509.0" type="line"/>
+      <point x="477.0" y="429.0"/>
+      <point x="435.0" y="293.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="161.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="330.0"/>
-      <point x="290.0" y="384.0"/>
-      <point x="290.0" y="456.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="525.0"/>
-      <point x="256.0" y="580.0"/>
-      <point x="182.0" y="580.0" type="curve" smooth="yes"/>
-      <point x="133.0" y="580.0"/>
-      <point x="81.0" y="555.0"/>
-      <point x="56.0" y="520.0" type="curve"/>
-      <point x="90.0" y="603.0"/>
-      <point x="141.0" y="650.0"/>
-      <point x="206.0" y="682.0" type="curve"/>
-      <point x="190.0" y="722.0" type="line"/>
-      <point x="146.0" y="703.0"/>
-      <point x="105.0" y="671.0"/>
-      <point x="76.0" y="631.0" type="curve" smooth="yes"/>
-      <point x="47.0" y="592.0"/>
-      <point x="27.0" y="545.0"/>
-      <point x="27.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="27.0" y="384.0"/>
-      <point x="86.0" y="330.0"/>
+      <point x="161" y="330" type="curve" smooth="yes"/>
+      <point x="233" y="330"/>
+      <point x="293" y="384"/>
+      <point x="293" y="456" type="curve" smooth="yes"/>
+      <point x="293" y="525"/>
+      <point x="249" y="580"/>
+      <point x="182" y="580" type="curve" smooth="yes"/>
+      <point x="143" y="580"/>
+      <point x="100" y="563"/>
+      <point x="83" y="534" type="curve"/>
+      <point x="90" y="587"/>
+      <point x="149" y="653"/>
+      <point x="212" y="683" type="curve"/>
+      <point x="190" y="722" type="line"/>
+      <point x="148" y="705"/>
+      <point x="105" y="669"/>
+      <point x="75" y="629" type="curve" smooth="yes"/>
+      <point x="46" y="590"/>
+      <point x="28" y="540"/>
+      <point x="28" y="486" type="curve" smooth="yes"/>
+      <point x="28" y="384"/>
+      <point x="85" y="330"/>
     </contour>
     <contour>
-      <point x="160.0" y="373.0" type="curve" smooth="yes"/>
-      <point x="107.0" y="373.0"/>
-      <point x="75.0" y="412.0"/>
-      <point x="75.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="75.0" y="503.0"/>
-      <point x="107.0" y="540.0"/>
-      <point x="160.0" y="540.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="540.0"/>
-      <point x="246.0" y="503.0"/>
-      <point x="246.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="246.0" y="412.0"/>
-      <point x="213.0" y="373.0"/>
+      <point x="160" y="379" type="curve" smooth="yes"/>
+      <point x="113" y="379"/>
+      <point x="84" y="414"/>
+      <point x="84" y="457" type="curve" smooth="yes"/>
+      <point x="84" y="500"/>
+      <point x="113" y="534"/>
+      <point x="160" y="534" type="curve" smooth="yes"/>
+      <point x="207" y="534"/>
+      <point x="236" y="500"/>
+      <point x="236" y="457" type="curve" smooth="yes"/>
+      <point x="236" y="414"/>
+      <point x="207" y="379"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,55 +4,55 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="418.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="459.0" y="228.0"/>
-      <point x="484.0" y="259.0"/>
-      <point x="484.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="333.0"/>
-      <point x="459.0" y="363.0"/>
-      <point x="418.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="377.0" y="363.0"/>
-      <point x="352.0" y="333.0"/>
-      <point x="352.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="259.0"/>
-      <point x="377.0" y="228.0"/>
+      <point x="418" y="235" type="curve" smooth="yes"/>
+      <point x="456" y="235"/>
+      <point x="479" y="263"/>
+      <point x="479" y="296" type="curve" smooth="yes"/>
+      <point x="479" y="329"/>
+      <point x="456" y="356"/>
+      <point x="418" y="356" type="curve" smooth="yes"/>
+      <point x="380" y="356"/>
+      <point x="357" y="329"/>
+      <point x="357" y="296" type="curve" smooth="yes"/>
+      <point x="357" y="263"/>
+      <point x="380" y="235"/>
     </contour>
     <contour>
       <point x="419.0" y="169.0" type="curve" smooth="yes"/>
       <point x="343.0" y="169.0"/>
-      <point x="283.0" y="223.0"/>
-      <point x="283.0" y="325.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="384.0"/>
+      <point x="280.0" y="223.0"/>
+      <point x="280.0" y="325.0" type="curve" smooth="yes"/>
+      <point x="280.0" y="384.0"/>
       <point x="303.0" y="431.0"/>
       <point x="332.0" y="470.0" type="curve" smooth="yes"/>
       <point x="362.0" y="510.0"/>
       <point x="404.0" y="542.0"/>
       <point x="448.0" y="561.0" type="curve"/>
-      <point x="477.0" y="514.0" type="line"/>
-      <point x="412.0" y="482.0"/>
-      <point x="360.0" y="435.0"/>
-      <point x="347.0" y="375.0" type="curve"/>
-      <point x="366.0" y="404.0"/>
+      <point x="483.0" y="505.0" type="line"/>
+      <point x="418.0" y="473.0"/>
+      <point x="372.0" y="434.0"/>
+      <point x="357.0" y="386.0" type="curve"/>
+      <point x="377.0" y="412.0"/>
       <point x="401.0" y="419.0"/>
       <point x="440.0" y="419.0" type="curve" smooth="yes"/>
       <point x="507.0" y="419.0"/>
-      <point x="551.0" y="364.0"/>
-      <point x="551.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="223.0"/>
+      <point x="554.0" y="364.0"/>
+      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="223.0"/>
       <point x="491.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,55 +4,55 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="418" y="235" type="curve" smooth="yes"/>
-      <point x="456" y="235"/>
-      <point x="479" y="263"/>
-      <point x="479" y="296" type="curve" smooth="yes"/>
-      <point x="479" y="329"/>
-      <point x="456" y="356"/>
-      <point x="418" y="356" type="curve" smooth="yes"/>
-      <point x="380" y="356"/>
-      <point x="357" y="329"/>
-      <point x="357" y="296" type="curve" smooth="yes"/>
-      <point x="357" y="263"/>
-      <point x="380" y="235"/>
+      <point x="418" y="210" type="curve" smooth="yes"/>
+      <point x="471" y="210"/>
+      <point x="503" y="249"/>
+      <point x="503" y="296" type="curve" smooth="yes"/>
+      <point x="503" y="343"/>
+      <point x="471" y="381"/>
+      <point x="418" y="381" type="curve" smooth="yes"/>
+      <point x="365" y="381"/>
+      <point x="333" y="343"/>
+      <point x="333" y="296" type="curve" smooth="yes"/>
+      <point x="333" y="249"/>
+      <point x="365" y="210"/>
     </contour>
     <contour>
       <point x="419.0" y="169.0" type="curve" smooth="yes"/>
       <point x="343.0" y="169.0"/>
-      <point x="280.0" y="223.0"/>
-      <point x="280.0" y="325.0" type="curve" smooth="yes"/>
-      <point x="280.0" y="384.0"/>
-      <point x="303.0" y="431.0"/>
-      <point x="332.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="362.0" y="510.0"/>
-      <point x="404.0" y="542.0"/>
-      <point x="448.0" y="561.0" type="curve"/>
-      <point x="483.0" y="505.0" type="line"/>
-      <point x="418.0" y="473.0"/>
-      <point x="372.0" y="434.0"/>
-      <point x="357.0" y="386.0" type="curve"/>
-      <point x="377.0" y="412.0"/>
-      <point x="401.0" y="419.0"/>
+      <point x="283.0" y="223.0"/>
+      <point x="283.0" y="325.0" type="curve" smooth="yes"/>
+      <point x="283.0" y="384.0"/>
+      <point x="306.0" y="427.0"/>
+      <point x="335.0" y="466.0" type="curve" smooth="yes"/>
+      <point x="365.0" y="506.0"/>
+      <point x="409.0" y="540.0"/>
+      <point x="450.0" y="558.0" type="curve"/>
+      <point x="471.0" y="525.0" type="line"/>
+      <point x="400.0" y="495.0"/>
+      <point x="338.0" y="426.0"/>
+      <point x="325.0" y="357.0" type="curve"/>
+      <point x="342.0" y="387.0"/>
+      <point x="388" y="419.0"/>
       <point x="440.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="507.0" y="419.0"/>
-      <point x="554.0" y="364.0"/>
-      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="223.0"/>
+      <point x="507" y="419"/>
+      <point x="551.0" y="364.0"/>
+      <point x="551.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="551.0" y="223.0"/>
       <point x="491.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="six.numerator" xOffset="258" yOffset="-161"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>six.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="236.0" y="330.0"/>
-      <point x="287.0" y="375.0"/>
-      <point x="287.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="287.0" y="494.0"/>
-      <point x="257.0" y="524.0"/>
-      <point x="217.0" y="536.0" type="curve"/>
-      <point x="249.0" y="551.0"/>
-      <point x="275.0" y="586.0"/>
-      <point x="275.0" y="623.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="684.0"/>
-      <point x="231.0" y="724.0"/>
-      <point x="160.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="47.0" y="682.0"/>
-      <point x="37.0" y="627.0" type="curve"/>
-      <point x="88.0" y="622.0" type="line"/>
-      <point x="96.0" y="647.0"/>
-      <point x="124.0" y="677.0"/>
-      <point x="159.0" y="677.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="677.0"/>
-      <point x="225.0" y="651.0"/>
-      <point x="225.0" y="620.0" type="curve" smooth="yes"/>
-      <point x="225.0" y="581.0"/>
-      <point x="195.0" y="556.0"/>
-      <point x="151.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="556.0"/>
-      <point x="127.0" y="556.0"/>
-      <point x="127.0" y="556.0" type="curve"/>
-      <point x="127.0" y="510.0" type="line"/>
-      <point x="127.0" y="510.0"/>
-      <point x="133.0" y="510.0"/>
-      <point x="158.0" y="510.0" type="curve" smooth="yes"/>
-      <point x="208.0" y="510.0"/>
-      <point x="237.0" y="481.0"/>
-      <point x="237.0" y="445.0" type="curve" smooth="yes"/>
-      <point x="237.0" y="403.0"/>
-      <point x="214.0" y="374.0"/>
-      <point x="167.0" y="374.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="374.0"/>
-      <point x="84.0" y="399.0"/>
-      <point x="76.0" y="448.0" type="curve"/>
-      <point x="32.0" y="444.0" type="line"/>
-      <point x="42.0" y="370.0"/>
-      <point x="92.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="236" y="330"/>
+      <point x="286" y="375"/>
+      <point x="286" y="446" type="curve" smooth="yes"/>
+      <point x="286" y="494"/>
+      <point x="265" y="522"/>
+      <point x="229" y="536" type="curve"/>
+      <point x="256" y="557"/>
+      <point x="275" y="586"/>
+      <point x="275" y="623" type="curve" smooth="yes"/>
+      <point x="275" y="684"/>
+      <point x="231" y="724"/>
+      <point x="160" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="52" y="679"/>
+      <point x="42" y="628" type="curve"/>
+      <point x="94" y="617" type="line"/>
+      <point x="102" y="642"/>
+      <point x="126" y="672"/>
+      <point x="163" y="672.0" type="curve" smooth="yes"/>
+      <point x="198" y="672"/>
+      <point x="223" y="649"/>
+      <point x="223" y="616" type="curve" smooth="yes"/>
+      <point x="223" y="577"/>
+      <point x="191" y="555"/>
+      <point x="151" y="555" type="curve" smooth="yes"/>
+      <point x="143" y="555"/>
+      <point x="127" y="555"/>
+      <point x="127" y="555" type="curve"/>
+      <point x="127" y="511" type="line"/>
+      <point x="127" y="511"/>
+      <point x="133" y="511"/>
+      <point x="158" y="511" type="curve" smooth="yes"/>
+      <point x="203" y="511"/>
+      <point x="232" y="481"/>
+      <point x="232" y="449" type="curve" smooth="yes"/>
+      <point x="232" y="407"/>
+      <point x="199" y="381"/>
+      <point x="162" y="381" type="curve" smooth="yes"/>
+      <point x="126" y="381"/>
+      <point x="88" y="403"/>
+      <point x="79" y="455" type="curve"/>
+      <point x="29" y="443" type="line"/>
+      <point x="40" y="371"/>
+      <point x="92" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,65 +4,65 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="352.0" y="284.0" type="line"/>
-      <point x="360.0" y="240.0"/>
-      <point x="387.0" y="219.0"/>
-      <point x="423.0" y="219.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="219.0"/>
-      <point x="487.0" y="241.0"/>
-      <point x="487.0" y="279.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="311.0"/>
-      <point x="461.0" y="335.0"/>
-      <point x="419.0" y="335.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="335.0"/>
-      <point x="388.0" y="335.0"/>
-      <point x="388.0" y="335.0" type="curve"/>
-      <point x="388.0" y="391.0" type="line"/>
-      <point x="388.0" y="391.0"/>
-      <point x="404.0" y="391.0"/>
-      <point x="412.0" y="391.0" type="curve" smooth="yes"/>
-      <point x="447.0" y="391.0"/>
-      <point x="474.0" y="407.0"/>
-      <point x="474.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="475.0"/>
-      <point x="454.0" y="495.0"/>
-      <point x="421.0" y="495.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="495.0"/>
-      <point x="367.0" y="472.0"/>
-      <point x="359.0" y="447.0" type="curve"/>
+      <point x="351.0" y="160.0"/>
+      <point x="296.0" y="199.0"/>
+      <point x="286.0" y="273.0" type="curve"/>
+      <point x="356" y="286.0" type="line"/>
+      <point x="364" y="246.0"/>
+      <point x="388" y="226.0"/>
+      <point x="421" y="226.0" type="curve" smooth="yes"/>
+      <point x="455" y="226.0"/>
+      <point x="480" y="246.0"/>
+      <point x="480" y="281.0" type="curve" smooth="yes"/>
+      <point x="480" y="311.0"/>
+      <point x="461.0" y="331.0"/>
+      <point x="419.0" y="331.0" type="curve" smooth="yes"/>
+      <point x="394.0" y="331.0"/>
+      <point x="388.0" y="331.0"/>
+      <point x="388.0" y="331.0" type="curve"/>
+      <point x="388" y="397.0" type="line"/>
+      <point x="388" y="397.0"/>
+      <point x="407" y="397.0"/>
+      <point x="415" y="397.0" type="curve" smooth="yes"/>
+      <point x="447" y="397.0"/>
+      <point x="471" y="407.0"/>
+      <point x="471" y="441.0" type="curve"/>
+      <point x="471" y="466.0"/>
+      <point x="453" y="484.0"/>
+      <point x="423" y="484.0" type="curve" smooth="yes"/>
+      <point x="391" y="484.0"/>
+      <point x="374" y="464.0"/>
+      <point x="366" y="442.0" type="curve"/>
       <point x="296.0" y="458.0" type="line"/>
       <point x="306.0" y="513.0"/>
       <point x="350.0" y="554.0"/>
       <point x="421.0" y="554.0" type="curve" smooth="yes"/>
       <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
+      <point x="544.0" y="514.0"/>
+      <point x="544.0" y="453.0" type="curve" smooth="yes"/>
+      <point x="544.0" y="416.0"/>
+      <point x="525.0" y="386.0"/>
       <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="533.0" y="353.0"/>
+      <point x="556.0" y="324.0"/>
+      <point x="556.0" y="276.0" type="curve" smooth="yes"/>
+      <point x="556.0" y="205.0"/>
+      <point x="497" y="160"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,65 +4,65 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="351.0" y="160.0"/>
-      <point x="296.0" y="199.0"/>
-      <point x="286.0" y="273.0" type="curve"/>
-      <point x="356" y="286.0" type="line"/>
-      <point x="364" y="246.0"/>
-      <point x="388" y="226.0"/>
-      <point x="421" y="226.0" type="curve" smooth="yes"/>
-      <point x="455" y="226.0"/>
-      <point x="480" y="246.0"/>
-      <point x="480" y="281.0" type="curve" smooth="yes"/>
-      <point x="480" y="311.0"/>
-      <point x="461.0" y="331.0"/>
-      <point x="419.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="331.0"/>
-      <point x="388.0" y="331.0"/>
-      <point x="388.0" y="331.0" type="curve"/>
-      <point x="388" y="397.0" type="line"/>
-      <point x="388" y="397.0"/>
-      <point x="407" y="397.0"/>
-      <point x="415" y="397.0" type="curve" smooth="yes"/>
-      <point x="447" y="397.0"/>
-      <point x="471" y="407.0"/>
-      <point x="471" y="441.0" type="curve"/>
-      <point x="471" y="466.0"/>
-      <point x="453" y="484.0"/>
-      <point x="423" y="484.0" type="curve" smooth="yes"/>
-      <point x="391" y="484.0"/>
-      <point x="374" y="464.0"/>
-      <point x="366" y="442.0" type="curve"/>
-      <point x="296.0" y="458.0" type="line"/>
-      <point x="306.0" y="513.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="544.0" y="514.0"/>
-      <point x="544.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="544.0" y="416.0"/>
-      <point x="525.0" y="386.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="533.0" y="353.0"/>
-      <point x="556.0" y="324.0"/>
-      <point x="556.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="556.0" y="205.0"/>
-      <point x="497" y="160"/>
+      <point x="426" y="160.0" type="curve" smooth="yes"/>
+      <point x="353.0" y="160.0"/>
+      <point x="300.0" y="199.0"/>
+      <point x="290.0" y="273.0" type="curve"/>
+      <point x="334.0" y="282" type="line"/>
+      <point x="344.0" y="230"/>
+      <point x="377.0" y="201.0"/>
+      <point x="423.0" y="201.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="201.0"/>
+      <point x="504.0" y="231"/>
+      <point x="504.0" y="274" type="curve" smooth="yes"/>
+      <point x="504.0" y="311"/>
+      <point x="472" y="342"/>
+      <point x="418.0" y="342" type="curve" smooth="yes"/>
+      <point x="406" y="342"/>
+      <point x="390.0" y="342"/>
+      <point x="390.0" y="342" type="curve"/>
+      <point x="390" y="384.0" type="line"/>
+      <point x="390" y="384.0"/>
+      <point x="411" y="384.0"/>
+      <point x="420" y="384.0" type="curve" smooth="yes"/>
+      <point x="460" y="384.0"/>
+      <point x="491" y="400.0"/>
+      <point x="491.0" y="446" type="curve" smooth="yes"/>
+      <point x="491" y="489"/>
+      <point x="468.0" y="512"/>
+      <point x="424" y="512" type="curve" smooth="yes"/>
+      <point x="379" y="512"/>
+      <point x="354" y="484"/>
+      <point x="344" y="449" type="curve"/>
+      <point x="299.0" y="458.0" type="line"/>
+      <point x="309.0" y="513.0"/>
+      <point x="357" y="554"/>
+      <point x="423" y="554.0" type="curve" smooth="yes"/>
+      <point x="495" y="554.0"/>
+      <point x="539.0" y="514.0"/>
+      <point x="539.0" y="453.0" type="curve" smooth="yes"/>
+      <point x="539.0" y="416.0"/>
+      <point x="519.0" y="386.0"/>
+      <point x="488.0" y="366.0" type="curve"/>
+      <point x="524.0" y="354.0"/>
+      <point x="551" y="324"/>
+      <point x="551.0" y="276.0" type="curve" smooth="yes"/>
+      <point x="551.0" y="203.0"/>
+      <point x="497.0" y="160.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="three.numerator" xOffset="266" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>three.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="36.0" y="338.0" type="line"/>
-      <point x="283.0" y="338.0" type="line"/>
-      <point x="283.0" y="382.0" type="line"/>
-      <point x="100.0" y="382.0" type="line"/>
-      <point x="134.0" y="407.0"/>
-      <point x="187.0" y="457.0"/>
-      <point x="212.0" y="485.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="525.0"/>
-      <point x="274.0" y="559.0"/>
-      <point x="274.0" y="610.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="680.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="156.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="34.0" y="679.0"/>
-      <point x="28.0" y="608.0" type="curve"/>
-      <point x="80.0" y="603.0" type="line"/>
-      <point x="85.0" y="643.0"/>
-      <point x="108.0" y="679.0"/>
-      <point x="157.0" y="679.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="679.0"/>
-      <point x="223.0" y="651.0"/>
-      <point x="223.0" y="607.0" type="curve" smooth="yes"/>
-      <point x="223.0" y="575.0"/>
-      <point x="206.0" y="546.0"/>
-      <point x="180.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="481.0"/>
-      <point x="102.0" y="439.0"/>
-      <point x="36.0" y="389.0" type="curve"/>
+      <point x="36" y="338" type="line"/>
+      <point x="283" y="338" type="line"/>
+      <point x="283" y="387" type="line"/>
+      <point x="92" y="387" type="line"/>
+      <point x="128" y="411"/>
+      <point x="187" y="458"/>
+      <point x="212" y="486" type="curve" smooth="yes"/>
+      <point x="248" y="526"/>
+      <point x="276" y="559"/>
+      <point x="276" y="610" type="curve" smooth="yes"/>
+      <point x="276" y="680"/>
+      <point x="233" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="37" y="679"/>
+      <point x="31" y="608" type="curve"/>
+      <point x="81" y="600" type="line"/>
+      <point x="86" y="640"/>
+      <point x="119" y="672"/>
+      <point x="157" y="672" type="curve" smooth="yes"/>
+      <point x="195.0" y="672.0"/>
+      <point x="222.0" y="649.0"/>
+      <point x="222" y="614" type="curve" smooth="yes"/>
+      <point x="222" y="582"/>
+      <point x="203" y="546"/>
+      <point x="177" y="515" type="curve" smooth="yes"/>
+      <point x="148" y="481"/>
+      <point x="100" y="442"/>
+      <point x="36" y="391" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
       <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="240.0" type="line"/>
-      <point x="357.0" y="280.0"/>
-      <point x="404.0" y="320.0"/>
-      <point x="433.0" y="354.0" type="curve" smooth="yes"/>
-      <point x="459.0" y="385.0"/>
-      <point x="476" y="408"/>
-      <point x="476" y="437" type="curve" smooth="yes"/>
-      <point x="476" y="471"/>
-      <point x="455" y="489"/>
-      <point x="427" y="489" type="curve" smooth="yes"/>
-      <point x="394" y="489"/>
-      <point x="376" y="464"/>
-      <point x="372" y="428" type="curve"/>
+      <point x="306.0" y="220.0" type="line"/>
+      <point x="353.0" y="257.0"/>
+      <point x="421.0" y="309.0"/>
+      <point x="451.0" y="342.0" type="curve" smooth="yes"/>
+      <point x="478" y="372"/>
+      <point x="496.0" y="408"/>
+      <point x="496.0" y="444" type="curve" smooth="yes"/>
+      <point x="496.0" y="487"/>
+      <point x="471.0" y="513"/>
+      <point x="428.0" y="513" type="curve" smooth="yes"/>
+      <point x="379.0" y="513"/>
+      <point x="353.0" y="478"/>
+      <point x="346.0" y="433" type="curve"/>
       <point x="298.0" y="441.0" type="line"/>
       <point x="304.0" y="512.0"/>
       <point x="359.0" y="557.0"/>
       <point x="426.0" y="557.0" type="curve" smooth="yes"/>
       <point x="503.0" y="557.0"/>
-      <point x="554.0" y="513.0"/>
-      <point x="554.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="392.0"/>
-      <point x="529.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467" y="281"/>
-      <point x="427.0" y="249.0"/>
-      <point x="412.0" y="238.0" type="curve"/>
-      <point x="553.0" y="238.0" type="line"/>
+      <point x="546" y="513.0"/>
+      <point x="546" y="443.0" type="curve" smooth="yes"/>
+      <point x="546" y="392.0"/>
+      <point x="515" y="347.0"/>
+      <point x="473" y="307.0" type="curve" smooth="yes"/>
+      <point x="445" y="279.0"/>
+      <point x="385" y="234.0"/>
+      <point x="359" y="217.0" type="curve"/>
+      <point x="553" y="217.0" type="line"/>
       <point x="553.0" y="171.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="227.0" type="line"/>
-      <point x="372.0" y="277.0"/>
-      <point x="418.0" y="314.0"/>
-      <point x="447.0" y="348.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="379.0"/>
-      <point x="485.0" y="408.0"/>
-      <point x="485.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="478.0"/>
-      <point x="459.0" y="498.0"/>
-      <point x="427.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="389.0" y="498.0"/>
-      <point x="369.0" y="470.0"/>
-      <point x="364.0" y="430.0" type="curve"/>
+      <point x="306.0" y="240.0" type="line"/>
+      <point x="357.0" y="280.0"/>
+      <point x="404.0" y="320.0"/>
+      <point x="433.0" y="354.0" type="curve" smooth="yes"/>
+      <point x="459.0" y="385.0"/>
+      <point x="476" y="408"/>
+      <point x="476" y="437" type="curve" smooth="yes"/>
+      <point x="476" y="471"/>
+      <point x="455" y="489"/>
+      <point x="427" y="489" type="curve" smooth="yes"/>
+      <point x="394" y="489"/>
+      <point x="376" y="464"/>
+      <point x="372" y="428" type="curve"/>
       <point x="298.0" y="441.0" type="line"/>
       <point x="304.0" y="512.0"/>
       <point x="359.0" y="557.0"/>
       <point x="426.0" y="557.0" type="curve" smooth="yes"/>
       <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
+      <point x="554.0" y="513.0"/>
+      <point x="554.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="392.0"/>
+      <point x="529.0" y="349.0"/>
       <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="436.0" y="255.0"/>
-      <point x="402.0" y="230.0" type="curve"/>
-      <point x="553.0" y="230.0" type="line"/>
+      <point x="467" y="281"/>
+      <point x="427.0" y="249.0"/>
+      <point x="412.0" y="238.0" type="curve"/>
+      <point x="553.0" y="238.0" type="line"/>
       <point x="553.0" y="171.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>two.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="72.0" y="68.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="379"/>
   <outline>
     <contour>
-      <point x="190.0" y="330.0" type="curve"/>
-      <point x="279.0" y="330.0"/>
-      <point x="338.0" y="411.0"/>
-      <point x="338.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="643.0"/>
-      <point x="279.0" y="724.0"/>
-      <point x="190.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="100.0" y="724.0"/>
-      <point x="42.0" y="643.0"/>
-      <point x="42.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="42.0" y="411.0"/>
-      <point x="100.0" y="330.0"/>
+      <point x="189" y="330" type="curve" smooth="yes"/>
+      <point x="282" y="330"/>
+      <point x="345" y="411"/>
+      <point x="345" y="527" type="curve" smooth="yes"/>
+      <point x="345" y="643"/>
+      <point x="282" y="724"/>
+      <point x="189" y="724" type="curve" smooth="yes"/>
+      <point x="96" y="724"/>
+      <point x="34" y="643"/>
+      <point x="34" y="527" type="curve" smooth="yes"/>
+      <point x="34" y="411"/>
+      <point x="96" y="330"/>
     </contour>
     <contour>
-      <point x="189.0" y="377.0" type="curve"/>
-      <point x="127.0" y="377.0"/>
-      <point x="90.0" y="431.0"/>
-      <point x="90.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="90.0" y="623.0"/>
-      <point x="127.0" y="677.0"/>
-      <point x="189.0" y="677.0" type="curve" smooth="yes"/>
-      <point x="251.0" y="677.0"/>
-      <point x="290.0" y="624.0"/>
-      <point x="290.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="430.0"/>
-      <point x="251.0" y="377.0"/>
+      <point x="189" y="378" type="curve" smooth="yes"/>
+      <point x="131" y="378"/>
+      <point x="94" y="434"/>
+      <point x="94" y="527" type="curve" smooth="yes"/>
+      <point x="94" y="620"/>
+      <point x="131" y="676"/>
+      <point x="189" y="676" type="curve" smooth="yes"/>
+      <point x="247" y="676"/>
+      <point x="285" y="620"/>
+      <point x="285" y="527" type="curve" smooth="yes"/>
+      <point x="285" y="434"/>
+      <point x="247" y="378"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/two.ss03.glif
@@ -8,8 +8,8 @@
       <point x="482" y="61" type="line"/>
       <point x="131" y="61" type="line"/>
       <point x="131" y="61" type="line"/>
-      <point x="131" y="61"/>
-      <point x="294" y="232"/>
+      <point x="144" y="74"/>
+      <point x="301" y="241"/>
       <point x="343" y="283" type="curve" smooth="yes"/>
       <point x="406" y="348"/>
       <point x="472" y="432"/>
@@ -28,10 +28,10 @@
       <point x="407" y="609"/>
       <point x="407" y="528" type="curve" smooth="yes"/>
       <point x="407" y="450"/>
-      <point x="375" y="406"/>
+      <point x="374" y="406"/>
       <point x="296" y="323" type="curve" smooth="yes"/>
-      <point x="228" y="251"/>
-      <point x="52" y="65"/>
+      <point x="233" y="256"/>
+      <point x="73" y="86"/>
       <point x="52" y="65" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="72" y="88" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-23.0" type="curve" smooth="yes"/>
-      <point x="635.0" y="-23.0"/>
-      <point x="806.0" y="148.0"/>
-      <point x="806.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="806.0" y="568.0"/>
-      <point x="635.0" y="739.0"/>
-      <point x="425.0" y="739.0" type="curve" smooth="yes"/>
-      <point x="215.0" y="739.0"/>
-      <point x="44.0" y="568.0"/>
-      <point x="44.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="44.0" y="148.0"/>
-      <point x="215.0" y="-23.0"/>
+      <point x="425.0" y="-20" type="curve" smooth="yes"/>
+      <point x="633" y="-20"/>
+      <point x="803" y="150"/>
+      <point x="803" y="358.0" type="curve" smooth="yes"/>
+      <point x="803" y="566"/>
+      <point x="633" y="736"/>
+      <point x="425.0" y="736" type="curve" smooth="yes"/>
+      <point x="217" y="736"/>
+      <point x="47" y="566"/>
+      <point x="47" y="358.0" type="curve" smooth="yes"/>
+      <point x="47" y="150"/>
+      <point x="217" y="-20"/>
     </contour>
     <contour>
-      <point x="425.0" y="56.0" type="curve" smooth="yes"/>
-      <point x="260.0" y="56.0"/>
-      <point x="123.0" y="193.0"/>
-      <point x="123.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="123.0" y="526.0"/>
-      <point x="260.0" y="660.0"/>
-      <point x="425.0" y="660.0" type="curve" smooth="yes"/>
-      <point x="594.0" y="660.0"/>
-      <point x="727.0" y="526.0"/>
-      <point x="727.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="727.0" y="193.0"/>
-      <point x="594.0" y="56.0"/>
+      <point x="425" y="69" type="curve" smooth="yes"/>
+      <point x="268" y="69"/>
+      <point x="136" y="201"/>
+      <point x="136" y="358" type="curve" smooth="yes"/>
+      <point x="136" y="518"/>
+      <point x="268" y="647"/>
+      <point x="425" y="647" type="curve" smooth="yes"/>
+      <point x="586" y="647"/>
+      <point x="714" y="518"/>
+      <point x="714" y="358" type="curve" smooth="yes"/>
+      <point x="714" y="201"/>
+      <point x="586" y="69"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="330.0"/>
-      <point x="300.0" y="373.0"/>
-      <point x="300.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="300.0" y="498.0"/>
-      <point x="271.0" y="531.0"/>
-      <point x="238.0" y="540.0" type="curve"/>
-      <point x="268.0" y="550.0"/>
-      <point x="288.0" y="577.0"/>
-      <point x="288.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="682.0"/>
-      <point x="236.0" y="724.0"/>
-      <point x="162.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89.0" y="724.0"/>
-      <point x="35.0" y="682.0"/>
-      <point x="35.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="35.0" y="579.0"/>
-      <point x="52.0" y="553.0"/>
-      <point x="77.0" y="540.0" type="curve"/>
-      <point x="48.0" y="530.0"/>
-      <point x="23.0" y="496.0"/>
-      <point x="23.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="23.0" y="375.0"/>
-      <point x="80.0" y="330.0"/>
+      <point x="162" y="328" type="curve" smooth="yes"/>
+      <point x="240" y="328"/>
+      <point x="302" y="372"/>
+      <point x="302" y="446" type="curve" smooth="yes"/>
+      <point x="302" y="488"/>
+      <point x="276" y="524"/>
+      <point x="248" y="541" type="curve"/>
+      <point x="268" y="559"/>
+      <point x="289" y="586"/>
+      <point x="289" y="618" type="curve" smooth="yes"/>
+      <point x="289" y="677"/>
+      <point x="246.0" y="726.0"/>
+      <point x="162" y="726" type="curve" smooth="yes"/>
+      <point x="78" y="726"/>
+      <point x="34" y="677"/>
+      <point x="34" y="618" type="curve" smooth="yes"/>
+      <point x="34" y="585"/>
+      <point x="54" y="555"/>
+      <point x="77" y="540" type="curve"/>
+      <point x="46" y="522"/>
+      <point x="21" y="488"/>
+      <point x="21" y="446" type="curve" smooth="yes"/>
+      <point x="21" y="374"/>
+      <point x="84" y="328"/>
     </contour>
     <contour>
-      <point x="162.0" y="401.0" type="curve" smooth="yes"/>
-      <point x="129.0" y="401.0"/>
-      <point x="110.0" y="418.0"/>
-      <point x="110.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="110.0" y="482.0"/>
-      <point x="125.0" y="503.0"/>
-      <point x="162.0" y="503.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="503.0"/>
-      <point x="213.0" y="480.0"/>
-      <point x="213.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="213.0" y="420.0"/>
-      <point x="198.0" y="401.0"/>
+      <point x="162" y="395" type="curve" smooth="yes"/>
+      <point x="127" y="395"/>
+      <point x="102" y="417"/>
+      <point x="102" y="450" type="curve" smooth="yes"/>
+      <point x="102" y="485"/>
+      <point x="127" y="507"/>
+      <point x="162" y="507" type="curve" smooth="yes"/>
+      <point x="197" y="507"/>
+      <point x="221" y="484"/>
+      <point x="221" y="450" type="curve" smooth="yes"/>
+      <point x="221" y="418"/>
+      <point x="197" y="395"/>
     </contour>
     <contour>
-      <point x="162.0" y="566.0" type="curve" smooth="yes"/>
-      <point x="135.0" y="566.0"/>
-      <point x="120.0" y="587.0"/>
-      <point x="120.0" y="609.0" type="curve" smooth="yes"/>
-      <point x="120.0" y="633.0"/>
-      <point x="138.0" y="653.0"/>
-      <point x="162.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="188.0" y="653.0"/>
-      <point x="203.0" y="636.0"/>
-      <point x="203.0" y="609.0" type="curve" smooth="yes"/>
-      <point x="203.0" y="583.0"/>
-      <point x="191.0" y="566.0"/>
+      <point x="162" y="568" type="curve" smooth="yes"/>
+      <point x="134" y="568"/>
+      <point x="114" y="586"/>
+      <point x="114" y="614" type="curve" smooth="yes"/>
+      <point x="114" y="640"/>
+      <point x="134" y="658"/>
+      <point x="162" y="658" type="curve" smooth="yes"/>
+      <point x="190" y="658"/>
+      <point x="209" y="640"/>
+      <point x="209" y="614" type="curve" smooth="yes"/>
+      <point x="209" y="586"/>
+      <point x="190" y="568"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,72 +4,72 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="426" y="199.0" type="curve" smooth="yes"/>
-      <point x="481" y="199"/>
-      <point x="516" y="232.0"/>
-      <point x="516" y="278.0" type="curve" smooth="yes"/>
-      <point x="516.0" y="319.0"/>
-      <point x="483" y="352"/>
-      <point x="426" y="352.0" type="curve" smooth="yes"/>
-      <point x="369.0" y="352"/>
-      <point x="335" y="323"/>
-      <point x="335" y="277.0" type="curve" smooth="yes"/>
-      <point x="335.0" y="227.0"/>
-      <point x="371.0" y="199.0"/>
+      <point x="426" y="231" type="curve" smooth="yes"/>
+      <point x="462" y="231"/>
+      <point x="487" y="255"/>
+      <point x="487" y="287" type="curve" smooth="yes"/>
+      <point x="487" y="319"/>
+      <point x="462" y="343"/>
+      <point x="426" y="343" type="curve" smooth="yes"/>
+      <point x="390" y="343"/>
+      <point x="364" y="320"/>
+      <point x="364" y="287" type="curve" smooth="yes"/>
+      <point x="364" y="254"/>
+      <point x="390" y="231"/>
     </contour>
     <contour>
-      <point x="426" y="163.0" type="curve" smooth="yes"/>
-      <point x="353" y="163.0"/>
-      <point x="295" y="208"/>
-      <point x="295" y="277.0" type="curve"/>
-      <point x="295" y="317"/>
-      <point x="321.0" y="356.0"/>
-      <point x="366" y="373.0" type="curve"/>
-      <point x="328" y="388.0"/>
-      <point x="309" y="418.0"/>
-      <point x="309" y="450.0" type="curve" smooth="yes"/>
-      <point x="309" y="515.0"/>
-      <point x="359" y="557.0"/>
-      <point x="426" y="557.0" type="curve" smooth="yes"/>
-      <point x="493" y="557.0"/>
-      <point x="542" y="515.0"/>
-      <point x="542" y="450.0" type="curve" smooth="yes"/>
-      <point x="542" y="419.0"/>
-      <point x="518" y="388.0"/>
-      <point x="479" y="373.0" type="curve"/>
-      <point x="531" y="356.0"/>
-      <point x="556.0" y="321.0"/>
-      <point x="556.0" y="278.0" type="curve" smooth="yes"/>
-      <point x="556.0" y="206.0"/>
-      <point x="499" y="163.0"/>
+      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
+      <point x="352.0" y="163.0"/>
+      <point x="292.0" y="208.0"/>
+      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
+      <point x="292.0" y="321.0"/>
+      <point x="312.0" y="353.0"/>
+      <point x="346.0" y="373.0" type="curve"/>
+      <point x="323.0" y="388.0"/>
+      <point x="304.0" y="418.0"/>
+      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
+      <point x="304.0" y="515.0"/>
+      <point x="358.0" y="557.0"/>
+      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
+      <point x="494.0" y="557.0"/>
+      <point x="547.0" y="515.0"/>
+      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
+      <point x="547.0" y="419.0"/>
+      <point x="527.0" y="388.0"/>
+      <point x="505.0" y="373.0" type="curve"/>
+      <point x="539.0" y="353.0"/>
+      <point x="559.0" y="321.0"/>
+      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
+      <point x="559.0" y="206.0"/>
+      <point x="500.0" y="163.0"/>
     </contour>
     <contour>
-      <point x="426" y="383.0" type="curve" smooth="yes"/>
-      <point x="468" y="383.0"/>
-      <point x="499" y="410.0"/>
-      <point x="499" y="451.0" type="curve" smooth="yes"/>
-      <point x="499" y="492.0"/>
-      <point x="468" y="521.0"/>
-      <point x="426" y="521.0" type="curve" smooth="yes"/>
-      <point x="383" y="521.0"/>
-      <point x="352" y="492.0"/>
-      <point x="352" y="451.0" type="curve" smooth="yes"/>
-      <point x="352" y="410.0"/>
-      <point x="383" y="383.0"/>
+      <point x="426" y="399" type="curve" smooth="yes"/>
+      <point x="455" y="399"/>
+      <point x="475" y="417"/>
+      <point x="475" y="445" type="curve" smooth="yes"/>
+      <point x="475" y="472"/>
+      <point x="455" y="491"/>
+      <point x="426" y="491" type="curve" smooth="yes"/>
+      <point x="397" y="491"/>
+      <point x="376" y="472"/>
+      <point x="376" y="445" type="curve" smooth="yes"/>
+      <point x="376" y="417"/>
+      <point x="397" y="399"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="248.0"/>
-      <point x="492.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="465.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="343.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="247.0"/>
-      <point x="387.0" y="222.0"/>
+      <point x="426" y="199.0" type="curve" smooth="yes"/>
+      <point x="481" y="199"/>
+      <point x="516" y="232.0"/>
+      <point x="516" y="278.0" type="curve" smooth="yes"/>
+      <point x="516.0" y="319.0"/>
+      <point x="483" y="352"/>
+      <point x="426" y="352.0" type="curve" smooth="yes"/>
+      <point x="369.0" y="352"/>
+      <point x="335" y="323"/>
+      <point x="335" y="277.0" type="curve" smooth="yes"/>
+      <point x="335.0" y="227.0"/>
+      <point x="371.0" y="199.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="426" y="163.0" type="curve" smooth="yes"/>
+      <point x="353" y="163.0"/>
+      <point x="295" y="208"/>
+      <point x="295" y="277.0" type="curve"/>
+      <point x="295" y="317"/>
+      <point x="321.0" y="356.0"/>
+      <point x="366" y="373.0" type="curve"/>
+      <point x="328" y="388.0"/>
+      <point x="309" y="418.0"/>
+      <point x="309" y="450.0" type="curve" smooth="yes"/>
+      <point x="309" y="515.0"/>
+      <point x="359" y="557.0"/>
+      <point x="426" y="557.0" type="curve" smooth="yes"/>
+      <point x="493" y="557.0"/>
+      <point x="542" y="515.0"/>
+      <point x="542" y="450.0" type="curve" smooth="yes"/>
+      <point x="542" y="419.0"/>
+      <point x="518" y="388.0"/>
+      <point x="479" y="373.0" type="curve"/>
+      <point x="531" y="356.0"/>
+      <point x="556.0" y="321.0"/>
+      <point x="556.0" y="278.0" type="curve" smooth="yes"/>
+      <point x="556.0" y="206.0"/>
+      <point x="499" y="163.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="458.0" y="397.0"/>
-      <point x="480.0" y="417.0"/>
-      <point x="480.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="477.0"/>
-      <point x="458.0" y="498.0"/>
-      <point x="426.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="498.0"/>
-      <point x="371.0" y="477.0"/>
-      <point x="371.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="417.0"/>
-      <point x="394.0" y="397.0"/>
+      <point x="426" y="383.0" type="curve" smooth="yes"/>
+      <point x="468" y="383.0"/>
+      <point x="499" y="410.0"/>
+      <point x="499" y="451.0" type="curve" smooth="yes"/>
+      <point x="499" y="492.0"/>
+      <point x="468" y="521.0"/>
+      <point x="426" y="521.0" type="curve" smooth="yes"/>
+      <point x="383" y="521.0"/>
+      <point x="352" y="492.0"/>
+      <point x="352" y="451.0" type="curve" smooth="yes"/>
+      <point x="352" y="410.0"/>
+      <point x="383" y="383.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="eight.numerator" xOffset="264" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>eight.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="162.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="331.0"/>
-      <point x="299.0" y="380.0"/>
-      <point x="299.0" y="461.0" type="curve" smooth="yes"/>
-      <point x="299.0" y="542.0"/>
-      <point x="256.0" y="589.0"/>
-      <point x="172.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="589.0"/>
-      <point x="119.0" y="579.0"/>
-      <point x="105.0" y="563.0" type="curve"/>
-      <point x="118.0" y="641.0" type="line"/>
-      <point x="273.0" y="641.0" type="line"/>
-      <point x="273.0" y="716.0" type="line"/>
-      <point x="61.0" y="716.0" type="line"/>
-      <point x="36.0" y="521.0" type="line"/>
-      <point x="105.0" y="493.0" type="line"/>
-      <point x="115.0" y="509.0"/>
-      <point x="133.0" y="523.0"/>
-      <point x="162.0" y="523.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="523.0"/>
-      <point x="218.0" y="501.0"/>
-      <point x="218.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="218.0" y="417.0"/>
-      <point x="198.0" y="400.0"/>
-      <point x="162.0" y="400.0" type="curve" smooth="yes"/>
-      <point x="124.0" y="400.0"/>
-      <point x="108.0" y="421.0"/>
-      <point x="101.0" y="453.0" type="curve"/>
-      <point x="23.0" y="435.0" type="line"/>
-      <point x="34.0" y="375.0"/>
-      <point x="81.0" y="331.0"/>
+      <point x="160" y="331" type="curve" smooth="yes"/>
+      <point x="253.0" y="331"/>
+      <point x="298" y="386"/>
+      <point x="298" y="461" type="curve" smooth="yes"/>
+      <point x="298.0" y="543.0"/>
+      <point x="252" y="592"/>
+      <point x="178" y="592.0" type="curve" smooth="yes"/>
+      <point x="148" y="592.0"/>
+      <point x="123" y="580"/>
+      <point x="113" y="573" type="curve"/>
+      <point x="122" y="645" type="line"/>
+      <point x="273" y="645" type="line"/>
+      <point x="273" y="716" type="line"/>
+      <point x="63" y="716" type="line"/>
+      <point x="37" y="519" type="line"/>
+      <point x="99.0" y="493" type="line"/>
+      <point x="112.0" y="510"/>
+      <point x="130.0" y="520"/>
+      <point x="158.0" y="520" type="curve" smooth="yes"/>
+      <point x="194.0" y="520"/>
+      <point x="219.0" y="497"/>
+      <point x="219.0" y="459" type="curve" smooth="yes"/>
+      <point x="219.0" y="420"/>
+      <point x="194" y="398"/>
+      <point x="160" y="398.0" type="curve" smooth="yes"/>
+      <point x="125.0" y="398.0"/>
+      <point x="103.0" y="426.0"/>
+      <point x="97" y="459" type="curve"/>
+      <point x="23" y="438" type="line"/>
+      <point x="35" y="371"/>
+      <point x="89" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -18,37 +18,37 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="356.0" y="280.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="388.0" y="222.0"/>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="249.0"/>
-      <point x="492.0" y="294.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="339.0"/>
-      <point x="465.0" y="365.0"/>
-      <point x="426.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="397.0" y="365.0"/>
-      <point x="375.0" y="352.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
+      <point x="429" y="163" type="curve" smooth="yes"/>
+      <point x="356" y="163"/>
+      <point x="312.0" y="208.0"/>
+      <point x="301.0" y="268.0" type="curve"/>
+      <point x="339.0" y="277" type="line"/>
+      <point x="349.0" y="227"/>
+      <point x="380" y="202"/>
+      <point x="429" y="202.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="202"/>
+      <point x="512" y="236"/>
+      <point x="512.0" y="292" type="curve" smooth="yes"/>
+      <point x="512.0" y="352.0"/>
+      <point x="478" y="384.0"/>
+      <point x="426.0" y="384" type="curve" smooth="yes"/>
+      <point x="391" y="384"/>
+      <point x="361.0" y="360"/>
+      <point x="348.0" y="336" type="curve"/>
+      <point x="315.0" y="348.0" type="line"/>
+      <point x="340.0" y="548.0" type="line"/>
       <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="492.0" type="line"/>
-      <point x="382.0" y="492.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
-      <point x="508.0" y="163.0"/>
+      <point x="537.0" y="507.0" type="line"/>
+      <point x="367.0" y="507.0" type="line"/>
+      <point x="351.0" y="380.0" type="line"/>
+      <point x="369.0" y="403.0"/>
+      <point x="406" y="419"/>
+      <point x="441" y="419.0" type="curve" smooth="yes"/>
+      <point x="503.0" y="419.0"/>
+      <point x="552.0" y="371.0"/>
+      <point x="552.0" y="293.0" type="curve" smooth="yes"/>
+      <point x="552.0" y="218.0"/>
+      <point x="502.0" y="163.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,51 +4,51 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="429" y="163" type="curve" smooth="yes"/>
-      <point x="356" y="163"/>
-      <point x="312.0" y="208.0"/>
-      <point x="301.0" y="268.0" type="curve"/>
-      <point x="339.0" y="277" type="line"/>
-      <point x="349.0" y="227"/>
-      <point x="380" y="202"/>
-      <point x="429" y="202.0" type="curve" smooth="yes"/>
-      <point x="478.0" y="202"/>
-      <point x="512" y="236"/>
-      <point x="512.0" y="292" type="curve" smooth="yes"/>
-      <point x="512.0" y="352.0"/>
-      <point x="478" y="384.0"/>
-      <point x="426.0" y="384" type="curve" smooth="yes"/>
-      <point x="391" y="384"/>
-      <point x="361.0" y="360"/>
-      <point x="348.0" y="336" type="curve"/>
-      <point x="315.0" y="348.0" type="line"/>
-      <point x="340.0" y="548.0" type="line"/>
+      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
+      <point x="356.0" y="163.0"/>
+      <point x="304.0" y="202.0"/>
+      <point x="292.0" y="267.0" type="curve"/>
+      <point x="362" y="283.0" type="line"/>
+      <point x="368" y="256.0"/>
+      <point x="391" y="233.0"/>
+      <point x="426" y="233.0" type="curve" smooth="yes"/>
+      <point x="461" y="233.0"/>
+      <point x="486" y="257.0"/>
+      <point x="486" y="296.0" type="curve" smooth="yes"/>
+      <point x="486" y="336.0"/>
+      <point x="461" y="359.0"/>
+      <point x="426" y="359.0" type="curve" smooth="yes"/>
+      <point x="399" y="359.0"/>
+      <point x="379" y="347.0"/>
+      <point x="366" y="328.0" type="curve"/>
+      <point x="305.0" y="353.0" type="line"/>
+      <point x="330.0" y="548.0" type="line"/>
       <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="507.0" type="line"/>
-      <point x="367.0" y="507.0" type="line"/>
-      <point x="351.0" y="380.0" type="line"/>
-      <point x="369.0" y="403.0"/>
-      <point x="406" y="419"/>
-      <point x="441" y="419.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="419.0"/>
-      <point x="552.0" y="371.0"/>
-      <point x="552.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="552.0" y="218.0"/>
-      <point x="502.0" y="163.0"/>
+      <point x="537.0" y="482.0" type="line"/>
+      <point x="382.0" y="482.0" type="line"/>
+      <point x="369.0" y="400.0" type="line"/>
+      <point x="383.0" y="416.0"/>
+      <point x="406" y="425"/>
+      <point x="436.0" y="425.0" type="curve" smooth="yes"/>
+      <point x="515.0" y="425.0"/>
+      <point x="561" y="375"/>
+      <point x="561.0" y="296.0" type="curve" smooth="yes"/>
+      <point x="561" y="218"/>
+      <point x="508.0" y="163.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="five.numerator" xOffset="265" yOffset="-168"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>five.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="21.0" y="409.0" type="line"/>
-      <point x="321.0" y="409.0" type="line"/>
-      <point x="321.0" y="477.0" type="line"/>
-      <point x="117.0" y="477.0" type="line"/>
-      <point x="193.0" y="592.0" type="line"/>
-      <point x="200.0" y="592.0" type="line"/>
-      <point x="200.0" y="338.0" type="line"/>
-      <point x="279.0" y="338.0" type="line"/>
-      <point x="279.0" y="716.0" type="line"/>
-      <point x="202.0" y="716.0" type="line"/>
-      <point x="21.0" y="460.0" type="line"/>
+      <point x="30" y="411" type="line"/>
+      <point x="321" y="411" type="line"/>
+      <point x="321" y="477" type="line"/>
+      <point x="113" y="477" type="line"/>
+      <point x="196" y="600" type="line"/>
+      <point x="202" y="600" type="line"/>
+      <point x="202" y="338" type="line"/>
+      <point x="275" y="338" type="line"/>
+      <point x="275" y="716" type="line"/>
+      <point x="204" y="716" type="line"/>
+      <point x="30" y="472" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="331.0" y="305.0" type="line"/>
-      <point x="433.0" y="305.0" type="line"/>
-      <point x="433.0" y="450.0" type="line"/>
-      <point x="429.0" y="450.0" type="line"/>
+      <point x="316.0" y="300.0" type="line"/>
+      <point x="438.0" y="300.0" type="line"/>
+      <point x="438.0" y="465.0" type="line"/>
+      <point x="429.0" y="465.0" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="171.0" type="line"/>
-      <point x="433.0" y="249.0" type="line"/>
-      <point x="256.0" y="249.0" type="line"/>
-      <point x="256.0" y="293.0" type="line"/>
-      <point x="437.0" y="549.0" type="line"/>
-      <point x="498.0" y="549.0" type="line"/>
-      <point x="498.0" y="305.0" type="line"/>
-      <point x="547.0" y="305.0" type="line"/>
-      <point x="547.0" y="249.0" type="line"/>
-      <point x="498.0" y="249.0" type="line"/>
-      <point x="498.0" y="171.0" type="line"/>
+      <point x="438.0" y="171.0" type="line"/>
+      <point x="438.0" y="259.0" type="line"/>
+      <point x="256.0" y="259.0" type="line"/>
+      <point x="256.0" y="288.0" type="line"/>
+      <point x="442.0" y="549.0" type="line"/>
+      <point x="488.0" y="549.0" type="line"/>
+      <point x="488.0" y="300.0" type="line"/>
+      <point x="547.0" y="300.0" type="line"/>
+      <point x="547.0" y="259.0" type="line"/>
+      <point x="488.0" y="259.0" type="line"/>
+      <point x="488.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="316.0" y="300.0" type="line"/>
-      <point x="438.0" y="300.0" type="line"/>
-      <point x="438.0" y="465.0" type="line"/>
-      <point x="429.0" y="465.0" type="line"/>
+      <point x="339.0" y="309.0" type="line"/>
+      <point x="428.0" y="309.0" type="line"/>
+      <point x="428.0" y="443.0" type="line"/>
+      <point x="426.0" y="443.0" type="line"/>
     </contour>
     <contour>
-      <point x="438.0" y="171.0" type="line"/>
-      <point x="438.0" y="259.0" type="line"/>
-      <point x="256.0" y="259.0" type="line"/>
-      <point x="256.0" y="288.0" type="line"/>
-      <point x="442.0" y="549.0" type="line"/>
-      <point x="488.0" y="549.0" type="line"/>
-      <point x="488.0" y="300.0" type="line"/>
-      <point x="547.0" y="300.0" type="line"/>
-      <point x="547.0" y="259.0" type="line"/>
-      <point x="488.0" y="259.0" type="line"/>
-      <point x="488.0" y="171.0" type="line"/>
+      <point x="428.0" y="171.0" type="line"/>
+      <point x="428.0" y="244.0" type="line"/>
+      <point x="256.0" y="244.0" type="line"/>
+      <point x="256.0" y="300.0" type="line"/>
+      <point x="427.0" y="549.0" type="line"/>
+      <point x="505.0" y="549.0" type="line"/>
+      <point x="505.0" y="309.0" type="line"/>
+      <point x="547.0" y="309.0" type="line"/>
+      <point x="547.0" y="244.0" type="line"/>
+      <point x="505.0" y="244.0" type="line"/>
+      <point x="505.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="four.numerator" xOffset="230" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>four.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="322"/>
   <outline>
     <contour>
-      <point x="136.0" y="329.0" type="line"/>
-      <point x="180.0" y="348.0"/>
-      <point x="227.0" y="382.0"/>
-      <point x="256.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="284.0" y="463.0"/>
-      <point x="302.0" y="509.0"/>
-      <point x="302.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="302.0" y="670.0"/>
-      <point x="238.0" y="724.0"/>
-      <point x="158.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="79.0" y="724.0"/>
-      <point x="19.0" y="670.0"/>
-      <point x="19.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="19.0" y="511.0"/>
-      <point x="57.0" y="464.0"/>
-      <point x="134.0" y="464.0" type="curve" smooth="yes"/>
-      <point x="169.0" y="464.0"/>
-      <point x="194.0" y="477.0"/>
-      <point x="209.0" y="503.0" type="curve"/>
-      <point x="207.0" y="458.0"/>
-      <point x="156.0" y="411.0"/>
-      <point x="91.0" y="379.0" type="curve"/>
+      <point x="129" y="327" type="line"/>
+      <point x="173" y="346"/>
+      <point x="218" y="381"/>
+      <point x="248" y="421" type="curve" smooth="yes"/>
+      <point x="277" y="460"/>
+      <point x="299" y="509"/>
+      <point x="299" y="568" type="curve" smooth="yes"/>
+      <point x="299" y="670"/>
+      <point x="242" y="724"/>
+      <point x="159" y="724" type="curve" smooth="yes"/>
+      <point x="76.0" y="724.0"/>
+      <point x="21.0" y="674.0"/>
+      <point x="21" y="598" type="curve" smooth="yes"/>
+      <point x="21" y="527"/>
+      <point x="63" y="471"/>
+      <point x="138" y="471" type="curve" smooth="yes"/>
+      <point x="177" y="471"/>
+      <point x="198" y="483"/>
+      <point x="210" y="494" type="curve"/>
+      <point x="195" y="455"/>
+      <point x="156" y="426"/>
+      <point x="92" y="391" type="curve"/>
     </contour>
     <contour>
-      <point x="159.0" y="535.0" type="curve" smooth="yes"/>
-      <point x="120.0" y="535.0"/>
-      <point x="102.0" y="560.0"/>
-      <point x="102.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="102.0" y="627.0"/>
-      <point x="124.0" y="650.0"/>
-      <point x="159.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="195.0" y="650.0"/>
-      <point x="216.0" y="629.0"/>
-      <point x="216.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="216.0" y="558.0"/>
-      <point x="200.0" y="535.0"/>
+      <point x="160" y="534" type="curve" smooth="yes"/>
+      <point x="122" y="534"/>
+      <point x="100" y="562"/>
+      <point x="100" y="596" type="curve" smooth="yes"/>
+      <point x="100" y="630"/>
+      <point x="122" y="657"/>
+      <point x="160" y="657" type="curve" smooth="yes"/>
+      <point x="198" y="657"/>
+      <point x="221" y="630"/>
+      <point x="221" y="596" type="curve" smooth="yes"/>
+      <point x="221" y="562"/>
+      <point x="198" y="534"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="396.0" y="159.0" type="curve"/>
-      <point x="367.0" y="206.0" type="line"/>
-      <point x="432.0" y="238.0"/>
-      <point x="484.0" y="285.0"/>
-      <point x="497.0" y="345.0" type="curve"/>
-      <point x="478.0" y="316.0"/>
-      <point x="443.0" y="301.0"/>
-      <point x="404.0" y="301.0" type="curve" smooth="yes"/>
-      <point x="337.0" y="301.0"/>
-      <point x="293.0" y="356.0"/>
-      <point x="293.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="293.0" y="497.0"/>
-      <point x="353.0" y="551.0"/>
-      <point x="425.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="501.0" y="551.0"/>
-      <point x="561.0" y="497.0"/>
-      <point x="561.0" y="395.0" type="curve" smooth="yes"/>
-      <point x="561.0" y="336.0"/>
-      <point x="541.0" y="289.0"/>
-      <point x="512.0" y="250.0" type="curve" smooth="yes"/>
-      <point x="482.0" y="210.0"/>
-      <point x="440.0" y="178.0"/>
+      <point x="393.0" y="162.0" type="curve"/>
+      <point x="372.0" y="195.0" type="line"/>
+      <point x="443.0" y="225.0"/>
+      <point x="505.0" y="294.0"/>
+      <point x="518.0" y="363.0" type="curve"/>
+      <point x="501.0" y="333.0"/>
+      <point x="455.0" y="301.0"/>
+      <point x="403.0" y="301.0" type="curve" smooth="yes"/>
+      <point x="336.0" y="301.0"/>
+      <point x="292.0" y="356.0"/>
+      <point x="292.0" y="425.0" type="curve" smooth="yes"/>
+      <point x="292.0" y="497.0"/>
+      <point x="352.0" y="551.0"/>
+      <point x="424.0" y="551.0" type="curve" smooth="yes"/>
+      <point x="500.0" y="551.0"/>
+      <point x="560.0" y="497.0"/>
+      <point x="560.0" y="395.0" type="curve" smooth="yes"/>
+      <point x="560.0" y="336.0"/>
+      <point x="537.0" y="293.0"/>
+      <point x="508.0" y="254.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="214.0"/>
+      <point x="434.0" y="180.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="357.0"/>
-      <point x="492.0" y="387.0"/>
-      <point x="492.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="461.0"/>
-      <point x="467.0" y="492.0"/>
-      <point x="426.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="385.0" y="492.0"/>
-      <point x="360.0" y="461.0"/>
-      <point x="360.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="360.0" y="387.0"/>
-      <point x="385.0" y="357.0"/>
+      <point x="425.0" y="339.0" type="curve" smooth="yes"/>
+      <point x="478.0" y="339.0"/>
+      <point x="510.0" y="377.0"/>
+      <point x="510.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="510.0" y="471.0"/>
+      <point x="478.0" y="510.0"/>
+      <point x="425.0" y="510.0" type="curve" smooth="yes"/>
+      <point x="372.0" y="510.0"/>
+      <point x="340.0" y="471.0"/>
+      <point x="340.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="340.0" y="377.0"/>
+      <point x="372.0" y="339.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="393.0" y="162.0" type="curve"/>
-      <point x="372.0" y="195.0" type="line"/>
-      <point x="443.0" y="225.0"/>
-      <point x="505.0" y="294.0"/>
-      <point x="518.0" y="363.0" type="curve"/>
-      <point x="501.0" y="333.0"/>
-      <point x="455.0" y="301.0"/>
-      <point x="403.0" y="301.0" type="curve" smooth="yes"/>
-      <point x="336.0" y="301.0"/>
-      <point x="292.0" y="356.0"/>
-      <point x="292.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="497.0"/>
-      <point x="352.0" y="551.0"/>
-      <point x="424.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="500.0" y="551.0"/>
-      <point x="560.0" y="497.0"/>
-      <point x="560.0" y="395.0" type="curve" smooth="yes"/>
-      <point x="560.0" y="336.0"/>
-      <point x="537.0" y="293.0"/>
-      <point x="508.0" y="254.0" type="curve" smooth="yes"/>
-      <point x="478.0" y="214.0"/>
-      <point x="434.0" y="180.0"/>
+      <point x="395.0" y="158.0" type="curve"/>
+      <point x="360.0" y="214.0" type="line"/>
+      <point x="425.0" y="246.0"/>
+      <point x="471.0" y="285.0"/>
+      <point x="486.0" y="333.0" type="curve"/>
+      <point x="466.0" y="307.0"/>
+      <point x="442.0" y="300.0"/>
+      <point x="403.0" y="300.0" type="curve" smooth="yes"/>
+      <point x="336.0" y="300.0"/>
+      <point x="289.0" y="355.0"/>
+      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="496.0"/>
+      <point x="352.0" y="550.0"/>
+      <point x="424.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="500.0" y="550.0"/>
+      <point x="563.0" y="496.0"/>
+      <point x="563.0" y="394.0" type="curve" smooth="yes"/>
+      <point x="563.0" y="335.0"/>
+      <point x="540.0" y="288.0"/>
+      <point x="511.0" y="249.0" type="curve" smooth="yes"/>
+      <point x="481.0" y="209.0"/>
+      <point x="439.0" y="177.0"/>
     </contour>
     <contour>
-      <point x="425.0" y="339.0" type="curve" smooth="yes"/>
-      <point x="478.0" y="339.0"/>
-      <point x="510.0" y="377.0"/>
-      <point x="510.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="510.0" y="471.0"/>
-      <point x="478.0" y="510.0"/>
-      <point x="425.0" y="510.0" type="curve" smooth="yes"/>
-      <point x="372.0" y="510.0"/>
-      <point x="340.0" y="471.0"/>
-      <point x="340.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="340.0" y="377.0"/>
-      <point x="372.0" y="339.0"/>
+      <point x="425.0" y="363.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="363.0"/>
+      <point x="486.0" y="390.0"/>
+      <point x="486.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="486.0" y="456.0"/>
+      <point x="463.0" y="484.0"/>
+      <point x="425.0" y="484.0" type="curve" smooth="yes"/>
+      <point x="387.0" y="484.0"/>
+      <point x="364.0" y="456.0"/>
+      <point x="364.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="364.0" y="390.0"/>
+      <point x="387.0" y="363.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="nine.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>nine.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="111.0" y="338.0" type="line"/>
-      <point x="206.0" y="338.0" type="line"/>
-      <point x="206.0" y="716.0" type="line"/>
-      <point x="120.0" y="716.0" type="line"/>
-      <point x="14.0" y="640.0" type="line"/>
-      <point x="32.0" y="538.0" type="line"/>
-      <point x="111.0" y="587.0" type="line"/>
+      <point x="111" y="338" type="line"/>
+      <point x="196" y="338" type="line"/>
+      <point x="196" y="716" type="line"/>
+      <point x="115" y="716" type="line"/>
+      <point x="22" y="650" type="line"/>
+      <point x="22" y="555" type="line"/>
+      <point x="111" y="619" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="406.0" y="171.0" type="line"/>
-      <point x="406.0" y="462.0" type="line"/>
-      <point x="317.0" y="398.0" type="line"/>
-      <point x="317.0" y="477.0" type="line"/>
-      <point x="415.0" y="549.0" type="line"/>
-      <point x="471.0" y="549.0" type="line"/>
-      <point x="471.0" y="171.0" type="line"/>
+      <point x="410.0" y="171.0" type="line"/>
+      <point x="410.0" y="484.0" type="line"/>
+      <point x="317.0" y="412.0" type="line"/>
+      <point x="317.0" y="469.0" type="line"/>
+      <point x="422.0" y="549.0" type="line"/>
+      <point x="461.0" y="549.0" type="line"/>
+      <point x="461.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="410.0" y="171.0" type="line"/>
-      <point x="410.0" y="484.0" type="line"/>
-      <point x="317.0" y="412.0" type="line"/>
-      <point x="317.0" y="469.0" type="line"/>
-      <point x="422.0" y="549.0" type="line"/>
-      <point x="461.0" y="549.0" type="line"/>
-      <point x="461.0" y="171.0" type="line"/>
+      <point x="396.0" y="171.0" type="line"/>
+      <point x="396.0" y="452.0" type="line"/>
+      <point x="307.0" y="388.0" type="line"/>
+      <point x="307.0" y="477.0" type="line"/>
+      <point x="405.0" y="549.0" type="line"/>
+      <point x="481.0" y="549.0" type="line"/>
+      <point x="481.0" y="171.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="one.numerator" xOffset="285" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>one.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="167.0" y="338.0" type="line"/>
-      <point x="166.0" y="459.0"/>
-      <point x="199.0" y="573.0"/>
-      <point x="283.0" y="653.0" type="curve"/>
-      <point x="283.0" y="716.0" type="line"/>
-      <point x="28.0" y="716.0" type="line"/>
-      <point x="28.0" y="640.0" type="line"/>
-      <point x="193.0" y="640.0" type="line"/>
-      <point x="135.0" y="577.0"/>
-      <point x="85.0" y="491.0"/>
-      <point x="80.0" y="338.0" type="curve"/>
+      <point x="166" y="338" type="line"/>
+      <point x="166" y="460"/>
+      <point x="199" y="573"/>
+      <point x="283" y="653" type="curve"/>
+      <point x="283" y="716" type="line"/>
+      <point x="28" y="716" type="line"/>
+      <point x="28" y="640" type="line"/>
+      <point x="185" y="640" type="line"/>
+      <point x="136" y="578"/>
+      <point x="84" y="480"/>
+      <point x="84" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="368.0" y="171.0" type="line"/>
-      <point x="368.0" y="324.0"/>
-      <point x="431.0" y="427.0"/>
-      <point x="489.0" y="490.0" type="curve"/>
-      <point x="306.0" y="490.0" type="line"/>
+      <point x="435.0" y="171.0" type="curve"/>
+      <point x="383.0" y="171.0" type="line"/>
+      <point x="383.0" y="324.0"/>
+      <point x="451.0" y="442.0"/>
+      <point x="509.0" y="505.0" type="curve"/>
+      <point x="306.0" y="505.0" type="line"/>
       <point x="306.0" y="549.0" type="line"/>
       <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="561.0" y="509.0" type="line"/>
+      <point x="477.0" y="429.0"/>
+      <point x="435.0" y="293.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="435.0" y="171.0" type="curve"/>
-      <point x="383.0" y="171.0" type="line"/>
-      <point x="383.0" y="324.0"/>
-      <point x="451.0" y="442.0"/>
-      <point x="509.0" y="505.0" type="curve"/>
-      <point x="306.0" y="505.0" type="line"/>
+      <point x="444.0" y="171.0" type="curve"/>
+      <point x="362.0" y="171.0" type="line"/>
+      <point x="362.0" y="324.0"/>
+      <point x="425.0" y="413.0"/>
+      <point x="483.0" y="476.0" type="curve"/>
+      <point x="306.0" y="476.0" type="line"/>
       <point x="306.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="509.0" type="line"/>
-      <point x="477.0" y="429.0"/>
-      <point x="435.0" y="293.0"/>
+      <point x="565.0" y="549.0" type="line"/>
+      <point x="565.0" y="489.0" type="line"/>
+      <point x="483.0" y="409.0"/>
+      <point x="444.0" y="293.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="161.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="330.0"/>
-      <point x="301.0" y="384.0"/>
-      <point x="301.0" y="456.0" type="curve" smooth="yes"/>
-      <point x="301.0" y="543.0"/>
-      <point x="263.0" y="590.0"/>
-      <point x="186.0" y="590.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="590.0"/>
-      <point x="126.0" y="577.0"/>
-      <point x="110.0" y="551.0" type="curve"/>
-      <point x="112.0" y="596.0"/>
-      <point x="164.0" y="643.0"/>
-      <point x="229.0" y="675.0" type="curve"/>
-      <point x="184.0" y="725.0" type="line"/>
-      <point x="140.0" y="706.0"/>
-      <point x="93.0" y="672.0"/>
-      <point x="64.0" y="631.0" type="curve" smooth="yes"/>
-      <point x="36.0" y="591.0"/>
-      <point x="18.0" y="545.0"/>
-      <point x="18.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="18.0" y="384.0"/>
-      <point x="81.0" y="330.0"/>
+      <point x="161" y="330" type="curve" smooth="yes"/>
+      <point x="244.0" y="330.0"/>
+      <point x="299.0" y="380.0"/>
+      <point x="299" y="456" type="curve" smooth="yes"/>
+      <point x="299" y="527"/>
+      <point x="257" y="583"/>
+      <point x="182" y="583" type="curve" smooth="yes"/>
+      <point x="143" y="583"/>
+      <point x="122" y="571"/>
+      <point x="110" y="560" type="curve"/>
+      <point x="125" y="599"/>
+      <point x="164" y="628"/>
+      <point x="228" y="663" type="curve"/>
+      <point x="191" y="727" type="line"/>
+      <point x="147" y="708"/>
+      <point x="102" y="673"/>
+      <point x="72" y="633" type="curve" smooth="yes"/>
+      <point x="43" y="594"/>
+      <point x="21" y="545"/>
+      <point x="21" y="486" type="curve" smooth="yes"/>
+      <point x="21" y="384"/>
+      <point x="78" y="330"/>
     </contour>
     <contour>
-      <point x="160.0" y="404.0" type="curve" smooth="yes"/>
-      <point x="125.0" y="404.0"/>
-      <point x="104.0" y="425.0"/>
-      <point x="104.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="104.0" y="496.0"/>
-      <point x="120.0" y="519.0"/>
-      <point x="160.0" y="519.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="519.0"/>
-      <point x="218.0" y="494.0"/>
-      <point x="218.0" y="460.0" type="curve" smooth="yes"/>
-      <point x="218.0" y="427.0"/>
-      <point x="196.0" y="404.0"/>
+      <point x="160" y="395" type="curve" smooth="yes"/>
+      <point x="122" y="395"/>
+      <point x="99" y="423"/>
+      <point x="99" y="457" type="curve" smooth="yes"/>
+      <point x="99" y="491"/>
+      <point x="122" y="518"/>
+      <point x="160" y="518" type="curve" smooth="yes"/>
+      <point x="198" y="518"/>
+      <point x="220" y="491"/>
+      <point x="220" y="457" type="curve" smooth="yes"/>
+      <point x="220" y="423"/>
+      <point x="198" y="395"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,18 +18,18 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="418.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="459.0" y="228.0"/>
-      <point x="484.0" y="259.0"/>
-      <point x="484.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="333.0"/>
-      <point x="459.0" y="363.0"/>
-      <point x="418.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="377.0" y="363.0"/>
-      <point x="352.0" y="333.0"/>
-      <point x="352.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="259.0"/>
-      <point x="377.0" y="228.0"/>
+      <point x="418" y="210" type="curve" smooth="yes"/>
+      <point x="471" y="210"/>
+      <point x="503" y="249"/>
+      <point x="503" y="296" type="curve" smooth="yes"/>
+      <point x="503" y="343"/>
+      <point x="471" y="381"/>
+      <point x="418" y="381" type="curve" smooth="yes"/>
+      <point x="365" y="381"/>
+      <point x="333" y="343"/>
+      <point x="333" y="296" type="curve" smooth="yes"/>
+      <point x="333" y="249"/>
+      <point x="365" y="210"/>
     </contour>
     <contour>
       <point x="419.0" y="169.0" type="curve" smooth="yes"/>
@@ -37,19 +37,19 @@
       <point x="283.0" y="223.0"/>
       <point x="283.0" y="325.0" type="curve" smooth="yes"/>
       <point x="283.0" y="384.0"/>
-      <point x="303.0" y="431.0"/>
-      <point x="332.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="362.0" y="510.0"/>
-      <point x="404.0" y="542.0"/>
-      <point x="448.0" y="561.0" type="curve"/>
-      <point x="477.0" y="514.0" type="line"/>
-      <point x="412.0" y="482.0"/>
-      <point x="360.0" y="435.0"/>
-      <point x="347.0" y="375.0" type="curve"/>
-      <point x="366.0" y="404.0"/>
-      <point x="401.0" y="419.0"/>
+      <point x="306.0" y="427.0"/>
+      <point x="335.0" y="466.0" type="curve" smooth="yes"/>
+      <point x="365.0" y="506.0"/>
+      <point x="409.0" y="540.0"/>
+      <point x="450.0" y="558.0" type="curve"/>
+      <point x="471.0" y="525.0" type="line"/>
+      <point x="400.0" y="495.0"/>
+      <point x="338.0" y="426.0"/>
+      <point x="325.0" y="357.0" type="curve"/>
+      <point x="342.0" y="387.0"/>
+      <point x="388" y="419.0"/>
       <point x="440.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="507.0" y="419.0"/>
+      <point x="507" y="419"/>
       <point x="551.0" y="364.0"/>
       <point x="551.0" y="295.0" type="curve" smooth="yes"/>
       <point x="551.0" y="223.0"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,55 +4,55 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="418" y="210" type="curve" smooth="yes"/>
-      <point x="471" y="210"/>
-      <point x="503" y="249"/>
-      <point x="503" y="296" type="curve" smooth="yes"/>
-      <point x="503" y="343"/>
-      <point x="471" y="381"/>
-      <point x="418" y="381" type="curve" smooth="yes"/>
-      <point x="365" y="381"/>
-      <point x="333" y="343"/>
-      <point x="333" y="296" type="curve" smooth="yes"/>
-      <point x="333" y="249"/>
-      <point x="365" y="210"/>
+      <point x="418" y="235" type="curve" smooth="yes"/>
+      <point x="456" y="235"/>
+      <point x="479" y="263"/>
+      <point x="479" y="296" type="curve" smooth="yes"/>
+      <point x="479" y="329"/>
+      <point x="456" y="356"/>
+      <point x="418" y="356" type="curve" smooth="yes"/>
+      <point x="380" y="356"/>
+      <point x="357" y="329"/>
+      <point x="357" y="296" type="curve" smooth="yes"/>
+      <point x="357" y="263"/>
+      <point x="380" y="235"/>
     </contour>
     <contour>
       <point x="419.0" y="169.0" type="curve" smooth="yes"/>
       <point x="343.0" y="169.0"/>
-      <point x="283.0" y="223.0"/>
-      <point x="283.0" y="325.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="384.0"/>
-      <point x="306.0" y="427.0"/>
-      <point x="335.0" y="466.0" type="curve" smooth="yes"/>
-      <point x="365.0" y="506.0"/>
-      <point x="409.0" y="540.0"/>
-      <point x="450.0" y="558.0" type="curve"/>
-      <point x="471.0" y="525.0" type="line"/>
-      <point x="400.0" y="495.0"/>
-      <point x="338.0" y="426.0"/>
-      <point x="325.0" y="357.0" type="curve"/>
-      <point x="342.0" y="387.0"/>
-      <point x="388" y="419.0"/>
+      <point x="280.0" y="223.0"/>
+      <point x="280.0" y="325.0" type="curve" smooth="yes"/>
+      <point x="280.0" y="384.0"/>
+      <point x="303.0" y="431.0"/>
+      <point x="332.0" y="470.0" type="curve" smooth="yes"/>
+      <point x="362.0" y="510.0"/>
+      <point x="404.0" y="542.0"/>
+      <point x="448.0" y="561.0" type="curve"/>
+      <point x="483.0" y="505.0" type="line"/>
+      <point x="418.0" y="473.0"/>
+      <point x="372.0" y="434.0"/>
+      <point x="357.0" y="386.0" type="curve"/>
+      <point x="377.0" y="412.0"/>
+      <point x="401.0" y="419.0"/>
       <point x="440.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="507" y="419"/>
-      <point x="551.0" y="364.0"/>
-      <point x="551.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="223.0"/>
+      <point x="507.0" y="419.0"/>
+      <point x="554.0" y="364.0"/>
+      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="223.0"/>
       <point x="491.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="six.numerator" xOffset="258" yOffset="-161"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>six.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="162.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="330.0"/>
-      <point x="298.0" y="375.0"/>
-      <point x="298.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="298.0" y="499.0"/>
-      <point x="274.0" y="529.0"/>
-      <point x="241.0" y="536.0" type="curve"/>
-      <point x="267.0" y="553.0"/>
-      <point x="290.0" y="586.0"/>
-      <point x="290.0" y="624.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="684.0"/>
-      <point x="239.0" y="724.0"/>
-      <point x="166.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="92.0" y="724.0"/>
-      <point x="41.0" y="685.0"/>
-      <point x="29.0" y="625.0" type="curve"/>
-      <point x="109.0" y="610.0" type="line"/>
-      <point x="116.0" y="636.0"/>
-      <point x="141.0" y="653.0"/>
-      <point x="161.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="191.0" y="653.0"/>
-      <point x="201.0" y="635.0"/>
-      <point x="201.0" y="613.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="583.0"/>
-      <point x="180.0" y="565.0"/>
-      <point x="151.0" y="565.0" type="curve" smooth="yes"/>
-      <point x="143.0" y="565.0"/>
-      <point x="124.0" y="565.0"/>
-      <point x="124.0" y="565.0" type="curve"/>
-      <point x="124.0" y="498.0" type="line"/>
-      <point x="124.0" y="498.0"/>
-      <point x="150.0" y="498.0"/>
-      <point x="154.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="196.0" y="498.0"/>
-      <point x="217.0" y="478.0"/>
-      <point x="217.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="217.0" y="421.0"/>
-      <point x="201.0" y="402.0"/>
-      <point x="164.0" y="402.0" type="curve" smooth="yes"/>
-      <point x="126.0" y="402.0"/>
-      <point x="106.0" y="428.0"/>
-      <point x="98.0" y="462.0" type="curve"/>
-      <point x="23.0" y="445.0" type="line"/>
-      <point x="33.0" y="371.0"/>
-      <point x="92.0" y="330.0"/>
+      <point x="162" y="330" type="curve" smooth="yes"/>
+      <point x="231.0" y="330.0"/>
+      <point x="296.0" y="372.0"/>
+      <point x="296" y="446" type="curve" smooth="yes"/>
+      <point x="296" y="494"/>
+      <point x="273" y="523"/>
+      <point x="237" y="536" type="curve"/>
+      <point x="264" y="553"/>
+      <point x="284" y="586"/>
+      <point x="284.0" y="623" type="curve" smooth="yes"/>
+      <point x="284.0" y="689.0"/>
+      <point x="241.0" y="724.0"/>
+      <point x="161" y="724.0" type="curve" smooth="yes"/>
+      <point x="89" y="724"/>
+      <point x="41" y="683"/>
+      <point x="30" y="625" type="curve"/>
+      <point x="105" y="611.0" type="line"/>
+      <point x="113" y="636.0"/>
+      <point x="128" y="653.0"/>
+      <point x="158" y="653.0" type="curve" smooth="yes"/>
+      <point x="188" y="653.0"/>
+      <point x="203" y="639.0"/>
+      <point x="203" y="614.0" type="curve" smooth="yes"/>
+      <point x="203" y="580.0"/>
+      <point x="180" y="566.0"/>
+      <point x="148" y="566.0" type="curve" smooth="yes"/>
+      <point x="140" y="566.0"/>
+      <point x="124" y="566.0"/>
+      <point x="124" y="566.0" type="curve"/>
+      <point x="124" y="502.0" type="line"/>
+      <point x="124" y="502.0"/>
+      <point x="147" y="502.0"/>
+      <point x="156" y="502.0" type="curve" smooth="yes"/>
+      <point x="196" y="502"/>
+      <point x="216" y="481.0"/>
+      <point x="216.0" y="452" type="curve" smooth="yes"/>
+      <point x="216" y="421"/>
+      <point x="196" y="402"/>
+      <point x="164" y="402.0" type="curve" smooth="yes"/>
+      <point x="126" y="402"/>
+      <point x="103" y="423"/>
+      <point x="96" y="461" type="curve"/>
+      <point x="22" y="446" type="line"/>
+      <point x="32" y="372"/>
+      <point x="92" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,65 +4,65 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="426" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="300.0" y="199.0"/>
-      <point x="290.0" y="273.0" type="curve"/>
-      <point x="334.0" y="282" type="line"/>
-      <point x="344.0" y="230"/>
-      <point x="377.0" y="201.0"/>
-      <point x="423.0" y="201.0" type="curve" smooth="yes"/>
-      <point x="469.0" y="201.0"/>
-      <point x="504.0" y="231"/>
-      <point x="504.0" y="274" type="curve" smooth="yes"/>
-      <point x="504.0" y="311"/>
-      <point x="472" y="342"/>
-      <point x="418.0" y="342" type="curve" smooth="yes"/>
-      <point x="406" y="342"/>
-      <point x="390.0" y="342"/>
-      <point x="390.0" y="342" type="curve"/>
-      <point x="390" y="384.0" type="line"/>
-      <point x="390" y="384.0"/>
-      <point x="411" y="384.0"/>
-      <point x="420" y="384.0" type="curve" smooth="yes"/>
-      <point x="460" y="384.0"/>
-      <point x="491" y="400.0"/>
-      <point x="491.0" y="446" type="curve" smooth="yes"/>
-      <point x="491" y="489"/>
-      <point x="468.0" y="512"/>
-      <point x="424" y="512" type="curve" smooth="yes"/>
-      <point x="379" y="512"/>
-      <point x="354" y="484"/>
-      <point x="344" y="449" type="curve"/>
-      <point x="299.0" y="458.0" type="line"/>
-      <point x="309.0" y="513.0"/>
-      <point x="357" y="554"/>
-      <point x="423" y="554.0" type="curve" smooth="yes"/>
-      <point x="495" y="554.0"/>
-      <point x="539.0" y="514.0"/>
-      <point x="539.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="539.0" y="416.0"/>
-      <point x="519.0" y="386.0"/>
-      <point x="488.0" y="366.0" type="curve"/>
-      <point x="524.0" y="354.0"/>
-      <point x="551" y="324"/>
-      <point x="551.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="203.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
+      <point x="351.0" y="160.0"/>
+      <point x="296.0" y="199.0"/>
+      <point x="286.0" y="273.0" type="curve"/>
+      <point x="356" y="286.0" type="line"/>
+      <point x="364" y="246.0"/>
+      <point x="388" y="226.0"/>
+      <point x="421" y="226.0" type="curve" smooth="yes"/>
+      <point x="455" y="226.0"/>
+      <point x="480" y="246.0"/>
+      <point x="480" y="281.0" type="curve" smooth="yes"/>
+      <point x="480" y="311.0"/>
+      <point x="461.0" y="331.0"/>
+      <point x="419.0" y="331.0" type="curve" smooth="yes"/>
+      <point x="394.0" y="331.0"/>
+      <point x="388.0" y="331.0"/>
+      <point x="388.0" y="331.0" type="curve"/>
+      <point x="388" y="397.0" type="line"/>
+      <point x="388" y="397.0"/>
+      <point x="407" y="397.0"/>
+      <point x="415" y="397.0" type="curve" smooth="yes"/>
+      <point x="447" y="397.0"/>
+      <point x="471" y="407.0"/>
+      <point x="471" y="441.0" type="curve"/>
+      <point x="471" y="466.0"/>
+      <point x="453" y="484.0"/>
+      <point x="423" y="484.0" type="curve" smooth="yes"/>
+      <point x="391" y="484.0"/>
+      <point x="374" y="464.0"/>
+      <point x="366" y="442.0" type="curve"/>
+      <point x="296.0" y="458.0" type="line"/>
+      <point x="306.0" y="513.0"/>
+      <point x="350.0" y="554.0"/>
+      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
+      <point x="492.0" y="554.0"/>
+      <point x="544.0" y="514.0"/>
+      <point x="544.0" y="453.0" type="curve" smooth="yes"/>
+      <point x="544.0" y="416.0"/>
+      <point x="525.0" y="386.0"/>
+      <point x="495.0" y="366.0" type="curve"/>
+      <point x="533.0" y="353.0"/>
+      <point x="556.0" y="324.0"/>
+      <point x="556.0" y="276.0" type="curve" smooth="yes"/>
+      <point x="556.0" y="205.0"/>
+      <point x="497" y="160"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
+      <point x="426" y="160.0" type="curve" smooth="yes"/>
       <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="352.0" y="284.0" type="line"/>
-      <point x="360.0" y="240.0"/>
-      <point x="387.0" y="219.0"/>
-      <point x="423.0" y="219.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="219.0"/>
-      <point x="487.0" y="241.0"/>
-      <point x="487.0" y="279.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="311.0"/>
-      <point x="461.0" y="335.0"/>
-      <point x="419.0" y="335.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="335.0"/>
-      <point x="388.0" y="335.0"/>
-      <point x="388.0" y="335.0" type="curve"/>
-      <point x="388.0" y="391.0" type="line"/>
-      <point x="388.0" y="391.0"/>
-      <point x="404.0" y="391.0"/>
-      <point x="412.0" y="391.0" type="curve" smooth="yes"/>
-      <point x="447.0" y="391.0"/>
-      <point x="474.0" y="407.0"/>
-      <point x="474.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="475.0"/>
-      <point x="454.0" y="495.0"/>
-      <point x="421.0" y="495.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="495.0"/>
-      <point x="367.0" y="472.0"/>
-      <point x="359.0" y="447.0" type="curve"/>
-      <point x="296.0" y="458.0" type="line"/>
-      <point x="306.0" y="513.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
+      <point x="300.0" y="199.0"/>
+      <point x="290.0" y="273.0" type="curve"/>
+      <point x="334.0" y="282" type="line"/>
+      <point x="344.0" y="230"/>
+      <point x="377.0" y="201.0"/>
+      <point x="423.0" y="201.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="201.0"/>
+      <point x="504.0" y="231"/>
+      <point x="504.0" y="274" type="curve" smooth="yes"/>
+      <point x="504.0" y="311"/>
+      <point x="472" y="342"/>
+      <point x="418.0" y="342" type="curve" smooth="yes"/>
+      <point x="406" y="342"/>
+      <point x="390.0" y="342"/>
+      <point x="390.0" y="342" type="curve"/>
+      <point x="390" y="384.0" type="line"/>
+      <point x="390" y="384.0"/>
+      <point x="411" y="384.0"/>
+      <point x="420" y="384.0" type="curve" smooth="yes"/>
+      <point x="460" y="384.0"/>
+      <point x="491" y="400.0"/>
+      <point x="491.0" y="446" type="curve" smooth="yes"/>
+      <point x="491" y="489"/>
+      <point x="468.0" y="512"/>
+      <point x="424" y="512" type="curve" smooth="yes"/>
+      <point x="379" y="512"/>
+      <point x="354" y="484"/>
+      <point x="344" y="449" type="curve"/>
+      <point x="299.0" y="458.0" type="line"/>
+      <point x="309.0" y="513.0"/>
+      <point x="357" y="554"/>
+      <point x="423" y="554.0" type="curve" smooth="yes"/>
+      <point x="495" y="554.0"/>
+      <point x="539.0" y="514.0"/>
+      <point x="539.0" y="453.0" type="curve" smooth="yes"/>
+      <point x="539.0" y="416.0"/>
+      <point x="519.0" y="386.0"/>
+      <point x="488.0" y="366.0" type="curve"/>
+      <point x="524.0" y="354.0"/>
+      <point x="551" y="324"/>
+      <point x="551.0" y="276.0" type="curve" smooth="yes"/>
+      <point x="551.0" y="203.0"/>
       <point x="497.0" y="160.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="three.numerator" xOffset="266" yOffset="-167"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>three.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.cap.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.cap.glif
@@ -7,7 +7,7 @@
       <point x="491.0" y="0.0" type="line"/>
       <point x="491.0" y="111.0" type="line"/>
       <point x="192.0" y="111.0" type="line"/>
-      <point x="282.0" y="177.0"/>
+      <point x="262.0" y="159.0"/>
       <point x="319.0" y="192.0"/>
       <point x="375.0" y="256.0" type="curve" smooth="yes"/>
       <point x="445.0" y="334.0"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.glif
@@ -26,13 +26,13 @@
       <point x="191.0" y="622.0"/>
       <point x="259.0" y="622.0" type="curve" smooth="yes"/>
       <point x="324.0" y="622.0"/>
-      <point x="365.0" y="600.0"/>
-      <point x="365.0" y="517.0" type="curve" smooth="yes"/>
-      <point x="365.0" y="456.0"/>
-      <point x="328.0" y="380.0"/>
-      <point x="289.0" y="325.0" type="curve" smooth="yes"/>
-      <point x="237.0" y="254.0"/>
-      <point x="195.0" y="225.0"/>
+      <point x="365.0" y="598.0"/>
+      <point x="365.0" y="529" type="curve" smooth="yes"/>
+      <point x="365" y="456"/>
+      <point x="329" y="378"/>
+      <point x="288.0" y="325.0" type="curve" smooth="yes"/>
+      <point x="234.0" y="254.0"/>
+      <point x="174.0" y="204.0"/>
       <point x="47.0" y="98.0" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="36.0" y="338.0" type="line"/>
-      <point x="288.0" y="338.0" type="line"/>
-      <point x="288.0" y="417.0" type="line"/>
-      <point x="155.0" y="417.0" type="line"/>
-      <point x="189.0" y="442.0"/>
-      <point x="197.0" y="444.0"/>
-      <point x="223.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="259.0" y="511.0"/>
-      <point x="284.0" y="559.0"/>
-      <point x="285.0" y="615.0" type="curve" smooth="yes"/>
-      <point x="286.0" y="680.0"/>
-      <point x="250.0" y="724.0"/>
-      <point x="159.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="86.0" y="724.0"/>
-      <point x="27.0" y="674.0"/>
-      <point x="22.0" y="610.0" type="curve"/>
-      <point x="106.0" y="592.0" type="line"/>
-      <point x="111.0" y="617.0"/>
-      <point x="124.0" y="645.0"/>
-      <point x="157.0" y="645.0" type="curve" smooth="yes"/>
-      <point x="182.0" y="645.0"/>
-      <point x="201.0" y="631.0"/>
-      <point x="201.0" y="601.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="579.0"/>
-      <point x="193.0" y="556.0"/>
-      <point x="167.0" y="525.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="491.0"/>
-      <point x="102.0" y="464.0"/>
-      <point x="36.0" y="414.0" type="curve"/>
+      <point x="33" y="338" type="line"/>
+      <point x="286" y="338" type="line"/>
+      <point x="286" y="415" type="line"/>
+      <point x="147" y="415" type="line"/>
+      <point x="174" y="433"/>
+      <point x="195" y="448"/>
+      <point x="220" y="476" type="curve" smooth="yes"/>
+      <point x="256" y="516"/>
+      <point x="287" y="557"/>
+      <point x="287" y="608" type="curve" smooth="yes"/>
+      <point x="287" y="678"/>
+      <point x="235" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="85" y="724"/>
+      <point x="31" y="679"/>
+      <point x="25" y="608" type="curve"/>
+      <point x="101" y="598" type="line"/>
+      <point x="106" y="629"/>
+      <point x="123" y="651"/>
+      <point x="157" y="651" type="curve" smooth="yes"/>
+      <point x="185" y="651"/>
+      <point x="208" y="635"/>
+      <point x="208" y="606" type="curve" smooth="yes"/>
+      <point x="208" y="581"/>
+      <point x="193" y="555"/>
+      <point x="167" y="524" type="curve" smooth="yes"/>
+      <point x="138" y="490"/>
+      <point x="92" y="451"/>
+      <point x="33" y="401" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="227.0" type="line"/>
-      <point x="372.0" y="277.0"/>
-      <point x="418.0" y="314.0"/>
-      <point x="447.0" y="348.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="379.0"/>
-      <point x="485.0" y="408.0"/>
-      <point x="485.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="478.0"/>
-      <point x="459.0" y="498.0"/>
-      <point x="427.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="389.0" y="498.0"/>
-      <point x="369.0" y="470.0"/>
-      <point x="364.0" y="430.0" type="curve"/>
+      <point x="306.0" y="220.0" type="line"/>
+      <point x="353.0" y="257.0"/>
+      <point x="421.0" y="309.0"/>
+      <point x="451.0" y="342.0" type="curve" smooth="yes"/>
+      <point x="478" y="372"/>
+      <point x="496.0" y="408"/>
+      <point x="496.0" y="444" type="curve" smooth="yes"/>
+      <point x="496.0" y="487"/>
+      <point x="471.0" y="513"/>
+      <point x="428.0" y="513" type="curve" smooth="yes"/>
+      <point x="379.0" y="513"/>
+      <point x="353.0" y="478"/>
+      <point x="346.0" y="433" type="curve"/>
       <point x="298.0" y="441.0" type="line"/>
       <point x="304.0" y="512.0"/>
       <point x="359.0" y="557.0"/>
       <point x="426.0" y="557.0" type="curve" smooth="yes"/>
       <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="436.0" y="255.0"/>
-      <point x="402.0" y="230.0" type="curve"/>
-      <point x="553.0" y="230.0" type="line"/>
+      <point x="546" y="513.0"/>
+      <point x="546" y="443.0" type="curve" smooth="yes"/>
+      <point x="546" y="392.0"/>
+      <point x="515" y="347.0"/>
+      <point x="473" y="307.0" type="curve" smooth="yes"/>
+      <point x="445" y="279.0"/>
+      <point x="385" y="234.0"/>
+      <point x="359" y="217.0" type="curve"/>
+      <point x="553" y="217.0" type="line"/>
       <point x="553.0" y="171.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="220.0" type="line"/>
-      <point x="353.0" y="257.0"/>
-      <point x="421.0" y="309.0"/>
-      <point x="451.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="478" y="372"/>
-      <point x="496.0" y="408"/>
-      <point x="496.0" y="444" type="curve" smooth="yes"/>
-      <point x="496.0" y="487"/>
-      <point x="471.0" y="513"/>
-      <point x="428.0" y="513" type="curve" smooth="yes"/>
-      <point x="379.0" y="513"/>
-      <point x="353.0" y="478"/>
-      <point x="346.0" y="433" type="curve"/>
+      <point x="306.0" y="240.0" type="line"/>
+      <point x="357.0" y="280.0"/>
+      <point x="404.0" y="320.0"/>
+      <point x="433.0" y="354.0" type="curve" smooth="yes"/>
+      <point x="459.0" y="385.0"/>
+      <point x="476" y="408"/>
+      <point x="476" y="437" type="curve" smooth="yes"/>
+      <point x="476" y="471"/>
+      <point x="455" y="489"/>
+      <point x="427" y="489" type="curve" smooth="yes"/>
+      <point x="394" y="489"/>
+      <point x="376" y="464"/>
+      <point x="372" y="428" type="curve"/>
       <point x="298.0" y="441.0" type="line"/>
       <point x="304.0" y="512.0"/>
       <point x="359.0" y="557.0"/>
       <point x="426.0" y="557.0" type="curve" smooth="yes"/>
       <point x="503.0" y="557.0"/>
-      <point x="546" y="513.0"/>
-      <point x="546" y="443.0" type="curve" smooth="yes"/>
-      <point x="546" y="392.0"/>
-      <point x="515" y="347.0"/>
-      <point x="473" y="307.0" type="curve" smooth="yes"/>
-      <point x="445" y="279.0"/>
-      <point x="385" y="234.0"/>
-      <point x="359" y="217.0" type="curve"/>
-      <point x="553" y="217.0" type="line"/>
+      <point x="554.0" y="513.0"/>
+      <point x="554.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="392.0"/>
+      <point x="529.0" y="349.0"/>
+      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
+      <point x="467" y="281"/>
+      <point x="427.0" y="249.0"/>
+      <point x="412.0" y="238.0" type="curve"/>
+      <point x="553.0" y="238.0" type="line"/>
       <point x="553.0" y="171.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,19 +6,4 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
-      <array>
-        <dict>
-          <key>alignment</key>
-          <integer>-1</integer>
-          <key>index</key>
-          <integer>0</integer>
-          <key>name</key>
-          <string>two.numerator</string>
-        </dict>
-      </array>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.sc.glif
@@ -9,9 +9,9 @@
       <point x="199.0" y="105.0" type="line"/>
       <point x="198.0" y="107.0" type="line"/>
       <point x="232.0" y="125.0"/>
-      <point x="281.0" y="167.0"/>
-      <point x="325.0" y="219.0" type="curve"/>
-      <point x="376.0" y="279.0"/>
+      <point x="281" y="167"/>
+      <point x="325.0" y="219.0" type="curve" smooth="yes"/>
+      <point x="376" y="279"/>
       <point x="408.0" y="345.0"/>
       <point x="408.0" y="426.0" type="curve" smooth="yes"/>
       <point x="408.0" y="532.0"/>
@@ -28,9 +28,9 @@
       <point x="294.0" y="473.0"/>
       <point x="294.0" y="409.0" type="curve" smooth="yes"/>
       <point x="294.0" y="364.0"/>
-      <point x="281.0" y="315.0"/>
-      <point x="244.0" y="270.0" type="curve"/>
-      <point x="206.0" y="221.0"/>
+      <point x="280" y="316"/>
+      <point x="244.0" y="270.0" type="curve" smooth="yes"/>
+      <point x="205" y="222"/>
       <point x="128.0" y="157.0"/>
       <point x="46.0" y="95.0" type="curve"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/two.tf.glif
@@ -8,7 +8,7 @@
       <point x="539.0" y="111.0" type="line"/>
       <point x="234.0" y="111.0" type="line"/>
       <point x="234.0" y="120.0" type="line"/>
-      <point x="318.0" y="176.0"/>
+      <point x="297.0" y="162.0"/>
       <point x="356.0" y="198.0"/>
       <point x="414.0" y="263.0" type="curve" smooth="yes"/>
       <point x="486.0" y="341.0"/>
@@ -31,14 +31,8 @@
       <point x="380.0" y="386.0"/>
       <point x="340.0" y="342.0" type="curve" smooth="yes"/>
       <point x="278.0" y="273.0"/>
-      <point x="188.0" y="200.0"/>
+      <point x="181.0" y="188.0"/>
       <point x="72.0" y="118.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="379"/>
   <outline>
     <contour>
-      <point x="189.0" y="330.0" type="curve"/>
-      <point x="292.0" y="330.0"/>
-      <point x="355.0" y="411.0"/>
-      <point x="355.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="355.0" y="643.0"/>
-      <point x="293.0" y="724.0"/>
-      <point x="189.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="85.0" y="724.0"/>
-      <point x="24.0" y="643.0"/>
-      <point x="24.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="24.0" y="411.0"/>
-      <point x="86.0" y="330.0"/>
+      <point x="189" y="330" type="curve" smooth="yes"/>
+      <point x="282" y="330"/>
+      <point x="345" y="411"/>
+      <point x="345" y="527" type="curve" smooth="yes"/>
+      <point x="345" y="643"/>
+      <point x="282" y="724"/>
+      <point x="189" y="724" type="curve" smooth="yes"/>
+      <point x="96" y="724"/>
+      <point x="34" y="643"/>
+      <point x="34" y="527" type="curve" smooth="yes"/>
+      <point x="34" y="411"/>
+      <point x="96" y="330"/>
     </contour>
     <contour>
-      <point x="189.0" y="404.0" type="curve"/>
-      <point x="145.0" y="404.0"/>
-      <point x="122.0" y="441.0"/>
-      <point x="122.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="613.0"/>
-      <point x="145.0" y="650.0"/>
-      <point x="189.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="650.0"/>
-      <point x="258.0" y="613.0"/>
-      <point x="258.0" y="527.0" type="curve" smooth="yes"/>
-      <point x="258.0" y="441.0"/>
-      <point x="232.0" y="404.0"/>
+      <point x="190" y="403.0" type="curve" smooth="yes"/>
+      <point x="143" y="403.0"/>
+      <point x="113" y="449.0"/>
+      <point x="113" y="526.0" type="curve" smooth="yes"/>
+      <point x="113" y="604.0"/>
+      <point x="143" y="650.0"/>
+      <point x="190" y="650.0" type="curve" smooth="yes"/>
+      <point x="236" y="650.0"/>
+      <point x="266.0" y="604.0"/>
+      <point x="266.0" y="526.0" type="curve" smooth="yes"/>
+      <point x="266.0" y="449.0"/>
+      <point x="236" y="403.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/two.ss03.glif
@@ -8,10 +8,10 @@
       <point x="482" y="61" type="line"/>
       <point x="131" y="61" type="line"/>
       <point x="131" y="61" type="line"/>
-      <point x="131" y="61"/>
-      <point x="294" y="232"/>
+      <point x="145" y="76"/>
+      <point x="305" y="245"/>
       <point x="343" y="283" type="curve" smooth="yes"/>
-      <point x="406" y="348"/>
+      <point x="407" y="347"/>
       <point x="472" y="432"/>
       <point x="472" y="530" type="curve" smooth="yes"/>
       <point x="472" y="648"/>
@@ -28,10 +28,10 @@
       <point x="407" y="609"/>
       <point x="407" y="528" type="curve" smooth="yes"/>
       <point x="407" y="450"/>
-      <point x="375" y="406"/>
+      <point x="374" y="407"/>
       <point x="296" y="323" type="curve" smooth="yes"/>
-      <point x="228" y="251"/>
-      <point x="52" y="65"/>
+      <point x="240" y="264"/>
+      <point x="68" y="82"/>
       <point x="52" y="65" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="63" y="120" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425" y="-14" type="curve" smooth="yes"/>
-      <point x="630" y="-14"/>
-      <point x="797" y="153"/>
-      <point x="797" y="358" type="curve" smooth="yes"/>
-      <point x="797" y="563"/>
-      <point x="630" y="730"/>
-      <point x="425" y="730" type="curve" smooth="yes"/>
-      <point x="220" y="730"/>
-      <point x="53" y="563"/>
-      <point x="53" y="358" type="curve" smooth="yes"/>
-      <point x="53" y="153"/>
-      <point x="220" y="-14"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="34" type="curve" smooth="yes"/>
+      <point x="425" y="34" type="curve" smooth="yes"/>
       <point x="249" y="34"/>
       <point x="101" y="182"/>
-      <point x="101" y="358.0" type="curve" smooth="yes"/>
-      <point x="101" y="538"/>
+      <point x="101" y="358" type="curve" smooth="yes"/>
+      <point x="101" y="537"/>
       <point x="249" y="682"/>
-      <point x="425.0" y="682" type="curve" smooth="yes"/>
-      <point x="606" y="682"/>
-      <point x="749" y="538"/>
-      <point x="749" y="358.0" type="curve" smooth="yes"/>
+      <point x="425" y="682" type="curve" smooth="yes"/>
+      <point x="605" y="682"/>
+      <point x="749" y="537"/>
+      <point x="749" y="358" type="curve" smooth="yes"/>
       <point x="749" y="182"/>
-      <point x="606" y="34"/>
+      <point x="605" y="34"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="313"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="228.0" y="342.0"/>
-      <point x="283.0" y="384.0"/>
-      <point x="283.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="490.0"/>
-      <point x="259.0" y="529.0"/>
-      <point x="212.0" y="543.0" type="curve"/>
-      <point x="247" y="552"/>
-      <point x="271.0" y="580.0"/>
-      <point x="271.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="271" y="682"/>
-      <point x="224" y="724.0"/>
-      <point x="157.0" y="724.0" type="curve" smooth="yes"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="223" y="342"/>
+      <point x="290" y="384"/>
+      <point x="290" y="455" type="curve" smooth="yes"/>
+      <point x="290" y="490"/>
+      <point x="264" y="529"/>
+      <point x="225" y="543" type="curve"/>
+      <point x="257" y="558"/>
+      <point x="278" y="588"/>
+      <point x="278" y="616" type="curve" smooth="yes"/>
+      <point x="278" y="682"/>
+      <point x="224.0" y="724.0"/>
+      <point x="157" y="724" type="curve" smooth="yes"/>
       <point x="90" y="724"/>
-      <point x="42" y="682"/>
-      <point x="42.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="42.0" y="582"/>
-      <point x="64.0" y="553.0"/>
-      <point x="100.0" y="543.0" type="curve"/>
-      <point x="54.0" y="525.0"/>
-      <point x="30.0" y="490.0"/>
-      <point x="30.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="30.0" y="385.0"/>
-      <point x="86" y="342"/>
+      <point x="35" y="682"/>
+      <point x="35" y="616" type="curve" smooth="yes"/>
+      <point x="35" y="587"/>
+      <point x="55" y="558"/>
+      <point x="87" y="543" type="curve"/>
+      <point x="47" y="526"/>
+      <point x="23" y="490"/>
+      <point x="23" y="455" type="curve" smooth="yes"/>
+      <point x="23" y="385"/>
+      <point x="90" y="342"/>
     </contour>
     <contour>
-      <point x="157.0" y="386.0" type="curve" smooth="yes"/>
-      <point x="109.0" y="386"/>
-      <point x="77.0" y="414.0"/>
-      <point x="77.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="77" y="492"/>
-      <point x="111.0" y="520.0"/>
-      <point x="157.0" y="520.0" type="curve" smooth="yes"/>
-      <point x="203" y="520"/>
-      <point x="236" y="491.0"/>
-      <point x="236.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="236" y="415"/>
-      <point x="205" y="386"/>
+      <point x="157" y="392" type="curve" smooth="yes"/>
+      <point x="118" y="392"/>
+      <point x="86" y="417"/>
+      <point x="86" y="455" type="curve" smooth="yes"/>
+      <point x="86" y="492"/>
+      <point x="115.0" y="517.0"/>
+      <point x="157" y="517" type="curve" smooth="yes"/>
+      <point x="199" y="517"/>
+      <point x="227" y="490"/>
+      <point x="227" y="455" type="curve" smooth="yes"/>
+      <point x="227" y="419"/>
+      <point x="196.0" y="392.0"/>
     </contour>
     <contour>
-      <point x="157.0" y="560.0" type="curve" smooth="yes"/>
-      <point x="119.0" y="560.0"/>
-      <point x="92" y="587"/>
-      <point x="92.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="92.0" y="655.0"/>
-      <point x="117" y="680"/>
-      <point x="157.0" y="680.0" type="curve" smooth="yes"/>
-      <point x="197.0" y="680.0"/>
-      <point x="221" y="654"/>
-      <point x="221.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="221.0" y="588.0"/>
-      <point x="195" y="560"/>
+      <point x="157" y="561" type="curve" smooth="yes"/>
+      <point x="124" y="561"/>
+      <point x="97" y="583"/>
+      <point x="97" y="616" type="curve" smooth="yes"/>
+      <point x="97" y="647"/>
+      <point x="121" y="672"/>
+      <point x="157" y="672" type="curve" smooth="yes"/>
+      <point x="191" y="672"/>
+      <point x="216" y="647"/>
+      <point x="216" y="616" type="curve" smooth="yes"/>
+      <point x="216" y="584"/>
+      <point x="188" y="561"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,72 +4,72 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="425.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="456.0" y="228.0"/>
-      <point x="492.0" y="252.0"/>
-      <point x="492.0" y="285.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="456.0" y="341.0"/>
-      <point x="425.0" y="341.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="341.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="285.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="251.0"/>
-      <point x="392.0" y="228.0"/>
+      <point x="425" y="232" type="curve" smooth="yes"/>
+      <point x="454" y="232"/>
+      <point x="485" y="252"/>
+      <point x="485" y="285" type="curve" smooth="yes"/>
+      <point x="485" y="317"/>
+      <point x="454" y="338"/>
+      <point x="425" y="338" type="curve" smooth="yes"/>
+      <point x="395" y="338"/>
+      <point x="366" y="318"/>
+      <point x="366" y="285" type="curve" smooth="yes"/>
+      <point x="366" y="251"/>
+      <point x="394" y="232"/>
     </contour>
     <contour>
       <point x="425.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="358.0" y="169.0"/>
-      <point x="292.0" y="212.0"/>
-      <point x="292.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="317.0"/>
+      <point x="355" y="169"/>
+      <point x="289.0" y="212.0"/>
+      <point x="289.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="317.0"/>
       <point x="312.0" y="349.0"/>
       <point x="346.0" y="370.0" type="curve"/>
       <point x="322.0" y="385.0"/>
-      <point x="304.0" y="414.0"/>
-      <point x="304.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="509.0"/>
-      <point x="362.0" y="551.0"/>
+      <point x="301.0" y="414.0"/>
+      <point x="301.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="301.0" y="509.0"/>
+      <point x="359" y="551"/>
       <point x="425.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="551.0"/>
-      <point x="546.0" y="509.0"/>
-      <point x="546.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="546.0" y="415.0"/>
+      <point x="491" y="551"/>
+      <point x="549.0" y="509.0"/>
+      <point x="549.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="549.0" y="415.0"/>
       <point x="528.0" y="385.0"/>
       <point x="505.0" y="370.0" type="curve"/>
       <point x="539.0" y="349.0"/>
-      <point x="558.0" y="317.0"/>
-      <point x="558.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="211.0"/>
-      <point x="491.0" y="169.0"/>
+      <point x="561.0" y="317.0"/>
+      <point x="561.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="561.0" y="211.0"/>
+      <point x="494" y="169"/>
     </contour>
     <contour>
-      <point x="425.0" y="395.0" type="curve" smooth="yes"/>
-      <point x="454.0" y="395.0"/>
-      <point x="480.0" y="415.0"/>
-      <point x="480.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="470.0"/>
-      <point x="457.0" y="492.0"/>
-      <point x="425.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="492.0"/>
-      <point x="371.0" y="470.0"/>
-      <point x="371.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="414.0"/>
-      <point x="396.0" y="395.0"/>
+      <point x="425" y="398" type="curve" smooth="yes"/>
+      <point x="453" y="398"/>
+      <point x="474" y="415"/>
+      <point x="474" y="443" type="curve" smooth="yes"/>
+      <point x="474" y="470"/>
+      <point x="455" y="488"/>
+      <point x="425" y="488" type="curve" smooth="yes"/>
+      <point x="395" y="488"/>
+      <point x="377" y="470"/>
+      <point x="377" y="443" type="curve" smooth="yes"/>
+      <point x="377" y="414"/>
+      <point x="397" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,72 +4,72 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="425" y="232" type="curve" smooth="yes"/>
-      <point x="454" y="232"/>
-      <point x="485" y="252"/>
-      <point x="485" y="285" type="curve" smooth="yes"/>
-      <point x="485" y="317"/>
-      <point x="454" y="338"/>
-      <point x="425" y="338" type="curve" smooth="yes"/>
-      <point x="395" y="338"/>
-      <point x="366" y="318"/>
-      <point x="366" y="285" type="curve" smooth="yes"/>
-      <point x="366" y="251"/>
-      <point x="394" y="232"/>
+      <point x="425" y="204" type="curve" smooth="yes"/>
+      <point x="465" y="204"/>
+      <point x="511" y="236"/>
+      <point x="511" y="279" type="curve" smooth="yes"/>
+      <point x="511" y="321"/>
+      <point x="465" y="353"/>
+      <point x="425" y="353" type="curve" smooth="yes"/>
+      <point x="383" y="353"/>
+      <point x="339" y="322"/>
+      <point x="339" y="279" type="curve" smooth="yes"/>
+      <point x="339" y="234"/>
+      <point x="382" y="204"/>
     </contour>
     <contour>
       <point x="425.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="355" y="169"/>
-      <point x="289.0" y="212.0"/>
-      <point x="289.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="317.0"/>
-      <point x="312.0" y="349.0"/>
-      <point x="346.0" y="370.0" type="curve"/>
-      <point x="322.0" y="385.0"/>
-      <point x="301.0" y="414.0"/>
-      <point x="301.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="301.0" y="509.0"/>
-      <point x="359" y="551"/>
+      <point x="358.0" y="169.0"/>
+      <point x="298.0" y="212.0"/>
+      <point x="298.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="298.0" y="317.0"/>
+      <point x="318.0" y="349.0"/>
+      <point x="366.0" y="371.0" type="curve"/>
+      <point x="332.0" y="388.0"/>
+      <point x="313.0" y="417.0"/>
+      <point x="313.0" y="446.0" type="curve" smooth="yes"/>
+      <point x="313.0" y="512.0"/>
+      <point x="362.0" y="551.0"/>
       <point x="425.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="491" y="551"/>
-      <point x="549.0" y="509.0"/>
-      <point x="549.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="549.0" y="415.0"/>
-      <point x="528.0" y="385.0"/>
-      <point x="505.0" y="370.0" type="curve"/>
-      <point x="539.0" y="349.0"/>
-      <point x="561.0" y="317.0"/>
-      <point x="561.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="561.0" y="211.0"/>
-      <point x="494" y="169"/>
+      <point x="488.0" y="551.0"/>
+      <point x="537.0" y="513.0"/>
+      <point x="537.0" y="447.0" type="curve" smooth="yes"/>
+      <point x="537.0" y="419.0"/>
+      <point x="514.0" y="384.0"/>
+      <point x="489.0" y="370.0" type="curve"/>
+      <point x="531.0" y="349.0"/>
+      <point x="552.0" y="317.0"/>
+      <point x="552.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="552.0" y="211.0"/>
+      <point x="491.0" y="169.0"/>
     </contour>
     <contour>
-      <point x="425" y="398" type="curve" smooth="yes"/>
-      <point x="453" y="398"/>
-      <point x="474" y="415"/>
-      <point x="474" y="443" type="curve" smooth="yes"/>
-      <point x="474" y="470"/>
-      <point x="455" y="488"/>
-      <point x="425" y="488" type="curve" smooth="yes"/>
-      <point x="395" y="488"/>
-      <point x="377" y="470"/>
-      <point x="377" y="443" type="curve" smooth="yes"/>
-      <point x="377" y="414"/>
-      <point x="397" y="398"/>
+      <point x="425.0" y="389" type="curve" smooth="yes"/>
+      <point x="462.0" y="389"/>
+      <point x="495.0" y="414"/>
+      <point x="495.0" y="449" type="curve" smooth="yes"/>
+      <point x="495.0" y="483"/>
+      <point x="466.0" y="511.0"/>
+      <point x="425.0" y="511.0" type="curve" smooth="yes"/>
+      <point x="384.0" y="511.0"/>
+      <point x="356.0" y="483"/>
+      <point x="356.0" y="449" type="curve" smooth="yes"/>
+      <point x="356.0" y="412"/>
+      <point x="388.0" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="eight.numerator" xOffset="269" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>eight.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="156.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="227.0" y="343.0"/>
-      <point x="283.0" y="397.0"/>
-      <point x="283.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="546.0"/>
+      <point x="156" y="343" type="curve" smooth="yes"/>
+      <point x="227" y="343"/>
+      <point x="285" y="395"/>
+      <point x="285" y="470" type="curve" smooth="yes"/>
+      <point x="285.0" y="547.0"/>
       <point x="232" y="595"/>
-      <point x="170" y="595.0" type="curve" smooth="yes"/>
-      <point x="131.0" y="595.0"/>
-      <point x="99" y="578.0"/>
-      <point x="83.0" y="559.0" type="curve"/>
-      <point x="97.0" y="673.0" type="line"/>
-      <point x="262.0" y="673.0" type="line"/>
-      <point x="262.0" y="716.0" type="line"/>
-      <point x="65.0" y="716.0" type="line"/>
-      <point x="40.0" y="527.0" type="line"/>
-      <point x="79" y="510.0" type="line"/>
-      <point x="102" y="540.0"/>
-      <point x="128" y="552.0"/>
-      <point x="159" y="552.0" type="curve" smooth="yes"/>
-      <point x="204" y="552.0"/>
-      <point x="235" y="520"/>
-      <point x="235" y="471.0" type="curve" smooth="yes"/>
-      <point x="235" y="422.0"/>
-      <point x="207" y="387.0"/>
-      <point x="159" y="387.0" type="curve" smooth="yes"/>
-      <point x="115" y="387"/>
-      <point x="77" y="411.0"/>
-      <point x="68" y="452.0" type="curve"/>
-      <point x="28.0" y="435.0" type="line"/>
-      <point x="46.0" y="369.0"/>
-      <point x="102.0" y="343.0"/>
+      <point x="164" y="595" type="curve" smooth="yes"/>
+      <point x="140" y="595"/>
+      <point x="108" y="579"/>
+      <point x="95" y="565" type="curve"/>
+      <point x="109" y="667" type="line"/>
+      <point x="267" y="667" type="line"/>
+      <point x="267" y="716" type="line"/>
+      <point x="63" y="716" type="line"/>
+      <point x="36" y="526" type="line"/>
+      <point x="86" y="506.0" type="line"/>
+      <point x="106" y="533.0"/>
+      <point x="130" y="547"/>
+      <point x="159" y="547.0" type="curve" smooth="yes"/>
+      <point x="198" y="547"/>
+      <point x="226" y="519.0"/>
+      <point x="226" y="470.0" type="curve" smooth="yes"/>
+      <point x="226" y="421"/>
+      <point x="198" y="396.0"/>
+      <point x="155" y="396.0" type="curve" smooth="yes"/>
+      <point x="117" y="396"/>
+      <point x="85" y="417.0"/>
+      <point x="77" y="455.0" type="curve"/>
+      <point x="26" y="436" type="line"/>
+      <point x="44" y="370"/>
+      <point x="102" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,50 +4,50 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
       <point x="426.0" y="169.0" type="curve" smooth="yes"/>
       <point x="372.0" y="169.0"/>
       <point x="311.0" y="194.0"/>
       <point x="293.0" y="260.0" type="curve"/>
-      <point x="359.0" y="287.0" type="line"/>
-      <point x="367.0" y="252.0"/>
-      <point x="389.0" y="232.0"/>
-      <point x="426.0" y="232.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="232.0"/>
-      <point x="488.0" y="259.0"/>
-      <point x="488.0" y="297.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="336.0"/>
-      <point x="463.0" y="361.0"/>
-      <point x="425.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="401.0" y="361.0"/>
-      <point x="382.0" y="351.0"/>
-      <point x="364.0" y="326.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="542.0" type="line"/>
-      <point x="540.0" y="542.0" type="line"/>
-      <point x="540.0" y="482.0" type="line"/>
-      <point x="386.0" y="482.0" type="line"/>
-      <point x="375.0" y="404.0" type="line"/>
-      <point x="389.0" y="417.0"/>
-      <point x="410.0" y="421.0"/>
-      <point x="442.0" y="421.0" type="curve"/>
-      <point x="505.0" y="421.0"/>
-      <point x="558.0" y="372.0"/>
-      <point x="558.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="223.0"/>
+      <point x="332" y="275" type="line"/>
+      <point x="342" y="233"/>
+      <point x="378" y="208"/>
+      <point x="427" y="208" type="curve" smooth="yes"/>
+      <point x="476" y="208"/>
+      <point x="511" y="248"/>
+      <point x="511" y="297" type="curve" smooth="yes"/>
+      <point x="511.0" y="349"/>
+      <point x="481.0" y="377.0"/>
+      <point x="432" y="377.0" type="curve" smooth="yes"/>
+      <point x="394" y="377"/>
+      <point x="369" y="362"/>
+      <point x="352" y="336" type="curve"/>
+      <point x="311.0" y="351.0" type="line"/>
+      <point x="339.0" y="542.0" type="line"/>
+      <point x="537.0" y="542.0" type="line"/>
+      <point x="537.0" y="502.0" type="line"/>
+      <point x="367.0" y="502.0" type="line"/>
+      <point x="347.0" y="372.0" type="line"/>
+      <point x="366.0" y="393.0"/>
+      <point x="393" y="413"/>
+      <point x="434.0" y="413.0" type="curve" smooth="yes"/>
+      <point x="503.0" y="413.0"/>
+      <point x="554.0" y="371.0"/>
+      <point x="554.0" y="296.0" type="curve" smooth="yes"/>
+      <point x="554" y="223"/>
       <point x="497.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,47 +4,47 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="426.0" y="169.0" type="curve" smooth="yes"/>
       <point x="372.0" y="169.0"/>
       <point x="311.0" y="194.0"/>
       <point x="293.0" y="260.0" type="curve"/>
-      <point x="354.0" y="283.0" type="line"/>
-      <point x="362.0" y="248.0"/>
-      <point x="389.0" y="228.0"/>
-      <point x="426.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="228.0"/>
-      <point x="492.0" y="259.0"/>
-      <point x="492.0" y="297.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="336.0"/>
-      <point x="463.0" y="365.0"/>
-      <point x="425.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="401.0" y="365.0"/>
-      <point x="379.0" y="355.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
+      <point x="359.0" y="287.0" type="line"/>
+      <point x="367.0" y="252.0"/>
+      <point x="389.0" y="232.0"/>
+      <point x="426.0" y="232.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="232.0"/>
+      <point x="488.0" y="259.0"/>
+      <point x="488.0" y="297.0" type="curve" smooth="yes"/>
+      <point x="488.0" y="336.0"/>
+      <point x="463.0" y="361.0"/>
+      <point x="425.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="401.0" y="361.0"/>
+      <point x="382.0" y="351.0"/>
+      <point x="364.0" y="326.0" type="curve"/>
       <point x="305.0" y="353.0" type="line"/>
       <point x="330.0" y="542.0" type="line"/>
-      <point x="537.0" y="542.0" type="line"/>
-      <point x="537.0" y="486.0" type="line"/>
-      <point x="384.0" y="486.0" type="line"/>
-      <point x="372.0" y="400.0" type="line"/>
-      <point x="386.0" y="413.0"/>
+      <point x="540.0" y="542.0" type="line"/>
+      <point x="540.0" y="482.0" type="line"/>
+      <point x="386.0" y="482.0" type="line"/>
+      <point x="375.0" y="404.0" type="line"/>
+      <point x="389.0" y="417.0"/>
       <point x="410.0" y="421.0"/>
-      <point x="434.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="502.0" y="421.0"/>
+      <point x="442.0" y="421.0" type="curve"/>
+      <point x="505.0" y="421.0"/>
       <point x="558.0" y="372.0"/>
       <point x="558.0" y="296.0" type="curve" smooth="yes"/>
       <point x="558.0" y="223.0"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="five.numerator" xOffset="270" yOffset="-174"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>five.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="340"/>
   <outline>
     <contour>
-      <point x="27.0" y="431.0" type="line"/>
-      <point x="313.0" y="431.0" type="line"/>
-      <point x="313.0" y="474.0" type="line"/>
-      <point x="85.0" y="474.0" type="line"/>
-      <point x="207.0" y="644.0" type="line"/>
-      <point x="211.0" y="644.0" type="line"/>
-      <point x="211.0" y="350.0" type="line"/>
-      <point x="256.0" y="350.0" type="line"/>
-      <point x="256.0" y="716.0" type="line"/>
-      <point x="208.0" y="716.0" type="line"/>
-      <point x="27.0" y="463.0" type="line"/>
+      <point x="27" y="431" type="line"/>
+      <point x="313" y="431" type="line"/>
+      <point x="313" y="478" type="line"/>
+      <point x="84" y="478" type="line"/>
+      <point x="201" y="637" type="line"/>
+      <point x="204" y="637" type="line"/>
+      <point x="204" y="350" type="line"/>
+      <point x="259" y="350" type="line"/>
+      <point x="259" y="716" type="line"/>
+      <point x="203" y="716" type="line"/>
+      <point x="27" y="468" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="336.0" y="310.0" type="line"/>
-      <point x="429.0" y="310.0" type="line"/>
-      <point x="429.0" y="439.0" type="line"/>
-      <point x="428.0" y="439.0" type="line"/>
+      <point x="308.0" y="299.0" type="line"/>
+      <point x="443.0" y="299.0" type="line"/>
+      <point x="443.0" y="484.0" type="line"/>
+      <point x="440.0" y="484.0" type="line"/>
     </contour>
     <contour>
-      <point x="429.0" y="177.0" type="line"/>
-      <point x="429.0" y="248.0" type="line"/>
-      <point x="260.0" y="248.0" type="line"/>
-      <point x="260.0" y="301.0" type="line"/>
-      <point x="433.0" y="543.0" type="line"/>
-      <point x="500.0" y="543.0" type="line"/>
-      <point x="500.0" y="310.0" type="line"/>
-      <point x="547.0" y="310.0" type="line"/>
-      <point x="547.0" y="248.0" type="line"/>
-      <point x="500.0" y="248.0" type="line"/>
-      <point x="500.0" y="177.0" type="line"/>
+      <point x="443.0" y="177.0" type="line"/>
+      <point x="443.0" y="258.0" type="line"/>
+      <point x="261.0" y="258.0" type="line"/>
+      <point x="261.0" y="302.0" type="line"/>
+      <point x="437.0" y="543.0" type="line"/>
+      <point x="488.0" y="543.0" type="line"/>
+      <point x="488.0" y="299.0" type="line"/>
+      <point x="547.0" y="299.0" type="line"/>
+      <point x="547.0" y="258.0" type="line"/>
+      <point x="488.0" y="258.0" type="line"/>
+      <point x="488.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="331.0" y="307.0" type="line"/>
-      <point x="433.0" y="307.0" type="line"/>
-      <point x="433.0" y="444.0" type="line"/>
-      <point x="429.0" y="444.0" type="line"/>
+      <point x="336.0" y="310.0" type="line"/>
+      <point x="429.0" y="310.0" type="line"/>
+      <point x="429.0" y="439.0" type="line"/>
+      <point x="428.0" y="439.0" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="177.0" type="line"/>
-      <point x="433.0" y="251.0" type="line"/>
-      <point x="261.0" y="251.0" type="line"/>
-      <point x="261.0" y="295.0" type="line"/>
-      <point x="437.0" y="543.0" type="line"/>
-      <point x="498.0" y="543.0" type="line"/>
-      <point x="498.0" y="307.0" type="line"/>
-      <point x="547.0" y="307.0" type="line"/>
-      <point x="547.0" y="251.0" type="line"/>
-      <point x="498.0" y="251.0" type="line"/>
-      <point x="498.0" y="177.0" type="line"/>
+      <point x="429.0" y="177.0" type="line"/>
+      <point x="429.0" y="248.0" type="line"/>
+      <point x="260.0" y="248.0" type="line"/>
+      <point x="260.0" y="301.0" type="line"/>
+      <point x="433.0" y="543.0" type="line"/>
+      <point x="500.0" y="543.0" type="line"/>
+      <point x="500.0" y="310.0" type="line"/>
+      <point x="547.0" y="310.0" type="line"/>
+      <point x="547.0" y="248.0" type="line"/>
+      <point x="500.0" y="248.0" type="line"/>
+      <point x="500.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="four.numerator" xOffset="233" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>four.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="136.0" y="334.0" type="line"/>
-      <point x="172.0" y="384.0"/>
-      <point x="207.0" y="434.0"/>
-      <point x="242.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="269.0" y="521.0"/>
-      <point x="287.0" y="557.0"/>
-      <point x="287.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="287.0" y="667.0"/>
-      <point x="228.0" y="724.0"/>
-      <point x="155.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="86.0" y="724.0"/>
-      <point x="26.0" y="667.0"/>
-      <point x="26.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="26.0" y="534.0"/>
-      <point x="70.0" y="474.0"/>
-      <point x="146.0" y="474.0" type="curve" smooth="yes"/>
-      <point x="165.0" y="474.0"/>
-      <point x="193.0" y="486.0"/>
-      <point x="205.0" y="496.0" type="curve"/>
-      <point x="155.0" y="436.0"/>
-      <point x="127.0" y="399.0"/>
-      <point x="98.0" y="362.0" type="curve"/>
+      <point x="136" y="334" type="line"/>
+      <point x="172" y="384"/>
+      <point x="208" y="434"/>
+      <point x="244" y="484" type="curve" smooth="yes"/>
+      <point x="271" y="521"/>
+      <point x="289" y="557"/>
+      <point x="289" y="598" type="curve" smooth="yes"/>
+      <point x="289" y="667"/>
+      <point x="229" y="724"/>
+      <point x="155" y="724" type="curve" smooth="yes"/>
+      <point x="85" y="724"/>
+      <point x="23" y="667"/>
+      <point x="23" y="598" type="curve" smooth="yes"/>
+      <point x="23" y="534"/>
+      <point x="77" y="477"/>
+      <point x="146" y="477" type="curve" smooth="yes"/>
+      <point x="155" y="477"/>
+      <point x="184" y="484"/>
+      <point x="193" y="493" type="curve"/>
+      <point x="164" y="461"/>
+      <point x="123" y="409"/>
+      <point x="91" y="366" type="curve"/>
     </contour>
     <contour>
-      <point x="156.0" y="514.0" type="curve" smooth="yes"/>
-      <point x="105.0" y="514.0"/>
-      <point x="70.0" y="553.0"/>
-      <point x="70.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="70.0" y="641.0"/>
-      <point x="105.0" y="681.0"/>
-      <point x="156.0" y="681.0" type="curve" smooth="yes"/>
-      <point x="208.0" y="681.0"/>
-      <point x="241.0" y="641.0"/>
-      <point x="241.0" y="597.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="553.0"/>
-      <point x="207.0" y="514.0"/>
+      <point x="156" y="524" type="curve" smooth="yes"/>
+      <point x="111" y="524"/>
+      <point x="84" y="557"/>
+      <point x="84" y="597" type="curve" smooth="yes"/>
+      <point x="84.0" y="639.0"/>
+      <point x="114" y="671"/>
+      <point x="156" y="671" type="curve" smooth="yes"/>
+      <point x="201.0" y="671.0"/>
+      <point x="228" y="638"/>
+      <point x="228" y="597" type="curve" smooth="yes"/>
+      <point x="228.0" y="556.0"/>
+      <point x="199.0" y="524.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="404.0" y="160.0" type="curve"/>
-      <point x="347.0" y="198.0" type="line"/>
-      <point x="374.0" y="236.0"/>
-      <point x="409.0" y="281.0"/>
-      <point x="438.0" y="306.0" type="curve"/>
-      <point x="432.0" y="302.0"/>
-      <point x="421.0" y="300.0"/>
+      <point x="402.0" y="160.0" type="curve"/>
+      <point x="366.0" y="186.0" type="line"/>
+      <point x="395.0" y="223.0"/>
+      <point x="445.0" y="287.0"/>
+      <point x="478.0" y="321.0" type="curve"/>
+      <point x="466.0" y="312.0"/>
+      <point x="438.0" y="300.0"/>
       <point x="412.0" y="300.0" type="curve" smooth="yes"/>
       <point x="343.0" y="300.0"/>
-      <point x="286.0" y="360.0"/>
-      <point x="286.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="286.0" y="493.0"/>
-      <point x="348.0" y="550.0"/>
+      <point x="289.0" y="360.0"/>
+      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="493.0"/>
+      <point x="351.0" y="550.0"/>
       <point x="421.0" y="550.0" type="curve" smooth="yes"/>
-      <point x="498.0" y="550.0"/>
-      <point x="558.0" y="493.0"/>
-      <point x="558.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="383.0"/>
-      <point x="539.0" y="345.0"/>
-      <point x="512.0" y="308.0" type="curve" smooth="yes"/>
-      <point x="476.0" y="258.0"/>
-      <point x="440.0" y="210.0"/>
+      <point x="495.0" y="550.0"/>
+      <point x="555.0" y="493.0"/>
+      <point x="555.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="555.0" y="383.0"/>
+      <point x="537.0" y="347.0"/>
+      <point x="510.0" y="310.0" type="curve" smooth="yes"/>
+      <point x="474.0" y="260.0"/>
+      <point x="438.0" y="210.0"/>
     </contour>
     <contour>
-      <point x="422.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="459.0" y="361.0"/>
-      <point x="482.0" y="390.0"/>
-      <point x="482.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="482.0" y="457.0"/>
-      <point x="460.0" y="486.0"/>
-      <point x="422.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="385.0" y="486.0"/>
-      <point x="362.0" y="457.0"/>
-      <point x="362.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="362.0" y="390.0"/>
-      <point x="385.0" y="361.0"/>
+      <point x="422.0" y="336.0" type="curve" smooth="yes"/>
+      <point x="476.0" y="336.0"/>
+      <point x="513.0" y="377.0"/>
+      <point x="513.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="513.0" y="470.0"/>
+      <point x="477.0" y="511.0"/>
+      <point x="422.0" y="511.0" type="curve" smooth="yes"/>
+      <point x="368.0" y="511.0"/>
+      <point x="331.0" y="470.0"/>
+      <point x="331.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="331.0" y="377.0"/>
+      <point x="368.0" y="336.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="402.0" y="161.0" type="curve"/>
-      <point x="352.0" y="196.0" type="line"/>
-      <point x="381.0" y="233.0"/>
-      <point x="410.0" y="270.0"/>
-      <point x="439.0" y="307.0" type="curve"/>
-      <point x="433.0" y="303.0"/>
-      <point x="422.0" y="301.0"/>
-      <point x="413.0" y="301.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="301.0"/>
-      <point x="290.0" y="361.0"/>
-      <point x="290.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="494.0"/>
-      <point x="351.0" y="551.0"/>
-      <point x="422.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="496.0" y="551.0"/>
-      <point x="555.0" y="494.0"/>
-      <point x="555.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="555.0" y="384.0"/>
-      <point x="537.0" y="348.0"/>
-      <point x="510.0" y="311.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="261.0"/>
-      <point x="438.0" y="211.0"/>
+      <point x="404.0" y="160.0" type="curve"/>
+      <point x="347.0" y="198.0" type="line"/>
+      <point x="374.0" y="236.0"/>
+      <point x="409.0" y="281.0"/>
+      <point x="438.0" y="306.0" type="curve"/>
+      <point x="432.0" y="302.0"/>
+      <point x="421.0" y="300.0"/>
+      <point x="412.0" y="300.0" type="curve" smooth="yes"/>
+      <point x="343.0" y="300.0"/>
+      <point x="286.0" y="360.0"/>
+      <point x="286.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="286.0" y="493.0"/>
+      <point x="348.0" y="550.0"/>
+      <point x="421.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="498.0" y="550.0"/>
+      <point x="558.0" y="493.0"/>
+      <point x="558.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="558.0" y="383.0"/>
+      <point x="539.0" y="345.0"/>
+      <point x="512.0" y="308.0" type="curve" smooth="yes"/>
+      <point x="476.0" y="258.0"/>
+      <point x="440.0" y="210.0"/>
     </contour>
     <contour>
-      <point x="423.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="462.0" y="357.0"/>
-      <point x="489.0" y="389.0"/>
-      <point x="489.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="489.0" y="460.0"/>
-      <point x="463.0" y="492.0"/>
-      <point x="423.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="492.0"/>
-      <point x="357.0" y="460.0"/>
-      <point x="357.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="357.0" y="389.0"/>
-      <point x="384.0" y="357.0"/>
+      <point x="422.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="459.0" y="361.0"/>
+      <point x="482.0" y="390.0"/>
+      <point x="482.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="482.0" y="457.0"/>
+      <point x="460.0" y="486.0"/>
+      <point x="422.0" y="486.0" type="curve" smooth="yes"/>
+      <point x="385.0" y="486.0"/>
+      <point x="362.0" y="457.0"/>
+      <point x="362.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="362.0" y="390.0"/>
+      <point x="385.0" y="361.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="nine.numerator" xOffset="267" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>nine.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="235"/>
   <outline>
     <contour>
-      <point x="122.0" y="350.0" type="line"/>
-      <point x="169.0" y="350.0" type="line"/>
-      <point x="169.0" y="716.0" type="line"/>
-      <point x="121.0" y="716.0" type="line"/>
-      <point x="23.0" y="637.0" type="line"/>
-      <point x="52.0" y="600.0" type="line"/>
-      <point x="122.0" y="654.0" type="line"/>
+      <point x="117" y="350" type="line"/>
+      <point x="174" y="350" type="line"/>
+      <point x="174" y="716" type="line"/>
+      <point x="126" y="716" type="line"/>
+      <point x="27" y="632" type="line"/>
+      <point x="56" y="595" type="line"/>
+      <point x="117" y="648" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="406.0" y="177.0" type="line"/>
-      <point x="406.0" y="459.0" type="line"/>
-      <point x="354.0" y="416.0" type="line"/>
-      <point x="318.0" y="464.0" type="line"/>
-      <point x="416.0" y="543.0" type="line"/>
-      <point x="471.0" y="543.0" type="line"/>
-      <point x="471.0" y="177.0" type="line"/>
+      <point x="402.0" y="177.0" type="line"/>
+      <point x="402.0" y="453.0" type="line"/>
+      <point x="351.0" y="412.0" type="line"/>
+      <point x="312.0" y="464.0" type="line"/>
+      <point x="410.0" y="543.0" type="line"/>
+      <point x="475.0" y="543.0" type="line"/>
+      <point x="475.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="402.0" y="177.0" type="line"/>
-      <point x="402.0" y="453.0" type="line"/>
-      <point x="351.0" y="412.0" type="line"/>
-      <point x="312.0" y="464.0" type="line"/>
-      <point x="410.0" y="543.0" type="line"/>
-      <point x="475.0" y="543.0" type="line"/>
-      <point x="475.0" y="177.0" type="line"/>
+      <point x="411.0" y="177.0" type="line"/>
+      <point x="411.0" y="482.0" type="line"/>
+      <point x="340.0" y="430.0" type="line"/>
+      <point x="318.0" y="464.0" type="line"/>
+      <point x="421.0" y="543.0" type="line"/>
+      <point x="457.0" y="543.0" type="line"/>
+      <point x="457.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="one.numerator" xOffset="295" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>one.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="295"/>
   <outline>
     <contour>
-      <point x="96.0" y="335.0" type="line"/>
-      <point x="151.0" y="445.0"/>
-      <point x="213.0" y="567.0"/>
-      <point x="271.0" y="676.0" type="curve"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="23.0" y="716.0" type="line"/>
-      <point x="23.0" y="672.0" type="line"/>
-      <point x="217.0" y="672.0" type="line"/>
-      <point x="166.0" y="575.0"/>
-      <point x="103.0" y="456.0"/>
-      <point x="54.0" y="358.0" type="curve"/>
+      <point x="96" y="335" type="line"/>
+      <point x="154" y="444"/>
+      <point x="213" y="552"/>
+      <point x="271" y="661" type="curve"/>
+      <point x="271" y="716" type="line"/>
+      <point x="23" y="716" type="line"/>
+      <point x="23" y="660" type="line"/>
+      <point x="208" y="660" type="line"/>
+      <point x="156" y="563"/>
+      <point x="99" y="459"/>
+      <point x="47" y="362" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="382.0" y="162.0" type="curve"/>
-      <point x="325.0" y="193.0" type="line"/>
-      <point x="378.0" y="290.0"/>
-      <point x="432.0" y="387.0"/>
-      <point x="485.0" y="484.0" type="curve"/>
-      <point x="310.0" y="484.0" type="line"/>
+      <point x="386.0" y="160.0" type="curve"/>
+      <point x="320.0" y="198.0" type="line"/>
+      <point x="373.0" y="295.0"/>
+      <point x="429.0" y="394.0"/>
+      <point x="476.0" y="480.0" type="curve"/>
+      <point x="310.0" y="480.0" type="line"/>
       <point x="310.0" y="543.0" type="line"/>
       <point x="557.0" y="543.0" type="line"/>
-      <point x="557.0" y="488.0" type="line"/>
-      <point x="499.0" y="379.0"/>
-      <point x="440.0" y="271.0"/>
+      <point x="557.0" y="483.0" type="line"/>
+      <point x="499.0" y="374.0"/>
+      <point x="444.0" y="269.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="386.0" y="160.0" type="curve"/>
-      <point x="320.0" y="198.0" type="line"/>
-      <point x="373.0" y="295.0"/>
-      <point x="429.0" y="394.0"/>
-      <point x="476.0" y="480.0" type="curve"/>
-      <point x="310.0" y="480.0" type="line"/>
+      <point x="372.0" y="167.0" type="curve"/>
+      <point x="336.0" y="189.0" type="line"/>
+      <point x="389.0" y="286.0"/>
+      <point x="460.0" y="408.0"/>
+      <point x="510.0" y="504.0" type="curve"/>
+      <point x="310.0" y="504.0" type="line"/>
       <point x="310.0" y="543.0" type="line"/>
       <point x="557.0" y="543.0" type="line"/>
-      <point x="557.0" y="483.0" type="line"/>
-      <point x="499.0" y="374.0"/>
-      <point x="444.0" y="269.0"/>
+      <point x="557.0" y="508.0" type="line"/>
+      <point x="499.0" y="399.0"/>
+      <point x="430.0" y="276.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="157" y="342.0" type="curve" smooth="yes"/>
-      <point x="226" y="342.0"/>
-      <point x="286" y="399.0"/>
-      <point x="286" y="468.0" type="curve" smooth="yes"/>
-      <point x="286" y="532.0"/>
-      <point x="242" y="592"/>
-      <point x="166" y="592.0" type="curve" smooth="yes"/>
-      <point x="147" y="592.0"/>
-      <point x="119" y="580.0"/>
-      <point x="107" y="570.0" type="curve"/>
-      <point x="157" y="630.0"/>
-      <point x="185" y="667.0"/>
-      <point x="214" y="704.0" type="curve"/>
-      <point x="176" y="732.0" type="line"/>
-      <point x="140" y="682.0"/>
-      <point x="105" y="632.0"/>
-      <point x="70" y="582.0" type="curve" smooth="yes"/>
-      <point x="43" y="545.0"/>
-      <point x="25" y="509.0"/>
-      <point x="25" y="468.0" type="curve" smooth="yes"/>
-      <point x="25" y="399.0"/>
-      <point x="84" y="342.0"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="227" y="342"/>
+      <point x="289" y="399"/>
+      <point x="289" y="468" type="curve" smooth="yes"/>
+      <point x="289" y="532"/>
+      <point x="235" y="589"/>
+      <point x="166" y="589" type="curve" smooth="yes"/>
+      <point x="157" y="589"/>
+      <point x="128" y="582"/>
+      <point x="119" y="573" type="curve"/>
+      <point x="148" y="608"/>
+      <point x="193" y="662"/>
+      <point x="221" y="700" type="curve"/>
+      <point x="176" y="732" type="line"/>
+      <point x="140" y="682"/>
+      <point x="104" y="632"/>
+      <point x="68" y="582" type="curve" smooth="yes"/>
+      <point x="41" y="545"/>
+      <point x="23" y="509"/>
+      <point x="23" y="468" type="curve" smooth="yes"/>
+      <point x="23" y="399"/>
+      <point x="83" y="342"/>
     </contour>
     <contour>
-      <point x="156.0" y="385" type="curve" smooth="yes"/>
-      <point x="104.0" y="385"/>
-      <point x="71.0" y="425"/>
-      <point x="71.0" y="469" type="curve" smooth="yes"/>
-      <point x="71.0" y="513"/>
-      <point x="105.0" y="552"/>
-      <point x="156.0" y="552" type="curve" smooth="yes"/>
-      <point x="207.0" y="552"/>
-      <point x="242.0" y="513"/>
-      <point x="242.0" y="469" type="curve" smooth="yes"/>
-      <point x="242.0" y="425"/>
-      <point x="207.0" y="385"/>
+      <point x="156" y="395" type="curve" smooth="yes"/>
+      <point x="111.0" y="395"/>
+      <point x="84" y="428"/>
+      <point x="84" y="469" type="curve" smooth="yes"/>
+      <point x="84.0" y="510.0"/>
+      <point x="113.0" y="542.0"/>
+      <point x="156" y="542" type="curve" smooth="yes"/>
+      <point x="201" y="542"/>
+      <point x="228" y="509"/>
+      <point x="228" y="469" type="curve" smooth="yes"/>
+      <point x="228" y="427.0"/>
+      <point x="198" y="395"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="421.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="228.0"/>
-      <point x="487.0" y="260.0"/>
-      <point x="487.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="331.0"/>
-      <point x="460.0" y="363.0"/>
-      <point x="421.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="382.0" y="363.0"/>
-      <point x="355.0" y="331.0"/>
-      <point x="355.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="355.0" y="260.0"/>
-      <point x="381.0" y="228.0"/>
+      <point x="421" y="233" type="curve" smooth="yes"/>
+      <point x="458" y="233"/>
+      <point x="481" y="262"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="329"/>
+      <point x="458" y="358"/>
+      <point x="421" y="358" type="curve" smooth="yes"/>
+      <point x="384" y="358"/>
+      <point x="361" y="329"/>
+      <point x="361" y="296" type="curve" smooth="yes"/>
+      <point x="361" y="262"/>
+      <point x="383" y="233"/>
     </contour>
     <contour>
       <point x="422.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="348.0" y="169.0"/>
-      <point x="288.0" y="226.0"/>
-      <point x="288.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="336.0"/>
-      <point x="306.0" y="372.0"/>
-      <point x="333.0" y="409.0" type="curve" smooth="yes"/>
-      <point x="369.0" y="459.0"/>
-      <point x="405.0" y="509.0"/>
-      <point x="441.0" y="559.0" type="curve"/>
-      <point x="492.0" y="524.0" type="line"/>
-      <point x="463.0" y="487.0"/>
-      <point x="434.0" y="450.0"/>
+      <point x="345" y="169"/>
+      <point x="285.0" y="226.0"/>
+      <point x="285.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="285.0" y="336.0"/>
+      <point x="304.0" y="374.0"/>
+      <point x="331.0" y="411.0" type="curve" smooth="yes"/>
+      <point x="367.0" y="461.0"/>
+      <point x="403.0" y="509.0"/>
+      <point x="439.0" y="559.0" type="curve"/>
+      <point x="496.0" y="521.0" type="line"/>
+      <point x="469.0" y="483.0"/>
+      <point x="434.0" y="438.0"/>
       <point x="405.0" y="413.0" type="curve"/>
       <point x="411.0" y="417.0"/>
       <point x="422.0" y="419.0"/>
       <point x="431.0" y="419.0" type="curve" smooth="yes"/>
       <point x="500.0" y="419.0"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="226.0"/>
-      <point x="492.0" y="169.0"/>
+      <point x="557.0" y="359.0"/>
+      <point x="557.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="557.0" y="226.0"/>
+      <point x="495" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="421" y="233" type="curve" smooth="yes"/>
-      <point x="458" y="233"/>
-      <point x="481" y="262"/>
-      <point x="481" y="296" type="curve" smooth="yes"/>
-      <point x="481" y="329"/>
-      <point x="458" y="358"/>
-      <point x="421" y="358" type="curve" smooth="yes"/>
-      <point x="384" y="358"/>
-      <point x="361" y="329"/>
-      <point x="361" y="296" type="curve" smooth="yes"/>
-      <point x="361" y="262"/>
-      <point x="383" y="233"/>
+      <point x="421" y="208" type="curve" smooth="yes"/>
+      <point x="475" y="208"/>
+      <point x="512" y="249"/>
+      <point x="512" y="296" type="curve" smooth="yes"/>
+      <point x="512" y="342"/>
+      <point x="475" y="383"/>
+      <point x="421" y="383" type="curve" smooth="yes"/>
+      <point x="367" y="383"/>
+      <point x="330" y="342"/>
+      <point x="330" y="296" type="curve" smooth="yes"/>
+      <point x="330" y="249"/>
+      <point x="366" y="208"/>
     </contour>
     <contour>
       <point x="422.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="345" y="169"/>
-      <point x="285.0" y="226.0"/>
-      <point x="285.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="336.0"/>
-      <point x="304.0" y="374.0"/>
-      <point x="331.0" y="411.0" type="curve" smooth="yes"/>
-      <point x="367.0" y="461.0"/>
-      <point x="403.0" y="509.0"/>
-      <point x="439.0" y="559.0" type="curve"/>
-      <point x="496.0" y="521.0" type="line"/>
-      <point x="469.0" y="483.0"/>
-      <point x="434.0" y="438.0"/>
-      <point x="405.0" y="413.0" type="curve"/>
-      <point x="411.0" y="417.0"/>
-      <point x="422.0" y="419.0"/>
+      <point x="348.0" y="169.0"/>
+      <point x="288.0" y="226.0"/>
+      <point x="288.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="288.0" y="336.0"/>
+      <point x="306.0" y="372.0"/>
+      <point x="333.0" y="409.0" type="curve" smooth="yes"/>
+      <point x="369.0" y="459.0"/>
+      <point x="405.0" y="509.0"/>
+      <point x="441.0" y="559.0" type="curve"/>
+      <point x="477.0" y="533.0" type="line"/>
+      <point x="448.0" y="496"/>
+      <point x="398.0" y="432"/>
+      <point x="365.0" y="398.0" type="curve"/>
+      <point x="377.0" y="407.0"/>
+      <point x="405" y="419.0"/>
       <point x="431.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="500.0" y="419.0"/>
-      <point x="557.0" y="359.0"/>
-      <point x="557.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="557.0" y="226.0"/>
-      <point x="495" y="169"/>
+      <point x="500" y="419"/>
+      <point x="554.0" y="359.0"/>
+      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="226.0"/>
+      <point x="492.0" y="169.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="six.numerator" xOffset="265" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>six.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="226.0" y="342.0"/>
-      <point x="283.0" y="385.0"/>
-      <point x="283.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="283.0" y="498.0"/>
-      <point x="250.0" y="527.0"/>
-      <point x="213.0" y="543.0" type="curve"/>
-      <point x="246.0" y="555.0"/>
-      <point x="271.0" y="585.0"/>
-      <point x="271.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="271.0" y="680.0"/>
-      <point x="227.0" y="724.0"/>
-      <point x="156.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="94.0" y="724.0"/>
-      <point x="56.0" y="690.0"/>
-      <point x="39.0" y="642.0" type="curve"/>
-      <point x="84.0" y="625.0" type="line"/>
-      <point x="92.0" y="645.0"/>
-      <point x="116" y="677"/>
-      <point x="155" y="677.0" type="curve" smooth="yes"/>
-      <point x="197" y="677"/>
-      <point x="221.0" y="653"/>
-      <point x="221.0" y="622.0" type="curve" smooth="yes"/>
-      <point x="221" y="592"/>
-      <point x="195.0" y="563.0"/>
-      <point x="153.0" y="563.0" type="curve" smooth="yes"/>
-      <point x="145" y="563"/>
-      <point x="117.0" y="563.0"/>
-      <point x="117.0" y="563.0" type="curve"/>
-      <point x="117.0" y="517.0" type="line"/>
-      <point x="117.0" y="517.0"/>
-      <point x="127" y="517"/>
-      <point x="158.0" y="517.0" type="curve" smooth="yes"/>
-      <point x="201" y="517.0"/>
-      <point x="233" y="492"/>
-      <point x="233.0" y="455" type="curve" smooth="yes"/>
-      <point x="233.0" y="416"/>
-      <point x="206" y="386"/>
-      <point x="162" y="386.0" type="curve" smooth="yes"/>
-      <point x="122" y="386"/>
-      <point x="80.0" y="407.0"/>
-      <point x="68.0" y="458.0" type="curve"/>
-      <point x="28.0" y="442.0" type="line"/>
-      <point x="45.0" y="373.0"/>
-      <point x="97.0" y="342.0"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="226" y="342"/>
+      <point x="283" y="385"/>
+      <point x="283" y="459" type="curve" smooth="yes"/>
+      <point x="283" y="498"/>
+      <point x="249" y="532"/>
+      <point x="218" y="543" type="curve"/>
+      <point x="248" y="556"/>
+      <point x="271" y="585"/>
+      <point x="271" y="619" type="curve" smooth="yes"/>
+      <point x="271" y="680"/>
+      <point x="227" y="724"/>
+      <point x="156" y="724" type="curve" smooth="yes"/>
+      <point x="94" y="724"/>
+      <point x="54" y="691"/>
+      <point x="37" y="643" type="curve"/>
+      <point x="87" y="623.0" type="line"/>
+      <point x="95" y="643.0"/>
+      <point x="113" y="671.0"/>
+      <point x="156" y="671.0" type="curve" smooth="yes"/>
+      <point x="187" y="671.0"/>
+      <point x="215" y="651.0"/>
+      <point x="215" y="618.0" type="curve" smooth="yes"/>
+      <point x="215" y="584.0"/>
+      <point x="190" y="564.0"/>
+      <point x="153" y="564.0" type="curve" smooth="yes"/>
+      <point x="144" y="564.0"/>
+      <point x="117" y="564.0"/>
+      <point x="117" y="564.0" type="curve"/>
+      <point x="117.0" y="517" type="line"/>
+      <point x="117.0" y="517"/>
+      <point x="139" y="517"/>
+      <point x="158.0" y="517" type="curve" smooth="yes"/>
+      <point x="197" y="517"/>
+      <point x="226.0" y="496"/>
+      <point x="226.0" y="460" type="curve" smooth="yes"/>
+      <point x="226.0" y="421"/>
+      <point x="196" y="395"/>
+      <point x="157.0" y="395" type="curve" smooth="yes"/>
+      <point x="121" y="395"/>
+      <point x="90.0" y="414"/>
+      <point x="78.0" y="463" type="curve"/>
+      <point x="23" y="441" type="line"/>
+      <point x="40" y="372"/>
+      <point x="97" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,64 +4,64 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
       <point x="423.0" y="166.0" type="curve" smooth="yes"/>
       <point x="363.0" y="166.0"/>
-      <point x="304.0" y="194.0"/>
-      <point x="287.0" y="263.0" type="curve"/>
-      <point x="351.0" y="289.0" type="line"/>
-      <point x="363.0" y="243.0"/>
-      <point x="392.0" y="232.0"/>
-      <point x="423.0" y="232.0" type="curve" smooth="yes"/>
-      <point x="457.0" y="232.0"/>
-      <point x="482.0" y="249.0"/>
-      <point x="482.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="482.0" y="317.0"/>
-      <point x="458.0" y="332.0"/>
-      <point x="423.0" y="332.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="332.0"/>
-      <point x="383.0" y="332.0"/>
-      <point x="383.0" y="332.0" type="curve"/>
-      <point x="383.0" y="396.0" type="line"/>
-      <point x="383.0" y="396.0"/>
-      <point x="411.0" y="396.0"/>
-      <point x="419.0" y="396.0" type="curve" smooth="yes"/>
-      <point x="452.0" y="396.0"/>
-      <point x="469.0" y="411.0"/>
-      <point x="469.0" y="442.0" type="curve" smooth="yes"/>
-      <point x="469.0" y="471.0"/>
-      <point x="450.0" y="484.0"/>
-      <point x="422.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="484.0"/>
-      <point x="371.0" y="461.0"/>
-      <point x="363.0" y="440.0" type="curve"/>
-      <point x="301.0" y="468.0" type="line"/>
-      <point x="318.0" y="516.0"/>
+      <point x="306.0" y="196.0"/>
+      <point x="289.0" y="265.0" type="curve"/>
+      <point x="325.0" y="279" type="line"/>
+      <point x="340.0" y="224"/>
+      <point x="381.0" y="204"/>
+      <point x="424.0" y="204" type="curve" smooth="yes"/>
+      <point x="469.0" y="204"/>
+      <point x="507" y="239"/>
+      <point x="507.0" y="281" type="curve" smooth="yes"/>
+      <point x="507.0" y="319"/>
+      <point x="475" y="343.0"/>
+      <point x="436" y="343.0" type="curve" smooth="yes"/>
+      <point x="411" y="343"/>
+      <point x="382.0" y="343"/>
+      <point x="382.0" y="343" type="curve"/>
+      <point x="382" y="384" type="line"/>
+      <point x="382" y="384"/>
+      <point x="409" y="384"/>
+      <point x="419" y="384" type="curve" smooth="yes"/>
+      <point x="461" y="384"/>
+      <point x="494" y="414"/>
+      <point x="494.0" y="445" type="curve" smooth="yes"/>
+      <point x="494.0" y="479.0"/>
+      <point x="466.0" y="506.0"/>
+      <point x="423" y="506" type="curve" smooth="yes"/>
+      <point x="374" y="506"/>
+      <point x="354" y="475"/>
+      <point x="344" y="451" type="curve"/>
+      <point x="303.0" y="466.0" type="line"/>
+      <point x="320.0" y="514.0"/>
       <point x="360.0" y="548.0"/>
       <point x="421.0" y="548.0" type="curve" smooth="yes"/>
       <point x="493.0" y="548.0"/>
-      <point x="545.0" y="504.0"/>
-      <point x="545.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="545.0" y="409.0"/>
-      <point x="529.0" y="386.0"/>
-      <point x="499.0" y="370.0" type="curve"/>
-      <point x="534.0" y="354.0"/>
-      <point x="557.0" y="321.0"/>
-      <point x="557.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="557.0" y="209.0"/>
+      <point x="534.0" y="506.0"/>
+      <point x="534.0" y="451" type="curve" smooth="yes"/>
+      <point x="534.0" y="411.0"/>
+      <point x="509.0" y="383.0"/>
+      <point x="476.0" y="372.0" type="curve"/>
+      <point x="519.0" y="363.0"/>
+      <point x="548.0" y="321.0"/>
+      <point x="548.0" y="286" type="curve" smooth="yes"/>
+      <point x="548.0" y="209.0"/>
       <point x="492.0" y="166.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,64 +4,64 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="423.0" y="166.0" type="curve" smooth="yes"/>
       <point x="363.0" y="166.0"/>
-      <point x="306.0" y="196.0"/>
-      <point x="289.0" y="265.0" type="curve"/>
-      <point x="349.0" y="287.0" type="line"/>
-      <point x="361.0" y="241.0"/>
-      <point x="392.0" y="225.0"/>
-      <point x="423.0" y="225.0" type="curve" smooth="yes"/>
-      <point x="457.0" y="225.0"/>
-      <point x="488.0" y="249.0"/>
-      <point x="488.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="317.0"/>
-      <point x="458.0" y="336.0"/>
-      <point x="423.0" y="336.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="336.0"/>
-      <point x="383.0" y="336.0"/>
-      <point x="383.0" y="336.0" type="curve"/>
-      <point x="383.0" y="392.0" type="line"/>
-      <point x="383.0" y="392.0"/>
-      <point x="411.0" y="392.0"/>
-      <point x="419.0" y="392.0" type="curve" smooth="yes"/>
-      <point x="452.0" y="392.0"/>
-      <point x="475.0" y="411.0"/>
-      <point x="475.0" y="442.0" type="curve" smooth="yes"/>
-      <point x="475.0" y="471.0"/>
-      <point x="450.0" y="488.0"/>
-      <point x="422.0" y="488.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="488.0"/>
-      <point x="368.0" y="464.0"/>
-      <point x="360.0" y="443.0" type="curve"/>
-      <point x="303.0" y="466.0" type="line"/>
-      <point x="320.0" y="514.0"/>
+      <point x="304.0" y="194.0"/>
+      <point x="287.0" y="263.0" type="curve"/>
+      <point x="351.0" y="289.0" type="line"/>
+      <point x="363.0" y="243.0"/>
+      <point x="392.0" y="232.0"/>
+      <point x="423.0" y="232.0" type="curve" smooth="yes"/>
+      <point x="457.0" y="232.0"/>
+      <point x="482.0" y="249.0"/>
+      <point x="482.0" y="283.0" type="curve" smooth="yes"/>
+      <point x="482.0" y="317.0"/>
+      <point x="458.0" y="332.0"/>
+      <point x="423.0" y="332.0" type="curve" smooth="yes"/>
+      <point x="393.0" y="332.0"/>
+      <point x="383.0" y="332.0"/>
+      <point x="383.0" y="332.0" type="curve"/>
+      <point x="383.0" y="396.0" type="line"/>
+      <point x="383.0" y="396.0"/>
+      <point x="411.0" y="396.0"/>
+      <point x="419.0" y="396.0" type="curve" smooth="yes"/>
+      <point x="452.0" y="396.0"/>
+      <point x="469.0" y="411.0"/>
+      <point x="469.0" y="442.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="471.0"/>
+      <point x="450.0" y="484.0"/>
+      <point x="422.0" y="484.0" type="curve" smooth="yes"/>
+      <point x="384.0" y="484.0"/>
+      <point x="371.0" y="461.0"/>
+      <point x="363.0" y="440.0" type="curve"/>
+      <point x="301.0" y="468.0" type="line"/>
+      <point x="318.0" y="516.0"/>
       <point x="360.0" y="548.0"/>
       <point x="421.0" y="548.0" type="curve" smooth="yes"/>
       <point x="493.0" y="548.0"/>
-      <point x="542.0" y="504.0"/>
-      <point x="542.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="542.0" y="409.0"/>
-      <point x="524.0" y="385.0"/>
-      <point x="496.0" y="367.0" type="curve"/>
-      <point x="529.0" y="348.0"/>
-      <point x="554.0" y="321.0"/>
-      <point x="554.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="209.0"/>
+      <point x="545.0" y="504.0"/>
+      <point x="545.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="545.0" y="409.0"/>
+      <point x="529.0" y="386.0"/>
+      <point x="499.0" y="370.0" type="curve"/>
+      <point x="534.0" y="354.0"/>
+      <point x="557.0" y="321.0"/>
+      <point x="557.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="557.0" y="209.0"/>
       <point x="492.0" y="166.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="three.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>three.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.cap.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.cap.glif
@@ -7,10 +7,10 @@
       <point x="490.0" y="0.0" type="line"/>
       <point x="490.0" y="61.0" type="line"/>
       <point x="120.0" y="61.0" type="line"/>
-      <point x="120.0" y="61.0"/>
-      <point x="327.0" y="276.0"/>
+      <point x="135.0" y="77.0"/>
+      <point x="336.0" y="285.0"/>
       <point x="366.0" y="317.0" type="curve" smooth="yes"/>
-      <point x="417" y="370"/>
+      <point x="416" y="371"/>
       <point x="478" y="436"/>
       <point x="478.0" y="538" type="curve" smooth="yes"/>
       <point x="478.0" y="640.0"/>
@@ -27,10 +27,10 @@
       <point x="408" y="607"/>
       <point x="408.0" y="544" type="curve" smooth="yes"/>
       <point x="408.0" y="471.0"/>
-      <point x="381.0" y="422.0"/>
+      <point x="382" y="420"/>
       <point x="316.0" y="351.0" type="curve" smooth="yes"/>
-      <point x="257.0" y="286.0"/>
-      <point x="45.0" y="68.0"/>
+      <point x="266.0" y="298.0"/>
+      <point x="57.0" y="80.0"/>
       <point x="45.0" y="68.0" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.glif
@@ -9,7 +9,7 @@
       <point x="477.0" y="62.0" type="line"/>
       <point x="118.0" y="62.0" type="line"/>
       <point x="118.0" y="65.0" type="line"/>
-      <point x="76.0" y="34.0"/>
+      <point x="164.0" y="111.0"/>
       <point x="321.0" y="261.0"/>
       <point x="352.0" y="293.0" type="curve" smooth="yes"/>
       <point x="401.0" y="343.0"/>
@@ -32,7 +32,7 @@
       <point x="365.0" y="402.0"/>
       <point x="303.0" y="335.0" type="curve" smooth="yes"/>
       <point x="241.0" y="268.0"/>
-      <point x="41.0" y="65.0"/>
+      <point x="82.0" y="109.0"/>
       <point x="45.0" y="72.0" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="300"/>
   <outline>
     <contour>
-      <point x="25.0" y="350.0" type="line"/>
-      <point x="272.0" y="350.0" type="line"/>
-      <point x="272.0" y="394.0" type="line"/>
-      <point x="79.0" y="394.0" type="line"/>
-      <point x="79.0" y="394.0"/>
-      <point x="175.0" y="492.0"/>
-      <point x="198.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="221.0" y="538.0"/>
-      <point x="263.0" y="569.0"/>
-      <point x="263.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="263.0" y="683.0"/>
-      <point x="210.0" y="724.0"/>
-      <point x="147.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="90.0" y="724.0"/>
-      <point x="37.0" y="689.0"/>
-      <point x="23.0" y="629.0" type="curve"/>
-      <point x="69.0" y="610.0" type="line"/>
-      <point x="78.0" y="652.0"/>
-      <point x="107.0" y="679.0"/>
-      <point x="148.0" y="679.0" type="curve" smooth="yes"/>
-      <point x="189" y="679"/>
-      <point x="212.0" y="650"/>
-      <point x="212.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="212" y="587"/>
-      <point x="183.0" y="562.0"/>
-      <point x="163.0" y="541.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="533.0"/>
-      <point x="25.0" y="401.0"/>
-      <point x="25.0" y="401.0" type="curve"/>
+      <point x="25" y="350" type="line"/>
+      <point x="272" y="350" type="line"/>
+      <point x="272" y="401" type="line"/>
+      <point x="93" y="401" type="line"/>
+      <point x="104.0" y="411.0"/>
+      <point x="184.0" y="491.0"/>
+      <point x="206" y="513" type="curve" smooth="yes"/>
+      <point x="229" y="536"/>
+      <point x="263" y="569"/>
+      <point x="263" y="617" type="curve" smooth="yes"/>
+      <point x="263" y="683"/>
+      <point x="210" y="724"/>
+      <point x="147" y="724" type="curve" smooth="yes"/>
+      <point x="90" y="724"/>
+      <point x="37" y="689"/>
+      <point x="23" y="629" type="curve"/>
+      <point x="73" y="608" type="line"/>
+      <point x="82" y="650"/>
+      <point x="118" y="670"/>
+      <point x="148" y="670" type="curve" smooth="yes"/>
+      <point x="183" y="670.0"/>
+      <point x="209.0" y="647.0"/>
+      <point x="209" y="617" type="curve" smooth="yes"/>
+      <point x="209" y="587"/>
+      <point x="184" y="559"/>
+      <point x="163" y="538" type="curve" smooth="yes"/>
+      <point x="158.0" y="533.0"/>
+      <point x="35.0" y="409.0"/>
+      <point x="25" y="400" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="302.0" y="177.0" type="line"/>
-      <point x="302.0" y="233.0" type="line"/>
-      <point x="302.0" y="233.0"/>
-      <point x="429.0" y="360.0"/>
-      <point x="436.0" y="368.0" type="curve" smooth="yes"/>
-      <point x="456.0" y="389.0"/>
-      <point x="480.0" y="414.0"/>
-      <point x="480.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="471.0"/>
-      <point x="457.0" y="492.0"/>
-      <point x="425.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="492.0"/>
-      <point x="369.0" y="473.0"/>
-      <point x="360.0" y="431.0" type="curve"/>
+      <point x="302.0" y="238.0" type="line"/>
+      <point x="313.0" y="250.0"/>
+      <point x="432" y="370"/>
+      <point x="435" y="373" type="curve" smooth="yes"/>
+      <point x="455" y="392"/>
+      <point x="474" y="415"/>
+      <point x="474" y="443" type="curve" smooth="yes"/>
+      <point x="474" y="467"/>
+      <point x="455" y="487"/>
+      <point x="425" y="487" type="curve" smooth="yes"/>
+      <point x="395" y="487"/>
+      <point x="371" y="465"/>
+      <point x="362" y="427" type="curve"/>
       <point x="300.0" y="456.0" type="line"/>
-      <point x="313.0" y="516.0"/>
-      <point x="366.0" y="551.0"/>
-      <point x="423.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="486.0" y="551.0"/>
-      <point x="547.0" y="510.0"/>
-      <point x="547.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="396.0"/>
-      <point x="507.0" y="356.0"/>
-      <point x="484.0" y="333.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="310.0"/>
-      <point x="387.0" y="236.0"/>
-      <point x="387.0" y="236.0" type="curve"/>
-      <point x="549.0" y="236.0" type="line"/>
+      <point x="313.0" y="512.0"/>
+      <point x="366" y="551"/>
+      <point x="426" y="551.0" type="curve" smooth="yes"/>
+      <point x="491.0" y="551.0"/>
+      <point x="551.0" y="510.0"/>
+      <point x="551.0" y="444.0" type="curve" smooth="yes"/>
+      <point x="551.0" y="396.0"/>
+      <point x="510" y="353"/>
+      <point x="487.0" y="330.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="312.0"/>
+      <point x="408.0" y="253.0"/>
+      <point x="396.0" y="240.0" type="curve"/>
+      <point x="549.0" y="240.0" type="line"/>
       <point x="549.0" y="177.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-12" type="curve" smooth="yes"/>
-      <point x="629" y="-12"/>
-      <point x="795" y="154"/>
-      <point x="795" y="358.0" type="curve" smooth="yes"/>
-      <point x="795" y="562"/>
-      <point x="629" y="728"/>
-      <point x="425.0" y="728" type="curve" smooth="yes"/>
-      <point x="221" y="728"/>
-      <point x="55" y="562"/>
-      <point x="55" y="358.0" type="curve" smooth="yes"/>
-      <point x="55" y="154"/>
-      <point x="221" y="-12"/>
+      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
+      <point x="631.0" y="-16.0"/>
+      <point x="799.0" y="152.0"/>
+      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="799.0" y="564.0"/>
+      <point x="631.0" y="732.0"/>
+      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="219.0" y="732.0"/>
+      <point x="51.0" y="564.0"/>
+      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="51.0" y="152.0"/>
+      <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
       <point x="302.0" y="177.0" type="line"/>
-      <point x="302.0" y="238.0" type="line"/>
-      <point x="313.0" y="250.0"/>
-      <point x="432" y="370"/>
-      <point x="435" y="373" type="curve" smooth="yes"/>
-      <point x="455" y="392"/>
-      <point x="474" y="415"/>
-      <point x="474" y="443" type="curve" smooth="yes"/>
-      <point x="474" y="467"/>
-      <point x="455" y="487"/>
-      <point x="425" y="487" type="curve" smooth="yes"/>
-      <point x="395" y="487"/>
-      <point x="371" y="465"/>
-      <point x="362" y="427" type="curve"/>
+      <point x="302.0" y="213.0" type="line"/>
+      <point x="302.0" y="213.0"/>
+      <point x="439.0" y="350.0"/>
+      <point x="446.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="466.0" y="379.0"/>
+      <point x="498" y="414"/>
+      <point x="498.0" y="444.0" type="curve" smooth="yes"/>
+      <point x="498.0" y="483"/>
+      <point x="469" y="512"/>
+      <point x="425.0" y="512.0" type="curve" smooth="yes"/>
+      <point x="381.0" y="512.0"/>
+      <point x="349.0" y="481.0"/>
+      <point x="340.0" y="439.0" type="curve"/>
       <point x="300.0" y="456.0" type="line"/>
-      <point x="313.0" y="512.0"/>
+      <point x="313.0" y="516.0"/>
       <point x="366" y="551"/>
-      <point x="426" y="551.0" type="curve" smooth="yes"/>
-      <point x="491.0" y="551.0"/>
-      <point x="551.0" y="510.0"/>
-      <point x="551.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="396.0"/>
-      <point x="510" y="353"/>
-      <point x="487.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="469.0" y="312.0"/>
-      <point x="408.0" y="253.0"/>
-      <point x="396.0" y="240.0" type="curve"/>
-      <point x="549.0" y="240.0" type="line"/>
+      <point x="423.0" y="551.0" type="curve" smooth="yes"/>
+      <point x="497.0" y="551.0"/>
+      <point x="541.0" y="504.0"/>
+      <point x="541.0" y="453" type="curve" smooth="yes"/>
+      <point x="541" y="397"/>
+      <point x="497.0" y="358.0"/>
+      <point x="474.0" y="335.0" type="curve" smooth="yes"/>
+      <point x="451.0" y="312.0"/>
+      <point x="358.0" y="216.0"/>
+      <point x="358.0" y="216.0" type="curve"/>
+      <point x="549.0" y="216.0" type="line"/>
       <point x="549.0" y="177.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>two.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.sc.glif
@@ -8,7 +8,7 @@
       <point x="433.0" y="59.0" type="line"/>
       <point x="108.0" y="59.0" type="line"/>
       <point x="108.0" y="59.0" type="line"/>
-      <point x="170.0" y="114.0"/>
+      <point x="167.0" y="115.0"/>
       <point x="258.0" y="199.0"/>
       <point x="318.0" y="256.0" type="curve" smooth="yes"/>
       <point x="363.0" y="301.0"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.ss03.glif
@@ -8,10 +8,10 @@
       <point x="468.0" y="61.0" type="line"/>
       <point x="129.0" y="61.0" type="line"/>
       <point x="129.0" y="61.0" type="line"/>
-      <point x="129.0" y="61.0"/>
-      <point x="299.0" y="235.0"/>
+      <point x="151.0" y="80.0"/>
+      <point x="303.0" y="239.0"/>
       <point x="346.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="407.0" y="343.0"/>
+      <point x="407" y="343"/>
       <point x="460.0" y="414.0"/>
       <point x="460.0" y="506.0" type="curve" smooth="yes"/>
       <point x="460.0" y="608.0"/>
@@ -28,10 +28,10 @@
       <point x="395.0" y="570.0"/>
       <point x="395.0" y="505.0" type="curve" smooth="yes"/>
       <point x="395.0" y="436.0"/>
-      <point x="369.0" y="399.0"/>
+      <point x="371" y="397"/>
       <point x="298.0" y="322.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="250.0"/>
-      <point x="46.0" y="65.0"/>
+      <point x="236.0" y="258.0"/>
+      <point x="64.0" y="82.0"/>
       <point x="46.0" y="65.0" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/two.tf.glif
@@ -8,10 +8,10 @@
       <point x="531.0" y="61.0" type="line"/>
       <point x="150.0" y="61.0" type="line"/>
       <point x="150.0" y="62.0" type="line"/>
-      <point x="150.0" y="62.0"/>
-      <point x="358.0" y="266.0"/>
+      <point x="179.0" y="94.0"/>
+      <point x="362.0" y="270.0"/>
       <point x="398.0" y="306.0" type="curve" smooth="yes"/>
-      <point x="452.0" y="360.0"/>
+      <point x="452" y="360"/>
       <point x="519.0" y="433.0"/>
       <point x="519.0" y="534" type="curve" smooth="yes"/>
       <point x="519.0" y="644.0"/>
@@ -28,17 +28,11 @@
       <point x="452" y="625"/>
       <point x="452.0" y="544" type="curve" smooth="yes"/>
       <point x="452.0" y="458.0"/>
-      <point x="430.0" y="418.0"/>
+      <point x="431" y="417"/>
       <point x="360" y="348" type="curve" smooth="yes"/>
-      <point x="292" y="280"/>
-      <point x="74.0" y="68.0"/>
+      <point x="302" y="292"/>
+      <point x="91.0" y="83.0"/>
       <point x="74.0" y="68.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="369"/>
   <outline>
     <contour>
-      <point x="185" y="342.0" type="curve" smooth="yes"/>
-      <point x="281" y="342.0"/>
-      <point x="331" y="438.0"/>
-      <point x="331" y="533.0" type="curve" smooth="yes"/>
-      <point x="331" y="628.0"/>
-      <point x="281" y="724.0"/>
-      <point x="185" y="724.0" type="curve" smooth="yes"/>
-      <point x="88" y="724.0"/>
-      <point x="39" y="628.0"/>
-      <point x="39" y="533.0" type="curve" smooth="yes"/>
-      <point x="39" y="438.0"/>
-      <point x="88" y="342.0"/>
+      <point x="184" y="342" type="curve"/>
+      <point x="284" y="342"/>
+      <point x="333" y="438"/>
+      <point x="333" y="533" type="curve" smooth="yes"/>
+      <point x="333" y="628"/>
+      <point x="284" y="724"/>
+      <point x="184" y="724" type="curve" smooth="yes"/>
+      <point x="84" y="724"/>
+      <point x="36" y="628"/>
+      <point x="36" y="533" type="curve" smooth="yes"/>
+      <point x="36" y="438"/>
+      <point x="84" y="342"/>
     </contour>
     <contour>
-      <point x="184" y="389" type="curve" smooth="yes"/>
-      <point x="114" y="389"/>
-      <point x="87" y="467"/>
-      <point x="87" y="533" type="curve" smooth="yes"/>
-      <point x="87.0" y="599.0"/>
-      <point x="114" y="677"/>
-      <point x="184" y="677" type="curve" smooth="yes"/>
-      <point x="255" y="677"/>
-      <point x="283.0" y="600.0"/>
-      <point x="283" y="533" type="curve" smooth="yes"/>
-      <point x="283" y="466"/>
-      <point x="255" y="389"/>
+      <point x="184" y="393" type="curve"/>
+      <point x="122" y="393"/>
+      <point x="95" y="462"/>
+      <point x="95" y="533" type="curve" smooth="yes"/>
+      <point x="95.0" y="604.0"/>
+      <point x="122" y="673"/>
+      <point x="184" y="673" type="curve" smooth="yes"/>
+      <point x="247" y="673"/>
+      <point x="274" y="609"/>
+      <point x="274" y="533" type="curve" smooth="yes"/>
+      <point x="274.0" y="457.0"/>
+      <point x="247" y="393"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.cap.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.cap.glif
@@ -7,10 +7,10 @@
       <point x="490" y="0" type="line"/>
       <point x="490" y="81" type="line"/>
       <point x="151" y="81" type="line"/>
-      <point x="151" y="81"/>
-      <point x="329" y="265"/>
+      <point x="169.0" y="100.0"/>
+      <point x="334.0" y="272.0"/>
       <point x="368" y="306" type="curve" smooth="yes"/>
-      <point x="419" y="360"/>
+      <point x="421" y="359"/>
       <point x="483" y="436"/>
       <point x="483" y="530" type="curve" smooth="yes"/>
       <point x="483" y="638"/>
@@ -29,8 +29,8 @@
       <point x="396" y="465"/>
       <point x="370" y="434"/>
       <point x="305" y="363" type="curve" smooth="yes"/>
-      <point x="246" y="298"/>
-      <point x="45" y="88"/>
+      <point x="248.0" y="301.0"/>
+      <point x="62.0" y="104.0"/>
       <point x="45" y="88" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.glif
@@ -9,10 +9,10 @@
       <point x="477" y="81" type="line"/>
       <point x="154" y="81" type="line"/>
       <point x="154" y="81" type="line"/>
-      <point x="154" y="81"/>
-      <point x="328" y="255"/>
+      <point x="177" y="102"/>
+      <point x="314" y="243"/>
       <point x="359" y="287" type="curve" smooth="yes"/>
-      <point x="408" y="337"/>
+      <point x="410" y="336"/>
       <point x="469" y="414"/>
       <point x="469" y="504" type="curve" smooth="yes"/>
       <point x="469" y="608"/>
@@ -31,8 +31,8 @@
       <point x="383" y="441"/>
       <point x="358" y="409"/>
       <point x="296" y="342" type="curve" smooth="yes"/>
-      <point x="234" y="275"/>
-      <point x="45" y="85"/>
+      <point x="238" y="279"/>
+      <point x="56" y="95"/>
       <point x="45" y="85" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.numerator.glif
@@ -7,10 +7,10 @@
       <point x="272" y="350" type="line"/>
       <point x="272" y="409" type="line"/>
       <point x="111" y="409" type="line"/>
-      <point x="111" y="409"/>
-      <point x="185" y="483"/>
+      <point x="121" y="417"/>
+      <point x="186" y="483"/>
       <point x="208" y="506" type="curve" smooth="yes"/>
-      <point x="231" y="529"/>
+      <point x="230" y="530"/>
       <point x="270" y="569"/>
       <point x="270" y="617" type="curve" smooth="yes"/>
       <point x="270" y="683"/>
@@ -27,10 +27,10 @@
       <point x="204" y="644"/>
       <point x="204" y="617" type="curve" smooth="yes"/>
       <point x="204" y="587"/>
-      <point x="180" y="562"/>
+      <point x="182" y="561"/>
       <point x="160" y="541" type="curve" smooth="yes"/>
-      <point x="152" y="533"/>
-      <point x="25" y="406"/>
+      <point x="143" y="525"/>
+      <point x="31" y="412"/>
       <point x="25" y="406" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -20,10 +20,10 @@
     <contour>
       <point x="302" y="177" type="line"/>
       <point x="302" y="233" type="line"/>
-      <point x="302" y="233"/>
-      <point x="429" y="360"/>
+      <point x="320" y="251"/>
+      <point x="421" y="354"/>
       <point x="436" y="368" type="curve" smooth="yes"/>
-      <point x="456" y="389"/>
+      <point x="457" y="387"/>
       <point x="480" y="414"/>
       <point x="480" y="444" type="curve" smooth="yes"/>
       <point x="480" y="471"/>
@@ -42,8 +42,8 @@
       <point x="547" y="396"/>
       <point x="507" y="356"/>
       <point x="484" y="333" type="curve" smooth="yes"/>
-      <point x="461" y="310"/>
-      <point x="387" y="236"/>
+      <point x="465" y="313"/>
+      <point x="401" y="249"/>
       <point x="387" y="236" type="curve"/>
       <point x="549" y="236" type="line"/>
       <point x="549" y="177" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.sc.glif
@@ -8,10 +8,10 @@
       <point x="433" y="74" type="line"/>
       <point x="149" y="74" type="line"/>
       <point x="149" y="74" type="line"/>
-      <point x="209" y="131"/>
-      <point x="268" y="189"/>
-      <point x="328" y="246" type="curve"/>
-      <point x="373" y="291"/>
+      <point x="172" y="95"/>
+      <point x="269" y="188"/>
+      <point x="328" y="246" type="curve" smooth="yes"/>
+      <point x="374" y="290"/>
       <point x="426" y="352"/>
       <point x="426" y="427" type="curve" smooth="yes"/>
       <point x="426" y="516"/>
@@ -29,9 +29,9 @@
       <point x="341" y="425" type="curve" smooth="yes"/>
       <point x="341" y="373"/>
       <point x="319" y="351"/>
-      <point x="268" y="300" type="curve"/>
+      <point x="268" y="300" type="curve" smooth="yes"/>
       <point x="194" y="227"/>
-      <point x="119" y="153"/>
+      <point x="74" y="110"/>
       <point x="45" y="80" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.ss03.glif
@@ -8,8 +8,8 @@
       <point x="477" y="81" type="line"/>
       <point x="154" y="81" type="line"/>
       <point x="154" y="81" type="line"/>
-      <point x="154" y="81"/>
-      <point x="328" y="255"/>
+      <point x="176" y="101"/>
+      <point x="333" y="260"/>
       <point x="359" y="287" type="curve" smooth="yes"/>
       <point x="408" y="337"/>
       <point x="469" y="414"/>
@@ -30,8 +30,8 @@
       <point x="383" y="441"/>
       <point x="358" y="409"/>
       <point x="296" y="342" type="curve" smooth="yes"/>
-      <point x="234" y="275"/>
-      <point x="45" y="85"/>
+      <point x="241" y="283"/>
+      <point x="62" y="103"/>
       <point x="45" y="85" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/two.tf.glif
@@ -8,10 +8,10 @@
       <point x="531" y="81" type="line"/>
       <point x="180" y="81" type="line"/>
       <point x="180" y="81" type="line"/>
-      <point x="180" y="81"/>
-      <point x="363" y="260"/>
+      <point x="202" y="102"/>
+      <point x="374" y="273"/>
       <point x="403" y="300" type="curve" smooth="yes"/>
-      <point x="457" y="354"/>
+      <point x="459" y="352"/>
       <point x="524" y="433"/>
       <point x="524" y="530" type="curve" smooth="yes"/>
       <point x="524" y="644"/>
@@ -30,15 +30,9 @@
       <point x="437" y="462"/>
       <point x="410" y="431"/>
       <point x="340" y="357" type="curve" smooth="yes"/>
-      <point x="280" y="293"/>
-      <point x="74" y="88"/>
+      <point x="294" y="308"/>
+      <point x="98" y="110"/>
       <point x="74" y="88" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-23" type="curve" smooth="yes"/>
-      <point x="635" y="-23"/>
-      <point x="806" y="148"/>
-      <point x="806" y="358.0" type="curve" smooth="yes"/>
-      <point x="806" y="568"/>
-      <point x="635" y="739"/>
-      <point x="425.0" y="739" type="curve" smooth="yes"/>
-      <point x="215" y="739"/>
-      <point x="44" y="568"/>
-      <point x="44" y="358.0" type="curve" smooth="yes"/>
-      <point x="44" y="148"/>
-      <point x="215" y="-23"/>
+      <point x="425.0" y="-20" type="curve" smooth="yes"/>
+      <point x="633" y="-20"/>
+      <point x="803" y="150"/>
+      <point x="803" y="358.0" type="curve" smooth="yes"/>
+      <point x="803" y="566"/>
+      <point x="633" y="736"/>
+      <point x="425.0" y="736" type="curve" smooth="yes"/>
+      <point x="217" y="736"/>
+      <point x="47" y="566"/>
+      <point x="47" y="358.0" type="curve" smooth="yes"/>
+      <point x="47" y="150"/>
+      <point x="217" y="-20"/>
     </contour>
     <contour>
-      <point x="425.0" y="56" type="curve" smooth="yes"/>
-      <point x="260" y="56"/>
-      <point x="123" y="193"/>
-      <point x="123" y="358.0" type="curve" smooth="yes"/>
-      <point x="123" y="526"/>
-      <point x="260" y="660"/>
-      <point x="425.0" y="660" type="curve" smooth="yes"/>
-      <point x="594" y="660"/>
-      <point x="727" y="526"/>
-      <point x="727" y="358.0" type="curve" smooth="yes"/>
-      <point x="727" y="193"/>
-      <point x="594" y="56"/>
+      <point x="425.0" y="67" type="curve" smooth="yes"/>
+      <point x="266" y="67"/>
+      <point x="135" y="199"/>
+      <point x="135" y="358.0" type="curve" smooth="yes"/>
+      <point x="135" y="520"/>
+      <point x="266" y="649"/>
+      <point x="425.0" y="649" type="curve" smooth="yes"/>
+      <point x="587" y="649"/>
+      <point x="715" y="520"/>
+      <point x="715" y="358.0" type="curve" smooth="yes"/>
+      <point x="715" y="199"/>
+      <point x="587" y="67"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="313"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="342.0"/>
-      <point x="295" y="384"/>
-      <point x="295.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="500.0"/>
-      <point x="266" y="533"/>
-      <point x="233.0" y="543.0" type="curve"/>
-      <point x="264" y="553"/>
-      <point x="283.0" y="579.0"/>
-      <point x="283.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="283" y="682"/>
-      <point x="225.0" y="724.0"/>
-      <point x="157.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="89" y="724"/>
-      <point x="30" y="682"/>
-      <point x="30.0" y="616.0" type="curve" smooth="yes"/>
-      <point x="30" y="581"/>
-      <point x="46" y="556"/>
-      <point x="72.0" y="543.0" type="curve"/>
-      <point x="43.0" y="532.0"/>
-      <point x="18" y="498.0"/>
-      <point x="18.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="18" y="385"/>
-      <point x="82" y="342"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="230" y="342"/>
+      <point x="294" y="384"/>
+      <point x="294" y="455" type="curve" smooth="yes"/>
+      <point x="294" y="490"/>
+      <point x="270" y="526"/>
+      <point x="236" y="543" type="curve"/>
+      <point x="261" y="556"/>
+      <point x="282" y="588"/>
+      <point x="282" y="616" type="curve" smooth="yes"/>
+      <point x="282" y="682"/>
+      <point x="228.0" y="724.0"/>
+      <point x="157" y="724" type="curve" smooth="yes"/>
+      <point x="86" y="724"/>
+      <point x="31" y="682"/>
+      <point x="31" y="616" type="curve" smooth="yes"/>
+      <point x="31" y="587"/>
+      <point x="53" y="556"/>
+      <point x="77" y="543" type="curve"/>
+      <point x="43" y="525"/>
+      <point x="19" y="490"/>
+      <point x="19" y="455" type="curve" smooth="yes"/>
+      <point x="19" y="385"/>
+      <point x="84.0" y="342"/>
     </contour>
     <contour>
-      <point x="157.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="129" y="413"/>
-      <point x="105.0" y="428.0"/>
-      <point x="105.0" y="458.0" type="curve" smooth="yes"/>
-      <point x="105" y="488"/>
-      <point x="126.0" y="507.0"/>
-      <point x="157.0" y="507.0" type="curve" smooth="yes"/>
-      <point x="188" y="507"/>
-      <point x="208.0" y="486.0"/>
-      <point x="208.0" y="458.0" type="curve" smooth="yes"/>
-      <point x="208" y="430"/>
-      <point x="185.0" y="413.0"/>
+      <point x="157" y="408" type="curve" smooth="yes"/>
+      <point x="127" y="408"/>
+      <point x="98" y="426"/>
+      <point x="98" y="458" type="curve" smooth="yes"/>
+      <point x="98" y="489"/>
+      <point x="128" y="510"/>
+      <point x="157" y="510" type="curve" smooth="yes"/>
+      <point x="184" y="510"/>
+      <point x="215" y="488"/>
+      <point x="215" y="458" type="curve" smooth="yes"/>
+      <point x="215" y="427"/>
+      <point x="184" y="408"/>
     </contour>
     <contour>
-      <point x="157.0" y="570.0" type="curve" smooth="yes"/>
-      <point x="132" y="570"/>
-      <point x="115" y="590"/>
-      <point x="115.0" y="611.0" type="curve" smooth="yes"/>
-      <point x="115.0" y="632.0"/>
-      <point x="132" y="653"/>
-      <point x="157.0" y="653.0" type="curve" smooth="yes"/>
-      <point x="182.0" y="653.0"/>
-      <point x="198" y="635"/>
-      <point x="198.0" y="611.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="587.0"/>
-      <point x="182.0" y="570.0"/>
+      <point x="157" y="569" type="curve" smooth="yes"/>
+      <point x="131" y="569"/>
+      <point x="109" y="588"/>
+      <point x="109" y="616" type="curve" smooth="yes"/>
+      <point x="109" y="642"/>
+      <point x="128" y="660"/>
+      <point x="157" y="660" type="curve" smooth="yes"/>
+      <point x="184" y="660"/>
+      <point x="204" y="642"/>
+      <point x="204" y="616" type="curve" smooth="yes"/>
+      <point x="204" y="589"/>
+      <point x="182" y="569"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="425.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="456.0" y="228.0"/>
-      <point x="492.0" y="252.0"/>
-      <point x="492.0" y="285.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="456.0" y="341.0"/>
-      <point x="425.0" y="341.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="341.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="285.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="251.0"/>
-      <point x="392.0" y="228.0"/>
+      <point x="425" y="204" type="curve" smooth="yes"/>
+      <point x="465" y="204"/>
+      <point x="511" y="236"/>
+      <point x="511" y="279" type="curve" smooth="yes"/>
+      <point x="511" y="321"/>
+      <point x="465" y="353"/>
+      <point x="425" y="353" type="curve" smooth="yes"/>
+      <point x="383" y="353"/>
+      <point x="339" y="322"/>
+      <point x="339" y="279" type="curve" smooth="yes"/>
+      <point x="339" y="234"/>
+      <point x="382" y="204"/>
     </contour>
     <contour>
       <point x="425.0" y="169.0" type="curve" smooth="yes"/>
       <point x="358.0" y="169.0"/>
-      <point x="292.0" y="212.0"/>
-      <point x="292.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="317.0"/>
-      <point x="312.0" y="349.0"/>
-      <point x="346.0" y="370.0" type="curve"/>
-      <point x="322.0" y="385.0"/>
-      <point x="304.0" y="414.0"/>
-      <point x="304.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="509.0"/>
+      <point x="298.0" y="212.0"/>
+      <point x="298.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="298.0" y="317.0"/>
+      <point x="318.0" y="349.0"/>
+      <point x="366.0" y="371.0" type="curve"/>
+      <point x="332.0" y="388.0"/>
+      <point x="313.0" y="417.0"/>
+      <point x="313.0" y="446.0" type="curve" smooth="yes"/>
+      <point x="313.0" y="512.0"/>
       <point x="362.0" y="551.0"/>
       <point x="425.0" y="551.0" type="curve" smooth="yes"/>
       <point x="488.0" y="551.0"/>
-      <point x="546.0" y="509.0"/>
-      <point x="546.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="546.0" y="415.0"/>
-      <point x="528.0" y="385.0"/>
-      <point x="505.0" y="370.0" type="curve"/>
-      <point x="539.0" y="349.0"/>
-      <point x="558.0" y="317.0"/>
-      <point x="558.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="211.0"/>
+      <point x="537.0" y="513.0"/>
+      <point x="537.0" y="447.0" type="curve" smooth="yes"/>
+      <point x="537.0" y="419.0"/>
+      <point x="514.0" y="384.0"/>
+      <point x="489.0" y="370.0" type="curve"/>
+      <point x="531.0" y="349.0"/>
+      <point x="552.0" y="317.0"/>
+      <point x="552.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="552.0" y="211.0"/>
       <point x="491.0" y="169.0"/>
     </contour>
     <contour>
-      <point x="425.0" y="395.0" type="curve" smooth="yes"/>
-      <point x="454.0" y="395.0"/>
-      <point x="480.0" y="415.0"/>
-      <point x="480.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="470.0"/>
-      <point x="457.0" y="492.0"/>
-      <point x="425.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="492.0"/>
-      <point x="371.0" y="470.0"/>
-      <point x="371.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="414.0"/>
-      <point x="396.0" y="395.0"/>
+      <point x="425.0" y="389" type="curve" smooth="yes"/>
+      <point x="462.0" y="389"/>
+      <point x="495.0" y="414"/>
+      <point x="495.0" y="449" type="curve" smooth="yes"/>
+      <point x="495.0" y="483"/>
+      <point x="466.0" y="511.0"/>
+      <point x="425.0" y="511.0" type="curve" smooth="yes"/>
+      <point x="384.0" y="511.0"/>
+      <point x="356.0" y="483"/>
+      <point x="356.0" y="449" type="curve" smooth="yes"/>
+      <point x="356.0" y="412"/>
+      <point x="388.0" y="389"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -4,72 +4,72 @@
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="425" y="204" type="curve" smooth="yes"/>
-      <point x="465" y="204"/>
-      <point x="511" y="236"/>
-      <point x="511" y="279" type="curve" smooth="yes"/>
-      <point x="511" y="321"/>
-      <point x="465" y="353"/>
-      <point x="425" y="353" type="curve" smooth="yes"/>
-      <point x="383" y="353"/>
-      <point x="339" y="322"/>
-      <point x="339" y="279" type="curve" smooth="yes"/>
-      <point x="339" y="234"/>
-      <point x="382" y="204"/>
+      <point x="425" y="232" type="curve" smooth="yes"/>
+      <point x="454" y="232"/>
+      <point x="485" y="252"/>
+      <point x="485" y="285" type="curve" smooth="yes"/>
+      <point x="485" y="317"/>
+      <point x="454" y="338"/>
+      <point x="425" y="338" type="curve" smooth="yes"/>
+      <point x="395" y="338"/>
+      <point x="366" y="318"/>
+      <point x="366" y="285" type="curve" smooth="yes"/>
+      <point x="366" y="251"/>
+      <point x="394" y="232"/>
     </contour>
     <contour>
       <point x="425.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="358.0" y="169.0"/>
-      <point x="298.0" y="212.0"/>
-      <point x="298.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="298.0" y="317.0"/>
-      <point x="318.0" y="349.0"/>
-      <point x="366.0" y="371.0" type="curve"/>
-      <point x="332.0" y="388.0"/>
-      <point x="313.0" y="417.0"/>
-      <point x="313.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="313.0" y="512.0"/>
-      <point x="362.0" y="551.0"/>
+      <point x="355" y="169"/>
+      <point x="289.0" y="212.0"/>
+      <point x="289.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="317.0"/>
+      <point x="312.0" y="349.0"/>
+      <point x="346.0" y="370.0" type="curve"/>
+      <point x="322.0" y="385.0"/>
+      <point x="301.0" y="414.0"/>
+      <point x="301.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="301.0" y="509.0"/>
+      <point x="359" y="551"/>
       <point x="425.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="551.0"/>
-      <point x="537.0" y="513.0"/>
-      <point x="537.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="537.0" y="419.0"/>
-      <point x="514.0" y="384.0"/>
-      <point x="489.0" y="370.0" type="curve"/>
-      <point x="531.0" y="349.0"/>
-      <point x="552.0" y="317.0"/>
-      <point x="552.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="552.0" y="211.0"/>
-      <point x="491.0" y="169.0"/>
+      <point x="491" y="551"/>
+      <point x="549.0" y="509.0"/>
+      <point x="549.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="549.0" y="415.0"/>
+      <point x="528.0" y="385.0"/>
+      <point x="505.0" y="370.0" type="curve"/>
+      <point x="539.0" y="349.0"/>
+      <point x="561.0" y="317.0"/>
+      <point x="561.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="561.0" y="211.0"/>
+      <point x="494" y="169"/>
     </contour>
     <contour>
-      <point x="425.0" y="389" type="curve" smooth="yes"/>
-      <point x="462.0" y="389"/>
-      <point x="495.0" y="414"/>
-      <point x="495.0" y="449" type="curve" smooth="yes"/>
-      <point x="495.0" y="483"/>
-      <point x="466.0" y="511.0"/>
-      <point x="425.0" y="511.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="511.0"/>
-      <point x="356.0" y="483"/>
-      <point x="356.0" y="449" type="curve" smooth="yes"/>
-      <point x="356.0" y="412"/>
-      <point x="388.0" y="389"/>
+      <point x="425" y="398" type="curve" smooth="yes"/>
+      <point x="453" y="398"/>
+      <point x="474" y="415"/>
+      <point x="474" y="443" type="curve" smooth="yes"/>
+      <point x="474" y="470"/>
+      <point x="455" y="488"/>
+      <point x="425" y="488" type="curve" smooth="yes"/>
+      <point x="395" y="488"/>
+      <point x="377" y="470"/>
+      <point x="377" y="443" type="curve" smooth="yes"/>
+      <point x="377" y="414"/>
+      <point x="397" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="eight.numerator" xOffset="269" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>eight.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="156.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="227" y="343"/>
-      <point x="293.0" y="391.0"/>
-      <point x="293.0" y="470.0" type="curve" smooth="yes"/>
-      <point x="293" y="549"/>
-      <point x="239" y="595.0"/>
-      <point x="164.0" y="595.0" type="curve" smooth="yes"/>
-      <point x="140" y="595"/>
-      <point x="118.0" y="587.0"/>
-      <point x="104.0" y="574.0" type="curve"/>
-      <point x="114.0" y="641.0" type="line"/>
-      <point x="267.0" y="641.0" type="line"/>
-      <point x="267.0" y="716.0" type="line"/>
-      <point x="55.0" y="716.0" type="line"/>
-      <point x="30.0" y="527.0" type="line"/>
-      <point x="99.0" y="499.0" type="line"/>
-      <point x="113.0" y="518.0"/>
+      <point x="156" y="343" type="curve" smooth="yes"/>
+      <point x="236" y="343"/>
+      <point x="288" y="394"/>
+      <point x="288" y="470" type="curve" smooth="yes"/>
+      <point x="288" y="552"/>
+      <point x="235" y="598"/>
+      <point x="164" y="598" type="curve" smooth="yes"/>
+      <point x="140" y="598"/>
+      <point x="115" y="585"/>
+      <point x="105" y="577" type="curve"/>
+      <point x="116" y="649" type="line"/>
+      <point x="267" y="649" type="line"/>
+      <point x="267" y="716" type="line"/>
+      <point x="55" y="716" type="line"/>
+      <point x="29" y="526" type="line"/>
+      <point x="98" y="498" type="line"/>
+      <point x="109" y="514"/>
       <point x="131" y="529"/>
-      <point x="156.0" y="529.0" type="curve" smooth="yes"/>
-      <point x="192.0" y="529.0"/>
-      <point x="212.0" y="504.0"/>
-      <point x="212.0" y="469" type="curve" smooth="yes"/>
+      <point x="156" y="529" type="curve" smooth="yes"/>
+      <point x="193" y="529"/>
+      <point x="212" y="500"/>
+      <point x="212" y="471" type="curve" smooth="yes"/>
       <point x="212" y="433"/>
-      <point x="190.0" y="412.0"/>
-      <point x="156.0" y="412.0" type="curve" smooth="yes"/>
-      <point x="120" y="412"/>
-      <point x="101.0" y="427.0"/>
-      <point x="93.0" y="462.0" type="curve"/>
-      <point x="18.0" y="434.0" type="line"/>
-      <point x="35" y="373"/>
-      <point x="91.0" y="343"/>
+      <point x="190" y="412"/>
+      <point x="156" y="412" type="curve" smooth="yes"/>
+      <point x="124" y="412"/>
+      <point x="98" y="424"/>
+      <point x="88" y="464" type="curve"/>
+      <point x="17" y="435" type="line"/>
+      <point x="34" y="364"/>
+      <point x="102" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -4,50 +4,50 @@
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="426.0" y="169.0" type="curve" smooth="yes"/>
       <point x="372.0" y="169.0"/>
       <point x="311.0" y="194.0"/>
       <point x="293.0" y="260.0" type="curve"/>
-      <point x="332" y="275" type="line"/>
-      <point x="342" y="233"/>
-      <point x="378" y="208"/>
-      <point x="427" y="208" type="curve" smooth="yes"/>
-      <point x="476" y="208"/>
-      <point x="511" y="248"/>
-      <point x="511" y="297" type="curve" smooth="yes"/>
-      <point x="511.0" y="349"/>
-      <point x="481.0" y="377.0"/>
-      <point x="432" y="377.0" type="curve" smooth="yes"/>
-      <point x="394" y="377"/>
-      <point x="369" y="362"/>
-      <point x="352" y="336" type="curve"/>
-      <point x="311.0" y="351.0" type="line"/>
-      <point x="339.0" y="542.0" type="line"/>
-      <point x="537.0" y="542.0" type="line"/>
-      <point x="537.0" y="502.0" type="line"/>
-      <point x="367.0" y="502.0" type="line"/>
-      <point x="347.0" y="372.0" type="line"/>
-      <point x="366.0" y="393.0"/>
-      <point x="393" y="413"/>
-      <point x="434.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="413.0"/>
-      <point x="554.0" y="371.0"/>
-      <point x="554.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="554" y="223"/>
+      <point x="359.0" y="287.0" type="line"/>
+      <point x="367.0" y="252.0"/>
+      <point x="389.0" y="232.0"/>
+      <point x="426.0" y="232.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="232.0"/>
+      <point x="488.0" y="259.0"/>
+      <point x="488.0" y="297.0" type="curve" smooth="yes"/>
+      <point x="488.0" y="336.0"/>
+      <point x="463.0" y="361.0"/>
+      <point x="425.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="401.0" y="361.0"/>
+      <point x="382.0" y="351.0"/>
+      <point x="364.0" y="326.0" type="curve"/>
+      <point x="305.0" y="353.0" type="line"/>
+      <point x="330.0" y="542.0" type="line"/>
+      <point x="540.0" y="542.0" type="line"/>
+      <point x="540.0" y="482.0" type="line"/>
+      <point x="386.0" y="482.0" type="line"/>
+      <point x="375.0" y="404.0" type="line"/>
+      <point x="389.0" y="417.0"/>
+      <point x="410.0" y="421.0"/>
+      <point x="442.0" y="421.0" type="curve"/>
+      <point x="505.0" y="421.0"/>
+      <point x="558.0" y="372.0"/>
+      <point x="558.0" y="296.0" type="curve" smooth="yes"/>
+      <point x="558.0" y="223.0"/>
       <point x="497.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -22,32 +22,32 @@
       <point x="372.0" y="169.0"/>
       <point x="311.0" y="194.0"/>
       <point x="293.0" y="260.0" type="curve"/>
-      <point x="354.0" y="283.0" type="line"/>
-      <point x="362.0" y="248.0"/>
-      <point x="389.0" y="228.0"/>
-      <point x="426.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="228.0"/>
-      <point x="492.0" y="259.0"/>
-      <point x="492.0" y="297.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="336.0"/>
-      <point x="463.0" y="365.0"/>
-      <point x="425.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="401.0" y="365.0"/>
-      <point x="379.0" y="355.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="542.0" type="line"/>
+      <point x="332" y="275" type="line"/>
+      <point x="342" y="233"/>
+      <point x="378" y="208"/>
+      <point x="427" y="208" type="curve" smooth="yes"/>
+      <point x="476" y="208"/>
+      <point x="511" y="248"/>
+      <point x="511" y="297" type="curve" smooth="yes"/>
+      <point x="511.0" y="349"/>
+      <point x="481.0" y="377.0"/>
+      <point x="432" y="377.0" type="curve" smooth="yes"/>
+      <point x="394" y="377"/>
+      <point x="369" y="362"/>
+      <point x="352" y="336" type="curve"/>
+      <point x="311.0" y="351.0" type="line"/>
+      <point x="339.0" y="542.0" type="line"/>
       <point x="537.0" y="542.0" type="line"/>
-      <point x="537.0" y="486.0" type="line"/>
-      <point x="384.0" y="486.0" type="line"/>
-      <point x="372.0" y="400.0" type="line"/>
-      <point x="386.0" y="413.0"/>
-      <point x="410.0" y="421.0"/>
-      <point x="434.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="502.0" y="421.0"/>
-      <point x="558.0" y="372.0"/>
-      <point x="558.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="223.0"/>
+      <point x="537.0" y="502.0" type="line"/>
+      <point x="367.0" y="502.0" type="line"/>
+      <point x="347.0" y="372.0" type="line"/>
+      <point x="366.0" y="393.0"/>
+      <point x="393" y="413"/>
+      <point x="434.0" y="413.0" type="curve" smooth="yes"/>
+      <point x="503.0" y="413.0"/>
+      <point x="554.0" y="371.0"/>
+      <point x="554.0" y="296.0" type="curve" smooth="yes"/>
+      <point x="554" y="223"/>
       <point x="497.0" y="169.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="five.numerator" xOffset="270" yOffset="-174"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>five.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="340"/>
   <outline>
     <contour>
-      <point x="18.0" y="417.0" type="line"/>
-      <point x="313.0" y="417.0" type="line"/>
-      <point x="313.0" y="485.0" type="line"/>
-      <point x="109.0" y="485.0" type="line"/>
-      <point x="185.0" y="592.0" type="line"/>
-      <point x="192.0" y="592.0" type="line"/>
-      <point x="192.0" y="350.0" type="line"/>
-      <point x="271.0" y="350.0" type="line"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="194.0" y="716.0" type="line"/>
-      <point x="18.0" y="468.0" type="line"/>
+      <point x="27" y="420" type="line"/>
+      <point x="316" y="420" type="line"/>
+      <point x="316" y="485" type="line"/>
+      <point x="104" y="485" type="line"/>
+      <point x="190" y="606" type="line"/>
+      <point x="193" y="606" type="line"/>
+      <point x="193" y="350" type="line"/>
+      <point x="268" y="350" type="line"/>
+      <point x="268" y="716" type="line"/>
+      <point x="198" y="716" type="line"/>
+      <point x="27" y="475" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -4,37 +4,37 @@
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="308.0" y="299.0" type="line"/>
-      <point x="443.0" y="299.0" type="line"/>
-      <point x="443.0" y="484.0" type="line"/>
-      <point x="440.0" y="484.0" type="line"/>
+      <point x="336.0" y="310.0" type="line"/>
+      <point x="429.0" y="310.0" type="line"/>
+      <point x="429.0" y="439.0" type="line"/>
+      <point x="428.0" y="439.0" type="line"/>
     </contour>
     <contour>
-      <point x="443.0" y="177.0" type="line"/>
-      <point x="443.0" y="258.0" type="line"/>
-      <point x="261.0" y="258.0" type="line"/>
-      <point x="261.0" y="302.0" type="line"/>
-      <point x="437.0" y="543.0" type="line"/>
-      <point x="488.0" y="543.0" type="line"/>
-      <point x="488.0" y="299.0" type="line"/>
-      <point x="547.0" y="299.0" type="line"/>
-      <point x="547.0" y="258.0" type="line"/>
-      <point x="488.0" y="258.0" type="line"/>
-      <point x="488.0" y="177.0" type="line"/>
+      <point x="429.0" y="177.0" type="line"/>
+      <point x="429.0" y="248.0" type="line"/>
+      <point x="260.0" y="248.0" type="line"/>
+      <point x="260.0" y="301.0" type="line"/>
+      <point x="433.0" y="543.0" type="line"/>
+      <point x="500.0" y="543.0" type="line"/>
+      <point x="500.0" y="310.0" type="line"/>
+      <point x="547.0" y="310.0" type="line"/>
+      <point x="547.0" y="248.0" type="line"/>
+      <point x="500.0" y="248.0" type="line"/>
+      <point x="500.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="331.0" y="307.0" type="line"/>
-      <point x="433.0" y="307.0" type="line"/>
-      <point x="433.0" y="444.0" type="line"/>
-      <point x="429.0" y="444.0" type="line"/>
+      <point x="308.0" y="299.0" type="line"/>
+      <point x="443.0" y="299.0" type="line"/>
+      <point x="443.0" y="484.0" type="line"/>
+      <point x="440.0" y="484.0" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="177.0" type="line"/>
-      <point x="433.0" y="251.0" type="line"/>
-      <point x="261.0" y="251.0" type="line"/>
-      <point x="261.0" y="295.0" type="line"/>
+      <point x="443.0" y="177.0" type="line"/>
+      <point x="443.0" y="258.0" type="line"/>
+      <point x="261.0" y="258.0" type="line"/>
+      <point x="261.0" y="302.0" type="line"/>
       <point x="437.0" y="543.0" type="line"/>
-      <point x="498.0" y="543.0" type="line"/>
-      <point x="498.0" y="307.0" type="line"/>
-      <point x="547.0" y="307.0" type="line"/>
-      <point x="547.0" y="251.0" type="line"/>
-      <point x="498.0" y="251.0" type="line"/>
-      <point x="498.0" y="177.0" type="line"/>
+      <point x="488.0" y="543.0" type="line"/>
+      <point x="488.0" y="299.0" type="line"/>
+      <point x="547.0" y="299.0" type="line"/>
+      <point x="547.0" y="258.0" type="line"/>
+      <point x="488.0" y="258.0" type="line"/>
+      <point x="488.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="four.numerator" xOffset="233" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>four.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="142.0" y="331.0" type="line"/>
-      <point x="178.0" y="381.0"/>
-      <point x="219.0" y="433.0"/>
-      <point x="254.0" y="484.0" type="curve" smooth="yes"/>
-      <point x="280.0" y="522.0"/>
-      <point x="296.0" y="557.0"/>
-      <point x="296.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="296.0" y="667.0"/>
-      <point x="233.0" y="724.0"/>
-      <point x="155.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="77.0" y="724.0"/>
-      <point x="15.0" y="667.0"/>
-      <point x="15.0" y="598.0" type="curve" smooth="yes"/>
-      <point x="15.0" y="516.0"/>
-      <point x="63.0" y="464.0"/>
-      <point x="142.0" y="464.0" type="curve" smooth="yes"/>
-      <point x="147.0" y="464.0"/>
-      <point x="148.0" y="464.0"/>
-      <point x="151.0" y="465.0" type="curve"/>
-      <point x="133.0" y="443.0"/>
-      <point x="104.0" y="406.0"/>
-      <point x="75.0" y="369.0" type="curve"/>
+      <point x="136" y="334" type="line"/>
+      <point x="172" y="384"/>
+      <point x="209" y="430"/>
+      <point x="245" y="480" type="curve" smooth="yes"/>
+      <point x="272" y="517"/>
+      <point x="293" y="557"/>
+      <point x="293" y="598" type="curve" smooth="yes"/>
+      <point x="293" y="667"/>
+      <point x="229" y="724"/>
+      <point x="155" y="724" type="curve" smooth="yes"/>
+      <point x="85" y="724"/>
+      <point x="23" y="667"/>
+      <point x="23" y="598" type="curve" smooth="yes"/>
+      <point x="23" y="534"/>
+      <point x="75" y="473"/>
+      <point x="144" y="473" type="curve" smooth="yes"/>
+      <point x="148" y="473"/>
+      <point x="154" y="474"/>
+      <point x="158" y="475" type="curve"/>
+      <point x="143" y="462"/>
+      <point x="103" y="414"/>
+      <point x="74" y="377" type="curve"/>
     </contour>
     <contour>
-      <point x="156.0" y="535.0" type="curve" smooth="yes"/>
-      <point x="118.0" y="535.0"/>
-      <point x="98.0" y="562.0"/>
-      <point x="98.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="98.0" y="626.0"/>
-      <point x="122.0" y="650.0"/>
-      <point x="156.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="650.0"/>
-      <point x="212.0" y="628.0"/>
-      <point x="212.0" y="594.0" type="curve" smooth="yes"/>
-      <point x="212.0" y="560.0"/>
-      <point x="194.0" y="535.0"/>
+      <point x="156" y="539" type="curve" smooth="yes"/>
+      <point x="123" y="539"/>
+      <point x="101" y="567"/>
+      <point x="101" y="597" type="curve" smooth="yes"/>
+      <point x="101" y="628"/>
+      <point x="123" y="656"/>
+      <point x="156" y="656" type="curve" smooth="yes"/>
+      <point x="190" y="656"/>
+      <point x="211" y="628"/>
+      <point x="211" y="597" type="curve" smooth="yes"/>
+      <point x="211" y="567"/>
+      <point x="189" y="539"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="402.0" y="160.0" type="curve"/>
-      <point x="366.0" y="186.0" type="line"/>
-      <point x="395.0" y="223.0"/>
-      <point x="445.0" y="287.0"/>
-      <point x="478.0" y="321.0" type="curve"/>
-      <point x="466.0" y="312.0"/>
-      <point x="438.0" y="300.0"/>
+      <point x="404.0" y="160.0" type="curve"/>
+      <point x="347.0" y="198.0" type="line"/>
+      <point x="374.0" y="236.0"/>
+      <point x="409.0" y="281.0"/>
+      <point x="438.0" y="306.0" type="curve"/>
+      <point x="432.0" y="302.0"/>
+      <point x="421.0" y="300.0"/>
       <point x="412.0" y="300.0" type="curve" smooth="yes"/>
       <point x="343.0" y="300.0"/>
-      <point x="289.0" y="360.0"/>
-      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="493.0"/>
-      <point x="351.0" y="550.0"/>
+      <point x="286.0" y="360.0"/>
+      <point x="286.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="286.0" y="493.0"/>
+      <point x="348.0" y="550.0"/>
       <point x="421.0" y="550.0" type="curve" smooth="yes"/>
-      <point x="495.0" y="550.0"/>
-      <point x="555.0" y="493.0"/>
-      <point x="555.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="555.0" y="383.0"/>
-      <point x="537.0" y="347.0"/>
-      <point x="510.0" y="310.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="260.0"/>
-      <point x="438.0" y="210.0"/>
+      <point x="498.0" y="550.0"/>
+      <point x="558.0" y="493.0"/>
+      <point x="558.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="558.0" y="383.0"/>
+      <point x="539.0" y="345.0"/>
+      <point x="512.0" y="308.0" type="curve" smooth="yes"/>
+      <point x="476.0" y="258.0"/>
+      <point x="440.0" y="210.0"/>
     </contour>
     <contour>
-      <point x="422.0" y="336.0" type="curve" smooth="yes"/>
-      <point x="476.0" y="336.0"/>
-      <point x="513.0" y="377.0"/>
-      <point x="513.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="470.0"/>
-      <point x="477.0" y="511.0"/>
-      <point x="422.0" y="511.0" type="curve" smooth="yes"/>
-      <point x="368.0" y="511.0"/>
-      <point x="331.0" y="470.0"/>
-      <point x="331.0" y="423.0" type="curve" smooth="yes"/>
-      <point x="331.0" y="377.0"/>
-      <point x="368.0" y="336.0"/>
+      <point x="422.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="459.0" y="361.0"/>
+      <point x="482.0" y="390.0"/>
+      <point x="482.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="482.0" y="457.0"/>
+      <point x="460.0" y="486.0"/>
+      <point x="422.0" y="486.0" type="curve" smooth="yes"/>
+      <point x="385.0" y="486.0"/>
+      <point x="362.0" y="457.0"/>
+      <point x="362.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="362.0" y="390.0"/>
+      <point x="385.0" y="361.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="402.0" y="161.0" type="curve"/>
-      <point x="352.0" y="196.0" type="line"/>
-      <point x="381.0" y="233.0"/>
-      <point x="410.0" y="270.0"/>
-      <point x="439.0" y="307.0" type="curve"/>
-      <point x="433.0" y="303.0"/>
-      <point x="422.0" y="301.0"/>
-      <point x="413.0" y="301.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="301.0"/>
-      <point x="290.0" y="361.0"/>
-      <point x="290.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="290.0" y="494.0"/>
-      <point x="351.0" y="551.0"/>
-      <point x="422.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="496.0" y="551.0"/>
-      <point x="555.0" y="494.0"/>
-      <point x="555.0" y="425.0" type="curve" smooth="yes"/>
-      <point x="555.0" y="384.0"/>
-      <point x="537.0" y="348.0"/>
-      <point x="510.0" y="311.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="261.0"/>
-      <point x="438.0" y="211.0"/>
+      <point x="402.0" y="160.0" type="curve"/>
+      <point x="366.0" y="186.0" type="line"/>
+      <point x="395.0" y="223.0"/>
+      <point x="445.0" y="287.0"/>
+      <point x="478.0" y="321.0" type="curve"/>
+      <point x="466.0" y="312.0"/>
+      <point x="438.0" y="300.0"/>
+      <point x="412.0" y="300.0" type="curve" smooth="yes"/>
+      <point x="343.0" y="300.0"/>
+      <point x="289.0" y="360.0"/>
+      <point x="289.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="289.0" y="493.0"/>
+      <point x="351.0" y="550.0"/>
+      <point x="421.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="495.0" y="550.0"/>
+      <point x="555.0" y="493.0"/>
+      <point x="555.0" y="424.0" type="curve" smooth="yes"/>
+      <point x="555.0" y="383.0"/>
+      <point x="537.0" y="347.0"/>
+      <point x="510.0" y="310.0" type="curve" smooth="yes"/>
+      <point x="474.0" y="260.0"/>
+      <point x="438.0" y="210.0"/>
     </contour>
     <contour>
-      <point x="423.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="462.0" y="357.0"/>
-      <point x="489.0" y="389.0"/>
-      <point x="489.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="489.0" y="460.0"/>
-      <point x="463.0" y="492.0"/>
-      <point x="423.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="492.0"/>
-      <point x="357.0" y="460.0"/>
-      <point x="357.0" y="424.0" type="curve" smooth="yes"/>
-      <point x="357.0" y="389.0"/>
-      <point x="384.0" y="357.0"/>
+      <point x="422.0" y="336.0" type="curve" smooth="yes"/>
+      <point x="476.0" y="336.0"/>
+      <point x="513.0" y="377.0"/>
+      <point x="513.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="513.0" y="470.0"/>
+      <point x="477.0" y="511.0"/>
+      <point x="422.0" y="511.0" type="curve" smooth="yes"/>
+      <point x="368.0" y="511.0"/>
+      <point x="331.0" y="470.0"/>
+      <point x="331.0" y="423.0" type="curve" smooth="yes"/>
+      <point x="331.0" y="377.0"/>
+      <point x="368.0" y="336.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="nine.numerator" xOffset="267" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>nine.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="235"/>
   <outline>
     <contour>
-      <point x="102.0" y="350.0" type="line"/>
-      <point x="197.0" y="350.0" type="line"/>
-      <point x="197.0" y="716.0" type="line"/>
-      <point x="111.0" y="716.0" type="line"/>
-      <point x="5.0" y="633.0" type="line"/>
-      <point x="60.0" y="562.0" type="line"/>
-      <point x="102.0" y="590.0" type="line"/>
+      <point x="103" y="350" type="line"/>
+      <point x="186" y="350" type="line"/>
+      <point x="186" y="716" type="line"/>
+      <point x="116" y="716" type="line"/>
+      <point x="16" y="636" type="line"/>
+      <point x="61" y="580" type="line"/>
+      <point x="103" y="618" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="406.0" y="177.0" type="line"/>
-      <point x="406.0" y="459.0" type="line"/>
-      <point x="354.0" y="416.0" type="line"/>
+      <point x="411.0" y="177.0" type="line"/>
+      <point x="411.0" y="482.0" type="line"/>
+      <point x="340.0" y="430.0" type="line"/>
       <point x="318.0" y="464.0" type="line"/>
-      <point x="416.0" y="543.0" type="line"/>
-      <point x="471.0" y="543.0" type="line"/>
-      <point x="471.0" y="177.0" type="line"/>
+      <point x="421.0" y="543.0" type="line"/>
+      <point x="457.0" y="543.0" type="line"/>
+      <point x="457.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -4,27 +4,27 @@
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="411.0" y="177.0" type="line"/>
-      <point x="411.0" y="482.0" type="line"/>
-      <point x="340.0" y="430.0" type="line"/>
-      <point x="318.0" y="464.0" type="line"/>
-      <point x="421.0" y="543.0" type="line"/>
-      <point x="457.0" y="543.0" type="line"/>
-      <point x="457.0" y="177.0" type="line"/>
+      <point x="402.0" y="177.0" type="line"/>
+      <point x="402.0" y="453.0" type="line"/>
+      <point x="351.0" y="412.0" type="line"/>
+      <point x="312.0" y="464.0" type="line"/>
+      <point x="410.0" y="543.0" type="line"/>
+      <point x="475.0" y="543.0" type="line"/>
+      <point x="475.0" y="177.0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="one.numerator" xOffset="295" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>one.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="295"/>
   <outline>
     <contour>
-      <point x="101.0" y="335.0" type="line"/>
-      <point x="158.0" y="443.0"/>
-      <point x="213.0" y="544.0"/>
-      <point x="271.0" y="653.0" type="curve"/>
-      <point x="271.0" y="716.0" type="line"/>
-      <point x="23.0" y="716.0" type="line"/>
-      <point x="23.0" y="640.0" type="line"/>
-      <point x="177.0" y="640.0" type="line"/>
-      <point x="125.0" y="543.0"/>
-      <point x="85.0" y="463.0"/>
-      <point x="28.0" y="366.0" type="curve"/>
+      <point x="98" y="334" type="line"/>
+      <point x="156" y="443"/>
+      <point x="217" y="552"/>
+      <point x="275" y="661" type="curve"/>
+      <point x="275" y="716" type="line"/>
+      <point x="23" y="716" type="line"/>
+      <point x="23" y="642" type="line"/>
+      <point x="178" y="642" type="line"/>
+      <point x="126" y="545"/>
+      <point x="82" y="465"/>
+      <point x="30" y="371" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -4,31 +4,31 @@
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="372.0" y="167.0" type="curve"/>
-      <point x="336.0" y="189.0" type="line"/>
-      <point x="389.0" y="286.0"/>
-      <point x="460.0" y="408.0"/>
-      <point x="510.0" y="504.0" type="curve"/>
-      <point x="310.0" y="504.0" type="line"/>
+      <point x="386.0" y="160.0" type="curve"/>
+      <point x="320.0" y="198.0" type="line"/>
+      <point x="373.0" y="295.0"/>
+      <point x="429.0" y="394.0"/>
+      <point x="476.0" y="480.0" type="curve"/>
+      <point x="310.0" y="480.0" type="line"/>
       <point x="310.0" y="543.0" type="line"/>
       <point x="557.0" y="543.0" type="line"/>
-      <point x="557.0" y="508.0" type="line"/>
-      <point x="499.0" y="399.0"/>
-      <point x="430.0" y="276.0"/>
+      <point x="557.0" y="483.0" type="line"/>
+      <point x="499.0" y="374.0"/>
+      <point x="444.0" y="269.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="382.0" y="162.0" type="curve"/>
-      <point x="325.0" y="193.0" type="line"/>
-      <point x="378.0" y="290.0"/>
-      <point x="432.0" y="387.0"/>
-      <point x="485.0" y="484.0" type="curve"/>
-      <point x="310.0" y="484.0" type="line"/>
+      <point x="372.0" y="167.0" type="curve"/>
+      <point x="336.0" y="189.0" type="line"/>
+      <point x="389.0" y="286.0"/>
+      <point x="460.0" y="408.0"/>
+      <point x="510.0" y="504.0" type="curve"/>
+      <point x="310.0" y="504.0" type="line"/>
       <point x="310.0" y="543.0" type="line"/>
       <point x="557.0" y="543.0" type="line"/>
-      <point x="557.0" y="488.0" type="line"/>
-      <point x="499.0" y="379.0"/>
-      <point x="440.0" y="271.0"/>
+      <point x="557.0" y="508.0" type="line"/>
+      <point x="499.0" y="399.0"/>
+      <point x="430.0" y="276.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="312"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="235.0" y="342.0"/>
-      <point x="297" y="399"/>
-      <point x="297.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="297.0" y="550"/>
-      <point x="249" y="602.0"/>
-      <point x="170" y="602.0" type="curve" smooth="yes"/>
-      <point x="165" y="602"/>
-      <point x="164.0" y="602.0"/>
-      <point x="161.0" y="601.0" type="curve"/>
-      <point x="179.0" y="623.0"/>
-      <point x="208.0" y="660.0"/>
-      <point x="237.0" y="697.0" type="curve"/>
-      <point x="170.0" y="735.0" type="line"/>
-      <point x="134.0" y="685.0"/>
-      <point x="93.0" y="633.0"/>
-      <point x="58.0" y="582.0" type="curve" smooth="yes"/>
-      <point x="32" y="544"/>
-      <point x="16.0" y="509.0"/>
-      <point x="16.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="16.0" y="399.0"/>
-      <point x="79" y="342"/>
+      <point x="157" y="342" type="curve" smooth="yes"/>
+      <point x="227" y="342"/>
+      <point x="289" y="399"/>
+      <point x="289" y="468" type="curve" smooth="yes"/>
+      <point x="289" y="532"/>
+      <point x="237" y="593"/>
+      <point x="168" y="593" type="curve" smooth="yes"/>
+      <point x="164" y="593"/>
+      <point x="158" y="592"/>
+      <point x="154" y="591" type="curve"/>
+      <point x="169" y="604"/>
+      <point x="209" y="652"/>
+      <point x="238" y="689" type="curve"/>
+      <point x="176" y="732" type="line"/>
+      <point x="140" y="682"/>
+      <point x="101" y="634"/>
+      <point x="65" y="584" type="curve" smooth="yes"/>
+      <point x="38" y="547"/>
+      <point x="20" y="509"/>
+      <point x="20" y="468" type="curve" smooth="yes"/>
+      <point x="20" y="399"/>
+      <point x="81" y="342"/>
     </contour>
     <contour>
-      <point x="156.0" y="416.0" type="curve" smooth="yes"/>
-      <point x="122.0" y="416.0"/>
-      <point x="100" y="438"/>
-      <point x="100.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="100.0" y="506.0"/>
-      <point x="118.0" y="531.0"/>
-      <point x="156.0" y="531.0" type="curve" smooth="yes"/>
-      <point x="194" y="531"/>
-      <point x="214.0" y="504.0"/>
-      <point x="214.0" y="472.0" type="curve" smooth="yes"/>
-      <point x="214" y="440"/>
-      <point x="190" y="416"/>
+      <point x="156" y="410" type="curve" smooth="yes"/>
+      <point x="122" y="410"/>
+      <point x="101" y="438"/>
+      <point x="101" y="469" type="curve" smooth="yes"/>
+      <point x="101" y="499"/>
+      <point x="123" y="527"/>
+      <point x="156" y="527" type="curve" smooth="yes"/>
+      <point x="189" y="527"/>
+      <point x="211" y="499"/>
+      <point x="211" y="469" type="curve" smooth="yes"/>
+      <point x="211" y="438"/>
+      <point x="189" y="410"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -4,56 +4,56 @@
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
-      <point x="421" y="208" type="curve" smooth="yes"/>
-      <point x="475" y="208"/>
-      <point x="512" y="249"/>
-      <point x="512" y="296" type="curve" smooth="yes"/>
-      <point x="512" y="342"/>
-      <point x="475" y="383"/>
-      <point x="421" y="383" type="curve" smooth="yes"/>
-      <point x="367" y="383"/>
-      <point x="330" y="342"/>
-      <point x="330" y="296" type="curve" smooth="yes"/>
-      <point x="330" y="249"/>
-      <point x="366" y="208"/>
+      <point x="421" y="233" type="curve" smooth="yes"/>
+      <point x="458" y="233"/>
+      <point x="481" y="262"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="329"/>
+      <point x="458" y="358"/>
+      <point x="421" y="358" type="curve" smooth="yes"/>
+      <point x="384" y="358"/>
+      <point x="361" y="329"/>
+      <point x="361" y="296" type="curve" smooth="yes"/>
+      <point x="361" y="262"/>
+      <point x="383" y="233"/>
     </contour>
     <contour>
       <point x="422.0" y="169.0" type="curve" smooth="yes"/>
-      <point x="348.0" y="169.0"/>
-      <point x="288.0" y="226.0"/>
-      <point x="288.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="336.0"/>
-      <point x="306.0" y="372.0"/>
-      <point x="333.0" y="409.0" type="curve" smooth="yes"/>
-      <point x="369.0" y="459.0"/>
-      <point x="405.0" y="509.0"/>
-      <point x="441.0" y="559.0" type="curve"/>
-      <point x="477.0" y="533.0" type="line"/>
-      <point x="448.0" y="496"/>
-      <point x="398.0" y="432"/>
-      <point x="365.0" y="398.0" type="curve"/>
-      <point x="377.0" y="407.0"/>
-      <point x="405" y="419.0"/>
+      <point x="345" y="169"/>
+      <point x="285.0" y="226.0"/>
+      <point x="285.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="285.0" y="336.0"/>
+      <point x="304.0" y="374.0"/>
+      <point x="331.0" y="411.0" type="curve" smooth="yes"/>
+      <point x="367.0" y="461.0"/>
+      <point x="403.0" y="509.0"/>
+      <point x="439.0" y="559.0" type="curve"/>
+      <point x="496.0" y="521.0" type="line"/>
+      <point x="469.0" y="483.0"/>
+      <point x="434.0" y="438.0"/>
+      <point x="405.0" y="413.0" type="curve"/>
+      <point x="411.0" y="417.0"/>
+      <point x="422.0" y="419.0"/>
       <point x="431.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="500" y="419"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="295.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="226.0"/>
-      <point x="492.0" y="169.0"/>
+      <point x="500.0" y="419.0"/>
+      <point x="557.0" y="359.0"/>
+      <point x="557.0" y="295.0" type="curve" smooth="yes"/>
+      <point x="557.0" y="226.0"/>
+      <point x="495" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,18 +18,18 @@
       <point x="219.0" y="-16.0"/>
     </contour>
     <contour>
-      <point x="421.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="228.0"/>
-      <point x="487.0" y="260.0"/>
-      <point x="487.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="331.0"/>
-      <point x="460.0" y="363.0"/>
-      <point x="421.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="382.0" y="363.0"/>
-      <point x="355.0" y="331.0"/>
-      <point x="355.0" y="296.0" type="curve" smooth="yes"/>
-      <point x="355.0" y="260.0"/>
-      <point x="381.0" y="228.0"/>
+      <point x="421" y="208" type="curve" smooth="yes"/>
+      <point x="475" y="208"/>
+      <point x="512" y="249"/>
+      <point x="512" y="296" type="curve" smooth="yes"/>
+      <point x="512" y="342"/>
+      <point x="475" y="383"/>
+      <point x="421" y="383" type="curve" smooth="yes"/>
+      <point x="367" y="383"/>
+      <point x="330" y="342"/>
+      <point x="330" y="296" type="curve" smooth="yes"/>
+      <point x="330" y="249"/>
+      <point x="366" y="208"/>
     </contour>
     <contour>
       <point x="422.0" y="169.0" type="curve" smooth="yes"/>
@@ -42,14 +42,14 @@
       <point x="369.0" y="459.0"/>
       <point x="405.0" y="509.0"/>
       <point x="441.0" y="559.0" type="curve"/>
-      <point x="492.0" y="524.0" type="line"/>
-      <point x="463.0" y="487.0"/>
-      <point x="434.0" y="450.0"/>
-      <point x="405.0" y="413.0" type="curve"/>
-      <point x="411.0" y="417.0"/>
-      <point x="422.0" y="419.0"/>
+      <point x="477.0" y="533.0" type="line"/>
+      <point x="448.0" y="496"/>
+      <point x="398.0" y="432"/>
+      <point x="365.0" y="398.0" type="curve"/>
+      <point x="377.0" y="407.0"/>
+      <point x="405" y="419.0"/>
       <point x="431.0" y="419.0" type="curve" smooth="yes"/>
-      <point x="500.0" y="419.0"/>
+      <point x="500" y="419"/>
       <point x="554.0" y="359.0"/>
       <point x="554.0" y="295.0" type="curve" smooth="yes"/>
       <point x="554.0" y="226.0"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="six.numerator" xOffset="265" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>six.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="157.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="235.0" y="342.0"/>
-      <point x="294" y="385"/>
-      <point x="294.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="294.0" y="503"/>
-      <point x="267.0" y="532.0"/>
-      <point x="237.0" y="543.0" type="curve"/>
-      <point x="264.0" y="557.0"/>
-      <point x="286.0" y="585.0"/>
-      <point x="286.0" y="620" type="curve" smooth="yes"/>
-      <point x="286.0" y="680.0"/>
-      <point x="235" y="724"/>
-      <point x="162" y="724.0" type="curve" smooth="yes"/>
-      <point x="97" y="724"/>
-      <point x="50.0" y="693.0"/>
-      <point x="31.0" y="640.0" type="curve"/>
-      <point x="105.0" y="613.0" type="line"/>
-      <point x="112.0" y="634.0"/>
-      <point x="133" y="653"/>
-      <point x="157" y="653.0" type="curve" smooth="yes"/>
-      <point x="182" y="653.0"/>
-      <point x="197" y="637"/>
-      <point x="197.0" y="615" type="curve" smooth="yes"/>
-      <point x="197" y="594"/>
-      <point x="180" y="572.0"/>
-      <point x="153.0" y="572.0" type="curve" smooth="yes"/>
+      <point x="157" y="340" type="curve" smooth="yes"/>
+      <point x="230" y="340"/>
+      <point x="295" y="385"/>
+      <point x="295" y="459" type="curve" smooth="yes"/>
+      <point x="295" y="498"/>
+      <point x="270" y="526"/>
+      <point x="235" y="543" type="curve"/>
+      <point x="262" y="558"/>
+      <point x="283" y="585"/>
+      <point x="283" y="619" type="curve" smooth="yes"/>
+      <point x="283" y="680"/>
+      <point x="227" y="726"/>
+      <point x="156" y="726" type="curve" smooth="yes"/>
+      <point x="93" y="726"/>
+      <point x="49" y="689"/>
+      <point x="31" y="641" type="curve"/>
+      <point x="98" y="612" type="line"/>
+      <point x="107" y="637"/>
+      <point x="126.0" y="656.0"/>
+      <point x="156" y="656" type="curve" smooth="yes"/>
+      <point x="182" y="656"/>
+      <point x="201" y="643"/>
+      <point x="201" y="616" type="curve" smooth="yes"/>
+      <point x="201" y="587"/>
+      <point x="186" y="572"/>
+      <point x="153" y="572" type="curve" smooth="yes"/>
       <point x="145" y="572"/>
-      <point x="114.0" y="572.0"/>
-      <point x="114.0" y="572.0" type="curve"/>
-      <point x="114.0" y="505.0" type="line"/>
-      <point x="114.0" y="505.0"/>
-      <point x="144" y="505.0"/>
-      <point x="154.0" y="505.0" type="curve" smooth="yes"/>
-      <point x="189" y="505"/>
-      <point x="213" y="489"/>
-      <point x="213.0" y="462" type="curve" smooth="yes"/>
-      <point x="213" y="434"/>
-      <point x="193.0" y="414.0"/>
-      <point x="159" y="414.0" type="curve" smooth="yes"/>
-      <point x="126" y="414"/>
-      <point x="102.0" y="436.0"/>
-      <point x="90.0" y="472.0" type="curve"/>
-      <point x="19.0" y="443.0" type="line"/>
-      <point x="36.0" y="374.0"/>
-      <point x="97" y="342"/>
+      <point x="113" y="572"/>
+      <point x="113" y="572" type="curve"/>
+      <point x="113" y="508" type="line"/>
+      <point x="113" y="508"/>
+      <point x="129" y="508"/>
+      <point x="158" y="508" type="curve" smooth="yes"/>
+      <point x="190" y="508"/>
+      <point x="216" y="493"/>
+      <point x="216" y="461" type="curve" smooth="yes"/>
+      <point x="216" y="427"/>
+      <point x="189" y="409"/>
+      <point x="157" y="409" type="curve" smooth="yes"/>
+      <point x="128" y="409"/>
+      <point x="102" y="425"/>
+      <point x="90" y="470" type="curve"/>
+      <point x="20" y="442" type="line"/>
+      <point x="37" y="373"/>
+      <point x="97" y="340"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -4,64 +4,64 @@
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="423.0" y="166.0" type="curve" smooth="yes"/>
       <point x="363.0" y="166.0"/>
-      <point x="306.0" y="196.0"/>
-      <point x="289.0" y="265.0" type="curve"/>
-      <point x="325.0" y="279" type="line"/>
-      <point x="340.0" y="224"/>
-      <point x="381.0" y="204"/>
-      <point x="424.0" y="204" type="curve" smooth="yes"/>
-      <point x="469.0" y="204"/>
-      <point x="507" y="239"/>
-      <point x="507.0" y="281" type="curve" smooth="yes"/>
-      <point x="507.0" y="319"/>
-      <point x="475" y="343.0"/>
-      <point x="436" y="343.0" type="curve" smooth="yes"/>
-      <point x="411" y="343"/>
-      <point x="382.0" y="343"/>
-      <point x="382.0" y="343" type="curve"/>
-      <point x="382" y="384" type="line"/>
-      <point x="382" y="384"/>
-      <point x="409" y="384"/>
-      <point x="419" y="384" type="curve" smooth="yes"/>
-      <point x="461" y="384"/>
-      <point x="494" y="414"/>
-      <point x="494.0" y="445" type="curve" smooth="yes"/>
-      <point x="494.0" y="479.0"/>
-      <point x="466.0" y="506.0"/>
-      <point x="423" y="506" type="curve" smooth="yes"/>
-      <point x="374" y="506"/>
-      <point x="354" y="475"/>
-      <point x="344" y="451" type="curve"/>
-      <point x="303.0" y="466.0" type="line"/>
-      <point x="320.0" y="514.0"/>
+      <point x="304.0" y="194.0"/>
+      <point x="287.0" y="263.0" type="curve"/>
+      <point x="351.0" y="289.0" type="line"/>
+      <point x="363.0" y="243.0"/>
+      <point x="392.0" y="232.0"/>
+      <point x="423.0" y="232.0" type="curve" smooth="yes"/>
+      <point x="457.0" y="232.0"/>
+      <point x="482.0" y="249.0"/>
+      <point x="482.0" y="283.0" type="curve" smooth="yes"/>
+      <point x="482.0" y="317.0"/>
+      <point x="458.0" y="332.0"/>
+      <point x="423.0" y="332.0" type="curve" smooth="yes"/>
+      <point x="393.0" y="332.0"/>
+      <point x="383.0" y="332.0"/>
+      <point x="383.0" y="332.0" type="curve"/>
+      <point x="383.0" y="396.0" type="line"/>
+      <point x="383.0" y="396.0"/>
+      <point x="411.0" y="396.0"/>
+      <point x="419.0" y="396.0" type="curve" smooth="yes"/>
+      <point x="452.0" y="396.0"/>
+      <point x="469.0" y="411.0"/>
+      <point x="469.0" y="442.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="471.0"/>
+      <point x="450.0" y="484.0"/>
+      <point x="422.0" y="484.0" type="curve" smooth="yes"/>
+      <point x="384.0" y="484.0"/>
+      <point x="371.0" y="461.0"/>
+      <point x="363.0" y="440.0" type="curve"/>
+      <point x="301.0" y="468.0" type="line"/>
+      <point x="318.0" y="516.0"/>
       <point x="360.0" y="548.0"/>
       <point x="421.0" y="548.0" type="curve" smooth="yes"/>
       <point x="493.0" y="548.0"/>
-      <point x="534.0" y="506.0"/>
-      <point x="534.0" y="451" type="curve" smooth="yes"/>
-      <point x="534.0" y="411.0"/>
-      <point x="509.0" y="383.0"/>
-      <point x="476.0" y="372.0" type="curve"/>
-      <point x="519.0" y="363.0"/>
-      <point x="548.0" y="321.0"/>
-      <point x="548.0" y="286" type="curve" smooth="yes"/>
-      <point x="548.0" y="209.0"/>
+      <point x="545.0" y="504.0"/>
+      <point x="545.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="545.0" y="409.0"/>
+      <point x="529.0" y="386.0"/>
+      <point x="499.0" y="370.0" type="curve"/>
+      <point x="534.0" y="354.0"/>
+      <point x="557.0" y="321.0"/>
+      <point x="557.0" y="282.0" type="curve" smooth="yes"/>
+      <point x="557.0" y="209.0"/>
       <point x="492.0" y="166.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -22,46 +22,46 @@
       <point x="363.0" y="166.0"/>
       <point x="306.0" y="196.0"/>
       <point x="289.0" y="265.0" type="curve"/>
-      <point x="349.0" y="287.0" type="line"/>
-      <point x="361.0" y="241.0"/>
-      <point x="392.0" y="225.0"/>
-      <point x="423.0" y="225.0" type="curve" smooth="yes"/>
-      <point x="457.0" y="225.0"/>
-      <point x="488.0" y="249.0"/>
-      <point x="488.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="317.0"/>
-      <point x="458.0" y="336.0"/>
-      <point x="423.0" y="336.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="336.0"/>
-      <point x="383.0" y="336.0"/>
-      <point x="383.0" y="336.0" type="curve"/>
-      <point x="383.0" y="392.0" type="line"/>
-      <point x="383.0" y="392.0"/>
-      <point x="411.0" y="392.0"/>
-      <point x="419.0" y="392.0" type="curve" smooth="yes"/>
-      <point x="452.0" y="392.0"/>
-      <point x="475.0" y="411.0"/>
-      <point x="475.0" y="442.0" type="curve" smooth="yes"/>
-      <point x="475.0" y="471.0"/>
-      <point x="450.0" y="488.0"/>
-      <point x="422.0" y="488.0" type="curve" smooth="yes"/>
-      <point x="384.0" y="488.0"/>
-      <point x="368.0" y="464.0"/>
-      <point x="360.0" y="443.0" type="curve"/>
+      <point x="325.0" y="279" type="line"/>
+      <point x="340.0" y="224"/>
+      <point x="381.0" y="204"/>
+      <point x="424.0" y="204" type="curve" smooth="yes"/>
+      <point x="469.0" y="204"/>
+      <point x="507" y="239"/>
+      <point x="507.0" y="281" type="curve" smooth="yes"/>
+      <point x="507.0" y="319"/>
+      <point x="475" y="343.0"/>
+      <point x="436" y="343.0" type="curve" smooth="yes"/>
+      <point x="411" y="343"/>
+      <point x="382.0" y="343"/>
+      <point x="382.0" y="343" type="curve"/>
+      <point x="382" y="384" type="line"/>
+      <point x="382" y="384"/>
+      <point x="409" y="384"/>
+      <point x="419" y="384" type="curve" smooth="yes"/>
+      <point x="461" y="384"/>
+      <point x="494" y="414"/>
+      <point x="494.0" y="445" type="curve" smooth="yes"/>
+      <point x="494.0" y="479.0"/>
+      <point x="466.0" y="506.0"/>
+      <point x="423" y="506" type="curve" smooth="yes"/>
+      <point x="374" y="506"/>
+      <point x="354" y="475"/>
+      <point x="344" y="451" type="curve"/>
       <point x="303.0" y="466.0" type="line"/>
       <point x="320.0" y="514.0"/>
       <point x="360.0" y="548.0"/>
       <point x="421.0" y="548.0" type="curve" smooth="yes"/>
       <point x="493.0" y="548.0"/>
-      <point x="542.0" y="504.0"/>
-      <point x="542.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="542.0" y="409.0"/>
-      <point x="524.0" y="385.0"/>
-      <point x="496.0" y="367.0" type="curve"/>
-      <point x="529.0" y="348.0"/>
-      <point x="554.0" y="321.0"/>
-      <point x="554.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="209.0"/>
+      <point x="534.0" y="506.0"/>
+      <point x="534.0" y="451" type="curve" smooth="yes"/>
+      <point x="534.0" y="411.0"/>
+      <point x="509.0" y="383.0"/>
+      <point x="476.0" y="372.0" type="curve"/>
+      <point x="519.0" y="363.0"/>
+      <point x="548.0" y="321.0"/>
+      <point x="548.0" y="286" type="curve" smooth="yes"/>
+      <point x="548.0" y="209.0"/>
       <point x="492.0" y="166.0"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="three.numerator" xOffset="266" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>three.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.glif
@@ -9,7 +9,7 @@
       <point x="491.0" y="117.0" type="line"/>
       <point x="212.0" y="117.0" type="line"/>
       <point x="212.0" y="121.0" type="line"/>
-      <point x="226.0" y="137.0"/>
+      <point x="227.0" y="134.0"/>
       <point x="348.0" y="268.0"/>
       <point x="376.0" y="297.0" type="curve" smooth="yes"/>
       <point x="422.0" y="345.0"/>
@@ -23,16 +23,16 @@
       <point x="34.0" y="550.0" type="curve"/>
       <point x="147.0" y="516.0" type="line"/>
       <point x="157.0" y="540.0"/>
-      <point x="182" y="589"/>
-      <point x="254.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="321.0" y="589.0"/>
+      <point x="189" y="589"/>
+      <point x="261.0" y="589.0" type="curve" smooth="yes"/>
+      <point x="328.0" y="589.0"/>
       <point x="362" y="554"/>
       <point x="362.0" y="507.0" type="curve" smooth="yes"/>
       <point x="362.0" y="455.0"/>
-      <point x="328" y="412"/>
+      <point x="329" y="412"/>
       <point x="281.0" y="355.0" type="curve" smooth="yes"/>
-      <point x="225" y="286"/>
-      <point x="82.0" y="140.0"/>
+      <point x="224" y="288"/>
+      <point x="84.0" y="140.0"/>
       <point x="40.0" y="95.0" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="300"/>
   <outline>
     <contour>
-      <point x="25.0" y="350.0" type="line"/>
-      <point x="277.0" y="350.0" type="line"/>
-      <point x="277.0" y="429.0" type="line"/>
-      <point x="134.0" y="429.0" type="line"/>
-      <point x="134.0" y="429.0"/>
-      <point x="185" y="479"/>
-      <point x="209.0" y="502.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="524.0"/>
-      <point x="273.0" y="569.0"/>
-      <point x="274.0" y="622" type="curve" smooth="yes"/>
+      <point x="25" y="350" type="line"/>
+      <point x="276" y="350" type="line"/>
+      <point x="276" y="419" type="line"/>
+      <point x="133" y="419" type="line"/>
+      <point x="133" y="419"/>
+      <point x="190" y="475"/>
+      <point x="213" y="498" type="curve" smooth="yes"/>
+      <point x="236" y="521"/>
+      <point x="275" y="569"/>
+      <point x="275" y="617" type="curve" smooth="yes"/>
       <point x="275" y="683"/>
-      <point x="227" y="724.0"/>
-      <point x="150" y="724.0" type="curve" smooth="yes"/>
-      <point x="87" y="724"/>
-      <point x="30" y="684.0"/>
-      <point x="17.0" y="631.0" type="curve"/>
-      <point x="95.0" y="599.0" type="line"/>
-      <point x="104.0" y="626.0"/>
-      <point x="123" y="645"/>
-      <point x="148" y="645.0" type="curve" smooth="yes"/>
-      <point x="173" y="645.0"/>
-      <point x="190" y="630"/>
-      <point x="190.0" y="611" type="curve" smooth="yes"/>
-      <point x="190" y="591"/>
-      <point x="170.0" y="572.0"/>
-      <point x="150.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="543.0"/>
-      <point x="25.0" y="426.0"/>
-      <point x="25.0" y="426.0" type="curve"/>
+      <point x="216" y="726"/>
+      <point x="148" y="726" type="curve" smooth="yes"/>
+      <point x="91" y="726"/>
+      <point x="35" y="690"/>
+      <point x="21" y="630" type="curve"/>
+      <point x="89" y="601" type="line"/>
+      <point x="97.0" y="635.0"/>
+      <point x="118.0" y="651.0"/>
+      <point x="148" y="651" type="curve" smooth="yes"/>
+      <point x="178" y="651"/>
+      <point x="192" y="633"/>
+      <point x="192" y="608" type="curve" smooth="yes"/>
+      <point x="192" y="585"/>
+      <point x="177" y="567"/>
+      <point x="155" y="544" type="curve" smooth="yes"/>
+      <point x="134" y="522"/>
+      <point x="39" y="423.0"/>
+      <point x="25" y="413" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="302.0" y="177.0" type="line"/>
-      <point x="302.0" y="233.0" type="line"/>
-      <point x="302.0" y="233.0"/>
-      <point x="429.0" y="360.0"/>
-      <point x="436.0" y="368.0" type="curve" smooth="yes"/>
-      <point x="456.0" y="389.0"/>
-      <point x="480.0" y="414.0"/>
-      <point x="480.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="471.0"/>
-      <point x="457.0" y="492.0"/>
-      <point x="425.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="492.0"/>
-      <point x="369.0" y="473.0"/>
-      <point x="360.0" y="431.0" type="curve"/>
+      <point x="302.0" y="213.0" type="line"/>
+      <point x="302.0" y="213.0"/>
+      <point x="439.0" y="350.0"/>
+      <point x="446.0" y="358.0" type="curve" smooth="yes"/>
+      <point x="466.0" y="379.0"/>
+      <point x="498" y="414"/>
+      <point x="498.0" y="444.0" type="curve" smooth="yes"/>
+      <point x="498.0" y="483"/>
+      <point x="469" y="512"/>
+      <point x="425.0" y="512.0" type="curve" smooth="yes"/>
+      <point x="381.0" y="512.0"/>
+      <point x="349.0" y="481.0"/>
+      <point x="340.0" y="439.0" type="curve"/>
       <point x="300.0" y="456.0" type="line"/>
       <point x="313.0" y="516.0"/>
-      <point x="366.0" y="551.0"/>
+      <point x="366" y="551"/>
       <point x="423.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="486.0" y="551.0"/>
-      <point x="547.0" y="510.0"/>
-      <point x="547.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="396.0"/>
-      <point x="507.0" y="356.0"/>
-      <point x="484.0" y="333.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="310.0"/>
-      <point x="387.0" y="236.0"/>
-      <point x="387.0" y="236.0" type="curve"/>
-      <point x="549.0" y="236.0" type="line"/>
+      <point x="497.0" y="551.0"/>
+      <point x="541.0" y="504.0"/>
+      <point x="541.0" y="453" type="curve" smooth="yes"/>
+      <point x="541" y="397"/>
+      <point x="497.0" y="358.0"/>
+      <point x="474.0" y="335.0" type="curve" smooth="yes"/>
+      <point x="451.0" y="312.0"/>
+      <point x="358.0" y="216.0"/>
+      <point x="358.0" y="216.0" type="curve"/>
+      <point x="549.0" y="216.0" type="line"/>
       <point x="549.0" y="177.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -4,48 +4,48 @@
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425.0" y="-12" type="curve" smooth="yes"/>
+      <point x="629" y="-12"/>
+      <point x="795" y="154"/>
+      <point x="795" y="358.0" type="curve" smooth="yes"/>
+      <point x="795" y="562"/>
+      <point x="629" y="728"/>
+      <point x="425.0" y="728" type="curve" smooth="yes"/>
+      <point x="221" y="728"/>
+      <point x="55" y="562"/>
+      <point x="55" y="358.0" type="curve" smooth="yes"/>
+      <point x="55" y="154"/>
+      <point x="221" y="-12"/>
     </contour>
     <contour>
       <point x="302.0" y="177.0" type="line"/>
-      <point x="302.0" y="213.0" type="line"/>
-      <point x="302.0" y="213.0"/>
-      <point x="439.0" y="350.0"/>
-      <point x="446.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="466.0" y="379.0"/>
-      <point x="498" y="414"/>
-      <point x="498.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="498.0" y="483"/>
-      <point x="469" y="512"/>
-      <point x="425.0" y="512.0" type="curve" smooth="yes"/>
-      <point x="381.0" y="512.0"/>
-      <point x="349.0" y="481.0"/>
-      <point x="340.0" y="439.0" type="curve"/>
+      <point x="302.0" y="238.0" type="line"/>
+      <point x="313.0" y="250.0"/>
+      <point x="432" y="370"/>
+      <point x="435" y="373" type="curve" smooth="yes"/>
+      <point x="455" y="392"/>
+      <point x="474" y="415"/>
+      <point x="474" y="443" type="curve" smooth="yes"/>
+      <point x="474" y="467"/>
+      <point x="455" y="487"/>
+      <point x="425" y="487" type="curve" smooth="yes"/>
+      <point x="395" y="487"/>
+      <point x="371" y="465"/>
+      <point x="362" y="427" type="curve"/>
       <point x="300.0" y="456.0" type="line"/>
-      <point x="313.0" y="516.0"/>
+      <point x="313.0" y="512.0"/>
       <point x="366" y="551"/>
-      <point x="423.0" y="551.0" type="curve" smooth="yes"/>
-      <point x="497.0" y="551.0"/>
-      <point x="541.0" y="504.0"/>
-      <point x="541.0" y="453" type="curve" smooth="yes"/>
-      <point x="541" y="397"/>
-      <point x="497.0" y="358.0"/>
-      <point x="474.0" y="335.0" type="curve" smooth="yes"/>
-      <point x="451.0" y="312.0"/>
-      <point x="358.0" y="216.0"/>
-      <point x="358.0" y="216.0" type="curve"/>
-      <point x="549.0" y="216.0" type="line"/>
+      <point x="426" y="551.0" type="curve" smooth="yes"/>
+      <point x="491.0" y="551.0"/>
+      <point x="551.0" y="510.0"/>
+      <point x="551.0" y="444.0" type="curve" smooth="yes"/>
+      <point x="551.0" y="396.0"/>
+      <point x="510" y="353"/>
+      <point x="487.0" y="330.0" type="curve" smooth="yes"/>
+      <point x="469.0" y="312.0"/>
+      <point x="408.0" y="253.0"/>
+      <point x="396.0" y="240.0" type="curve"/>
+      <point x="549.0" y="240.0" type="line"/>
       <point x="549.0" y="177.0" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -6,4 +6,19 @@
     <component base="two.numerator" xOffset="276" yOffset="-173"/>
     <component base="SansSerifCircle"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>two.numerator</string>
+        </dict>
+      </array>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.sc.glif
@@ -28,10 +28,10 @@
       <point x="320.0" y="464.0"/>
       <point x="320.0" y="417" type="curve" smooth="yes"/>
       <point x="320" y="376"/>
-      <point x="307.0" y="355"/>
+      <point x="307" y="355"/>
       <point x="258.0" y="306" type="curve" smooth="yes"/>
-      <point x="188.0" y="235"/>
-      <point x="116.0" y="164"/>
+      <point x="213.0" y="261"/>
+      <point x="82.0" y="128"/>
       <point x="45.0" y="94" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.ss03.glif
@@ -28,9 +28,9 @@
       <point x="362" y="554"/>
       <point x="362.0" y="507.0" type="curve" smooth="yes"/>
       <point x="362.0" y="455.0"/>
-      <point x="330" y="412"/>
+      <point x="333" y="410"/>
       <point x="283.0" y="355.0" type="curve" smooth="yes"/>
-      <point x="227" y="286"/>
+      <point x="224" y="290"/>
       <point x="84.0" y="140.0"/>
       <point x="42.0" y="95.0" type="curve"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="74.0" y="118.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="369"/>
   <outline>
     <contour>
-      <point x="184.0" y="342.0" type="curve" smooth="yes"/>
-      <point x="294" y="342"/>
-      <point x="348.0" y="438.0"/>
-      <point x="348.0" y="533.0" type="curve" smooth="yes"/>
-      <point x="348.0" y="628.0"/>
-      <point x="295" y="724"/>
-      <point x="184.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="73.0" y="724.0"/>
-      <point x="21.0" y="628.0"/>
-      <point x="21.0" y="533.0" type="curve" smooth="yes"/>
-      <point x="21.0" y="438.0"/>
-      <point x="74.0" y="342"/>
+      <point x="184" y="342" type="curve"/>
+      <point x="284" y="342"/>
+      <point x="341" y="438"/>
+      <point x="341" y="533" type="curve" smooth="yes"/>
+      <point x="341" y="628"/>
+      <point x="284" y="724"/>
+      <point x="184" y="724" type="curve" smooth="yes"/>
+      <point x="84" y="724"/>
+      <point x="28" y="628"/>
+      <point x="28" y="533" type="curve" smooth="yes"/>
+      <point x="28" y="438"/>
+      <point x="84" y="342"/>
     </contour>
     <contour>
-      <point x="184.0" y="416.0" type="curve" smooth="yes"/>
-      <point x="132.0" y="416"/>
-      <point x="119.0" y="477.0"/>
-      <point x="119.0" y="533.0" type="curve" smooth="yes"/>
-      <point x="119.0" y="589.0"/>
-      <point x="132.0" y="650.0"/>
-      <point x="184.0" y="650.0" type="curve" smooth="yes"/>
-      <point x="236" y="650"/>
-      <point x="251.0" y="589.0"/>
-      <point x="251.0" y="533.0" type="curve" smooth="yes"/>
-      <point x="251.0" y="477.0"/>
-      <point x="236" y="416"/>
+      <point x="184" y="415" type="curve"/>
+      <point x="122" y="415"/>
+      <point x="108" y="477"/>
+      <point x="108" y="533" type="curve" smooth="yes"/>
+      <point x="108" y="589"/>
+      <point x="122" y="651"/>
+      <point x="184" y="651" type="curve" smooth="yes"/>
+      <point x="247" y="651"/>
+      <point x="261" y="589"/>
+      <point x="261" y="533" type="curve" smooth="yes"/>
+      <point x="261" y="477"/>
+      <point x="247" y="415"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.cap.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.cap.glif
@@ -7,10 +7,10 @@
       <point x="520" y="0" type="line"/>
       <point x="520" y="115" type="line"/>
       <point x="219" y="115" type="line"/>
-      <point x="219" y="115"/>
-      <point x="360" y="259"/>
+      <point x="231" y="127"/>
+      <point x="364" y="261"/>
       <point x="398" y="297" type="curve" smooth="yes"/>
-      <point x="458" y="360"/>
+      <point x="457" y="361"/>
       <point x="508" y="433"/>
       <point x="508" y="523" type="curve" smooth="yes"/>
       <point x="508" y="637"/>
@@ -27,10 +27,10 @@
       <point x="375" y="567"/>
       <point x="375" y="516" type="curve" smooth="yes"/>
       <point x="375" y="469"/>
-      <point x="357" y="438"/>
+      <point x="358" y="437"/>
       <point x="310" y="385" type="curve" smooth="yes"/>
-      <point x="267" y="337"/>
-      <point x="53" y="120"/>
+      <point x="265.0" y="337.0"/>
+      <point x="65.0" y="131.0"/>
       <point x="53" y="120" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.glif
@@ -9,10 +9,10 @@
       <point x="506" y="115" type="line"/>
       <point x="229" y="115" type="line"/>
       <point x="226" y="121" type="line"/>
-      <point x="380" y="275"/>
-      <point x="340" y="236"/>
+      <point x="255" y="149"/>
+      <point x="341" y="236"/>
       <point x="389" y="283" type="curve" smooth="yes"/>
-      <point x="450" y="343"/>
+      <point x="451" y="343"/>
       <point x="497" y="415"/>
       <point x="497" y="500" type="curve" smooth="yes"/>
       <point x="497" y="611"/>
@@ -31,8 +31,8 @@
       <point x="364" y="448"/>
       <point x="347" y="420"/>
       <point x="301" y="370" type="curve" smooth="yes"/>
-      <point x="255" y="320"/>
-      <point x="52" y="119"/>
+      <point x="259.0" y="325.0"/>
+      <point x="59.0" y="126.0"/>
       <point x="52" y="119" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.numerator.glif
@@ -3,12 +3,12 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="28.004" y="350" type="line"/>
+      <point x="28" y="350" type="line"/>
       <point x="289" y="350" type="line"/>
       <point x="289" y="429" type="line"/>
       <point x="150" y="429" type="line"/>
-      <point x="150" y="429"/>
-      <point x="205" y="483"/>
+      <point x="157" y="435"/>
+      <point x="207" y="484"/>
       <point x="225" y="503" type="curve" smooth="yes"/>
       <point x="248" y="526"/>
       <point x="287" y="568"/>
@@ -27,10 +27,10 @@
       <point x="197" y="628"/>
       <point x="197" y="609" type="curve" smooth="yes"/>
       <point x="197" y="583"/>
-      <point x="180" y="565"/>
+      <point x="178" y="568"/>
       <point x="156" y="542" type="curve" smooth="yes"/>
-      <point x="144" y="530"/>
-      <point x="28" y="413"/>
+      <point x="144" y="528"/>
+      <point x="33" y="418"/>
       <point x="28" y="413" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -20,8 +20,8 @@
     <contour>
       <point x="295" y="177" type="line"/>
       <point x="295" y="240" type="line"/>
-      <point x="295" y="240"/>
-      <point x="411" y="357"/>
+      <point x="297" y="242"/>
+      <point x="412" y="357"/>
       <point x="423" y="369" type="curve" smooth="yes"/>
       <point x="446" y="392"/>
       <point x="463" y="410"/>
@@ -40,10 +40,10 @@
       <point x="554" y="507"/>
       <point x="554" y="443" type="curve" smooth="yes"/>
       <point x="554" y="395"/>
-      <point x="514" y="353"/>
+      <point x="513" y="354"/>
       <point x="491" y="330" type="curve" smooth="yes"/>
-      <point x="472" y="310"/>
-      <point x="417" y="256"/>
+      <point x="473" y="312"/>
+      <point x="420" y="259"/>
       <point x="417" y="256" type="curve"/>
       <point x="556" y="256" type="line"/>
       <point x="556" y="177" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.ss03.glif
@@ -8,8 +8,8 @@
       <point x="468" y="61" type="line"/>
       <point x="129" y="61" type="line"/>
       <point x="129" y="61" type="line"/>
-      <point x="129" y="61"/>
-      <point x="299" y="235"/>
+      <point x="142.0" y="74.0"/>
+      <point x="305.0" y="241.0"/>
       <point x="346" y="282" type="curve" smooth="yes"/>
       <point x="407" y="343"/>
       <point x="460" y="414"/>
@@ -28,10 +28,10 @@
       <point x="395" y="570"/>
       <point x="395" y="505" type="curve" smooth="yes"/>
       <point x="395" y="436"/>
-      <point x="369" y="399"/>
+      <point x="371" y="397"/>
       <point x="298" y="322" type="curve" smooth="yes"/>
-      <point x="232" y="250"/>
-      <point x="46" y="65"/>
+      <point x="242.0" y="264.0"/>
+      <point x="59.0" y="77.0"/>
       <point x="46" y="65" type="curve"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/two.tf.glif
@@ -8,10 +8,10 @@
       <point x="544" y="115" type="line"/>
       <point x="232" y="115" type="line"/>
       <point x="232" y="115" type="line"/>
-      <point x="232" y="115"/>
-      <point x="380" y="253"/>
+      <point x="253" y="135.0"/>
+      <point x="390" y="262"/>
       <point x="421" y="291" type="curve" smooth="yes"/>
-      <point x="489" y="354"/>
+      <point x="489" y="355"/>
       <point x="532" y="428"/>
       <point x="532" y="523" type="curve" smooth="yes"/>
       <point x="532" y="637"/>
@@ -25,20 +25,14 @@
       <point x="224" y="609"/>
       <point x="291" y="609" type="curve" smooth="yes"/>
       <point x="356" y="609"/>
-      <point x="399" y="564"/>
+      <point x="399" y="567"/>
       <point x="399" y="515" type="curve" smooth="yes"/>
       <point x="399" y="461"/>
       <point x="378" y="419"/>
       <point x="333" y="375" type="curve" smooth="yes"/>
       <point x="281" y="325"/>
-      <point x="66" y="120"/>
-      <point x="66" y="120" type="curve"/>
+      <point x="77" y="128"/>
+      <point x="66" y="118" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="28.0" type="curve" smooth="yes"/>
-      <point x="245.0" y="28.0"/>
-      <point x="95.0" y="178.0"/>
-      <point x="95.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="95.0" y="541.0"/>
-      <point x="245.0" y="688.0"/>
-      <point x="425.0" y="688.0" type="curve" smooth="yes"/>
-      <point x="609.0" y="688.0"/>
-      <point x="755.0" y="541.0"/>
-      <point x="755.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="755.0" y="178.0"/>
-      <point x="609.0" y="28.0"/>
+      <point x="425" y="34" type="curve" smooth="yes"/>
+      <point x="249" y="34"/>
+      <point x="101" y="182"/>
+      <point x="101" y="358" type="curve" smooth="yes"/>
+      <point x="101" y="537"/>
+      <point x="249" y="682"/>
+      <point x="425" y="682" type="curve" smooth="yes"/>
+      <point x="605" y="682"/>
+      <point x="749" y="537"/>
+      <point x="749" y="358" type="curve" smooth="yes"/>
+      <point x="749" y="182"/>
+      <point x="605" y="34"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="182.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="272.0" y="330.0"/>
-      <point x="326.0" y="381.0"/>
-      <point x="326.0" y="462.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="496.0"/>
-      <point x="302.0" y="526.0"/>
-      <point x="269.0" y="538.0" type="curve"/>
-      <point x="306.0" y="551.0"/>
-      <point x="344.0" y="586.0"/>
-      <point x="344.0" y="628.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="687.0"/>
-      <point x="302.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="724.0"/>
-      <point x="101.0" y="681.0"/>
-      <point x="101.0" y="613.0" type="curve" smooth="yes"/>
-      <point x="101.0" y="586.0"/>
-      <point x="129.0" y="559.0"/>
-      <point x="155.0" y="547.0" type="curve"/>
-      <point x="108.0" y="535.0"/>
-      <point x="61.0" y="495.0"/>
-      <point x="61.0" y="438.0" type="curve" smooth="yes"/>
-      <point x="61.0" y="378.0"/>
-      <point x="110.0" y="330.0"/>
+      <point x="182" y="330" type="curve" smooth="yes"/>
+      <point x="272" y="330"/>
+      <point x="328" y="381"/>
+      <point x="328" y="450" type="curve"/>
+      <point x="328" y="492"/>
+      <point x="311" y="520"/>
+      <point x="278" y="539" type="curve"/>
+      <point x="317" y="553"/>
+      <point x="343" y="586"/>
+      <point x="343" y="628" type="curve" smooth="yes"/>
+      <point x="343" y="687"/>
+      <point x="302" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="151" y="724"/>
+      <point x="103" y="681"/>
+      <point x="103" y="613" type="curve" smooth="yes"/>
+      <point x="103" y="586"/>
+      <point x="121" y="558"/>
+      <point x="148" y="543" type="curve"/>
+      <point x="100" y="529"/>
+      <point x="61" y="495"/>
+      <point x="61" y="438" type="curve" smooth="yes"/>
+      <point x="61" y="378"/>
+      <point x="110" y="330"/>
     </contour>
     <contour>
-      <point x="188.0" y="377.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="377.0"/>
-      <point x="114.0" y="404.0"/>
-      <point x="114.0" y="444.0" type="curve" smooth="yes"/>
-      <point x="114.0" y="494.0"/>
-      <point x="148.0" y="516.0"/>
-      <point x="201.0" y="516.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="516.0"/>
-      <point x="273.0" y="498.0"/>
-      <point x="273.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="405.0"/>
-      <point x="242.0" y="377.0"/>
+      <point x="188" y="377.0" type="curve" smooth="yes"/>
+      <point x="147" y="377.0"/>
+      <point x="117" y="405.0"/>
+      <point x="117" y="438.0" type="curve" smooth="yes"/>
+      <point x="117" y="484.0"/>
+      <point x="153" y="512.0"/>
+      <point x="203" y="512.0" type="curve" smooth="yes"/>
+      <point x="246" y="512.0"/>
+      <point x="272" y="489.0"/>
+      <point x="272" y="451.0" type="curve" smooth="yes"/>
+      <point x="272" y="406.0"/>
+      <point x="239" y="377.0"/>
     </contour>
     <contour>
-      <point x="216.0" y="560.0" type="curve" smooth="yes"/>
-      <point x="176.0" y="560.0"/>
-      <point x="157.0" y="582.0"/>
-      <point x="157.0" y="614.0" type="curve" smooth="yes"/>
-      <point x="157.0" y="657.0"/>
-      <point x="181.0" y="675.0"/>
-      <point x="229.0" y="675.0" type="curve" smooth="yes"/>
-      <point x="267.0" y="675.0"/>
-      <point x="288.0" y="653.0"/>
-      <point x="288.0" y="621.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="585.0"/>
-      <point x="265.0" y="560.0"/>
+      <point x="215" y="555" type="curve" smooth="yes"/>
+      <point x="179" y="555"/>
+      <point x="156" y="580"/>
+      <point x="156" y="609" type="curve" smooth="yes"/>
+      <point x="156" y="648"/>
+      <point x="185" y="674"/>
+      <point x="230" y="674" type="curve" smooth="yes"/>
+      <point x="268" y="674"/>
+      <point x="289" y="647"/>
+      <point x="289" y="619" type="curve" smooth="yes"/>
+      <point x="289" y="581"/>
+      <point x="261" y="555"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="413" y="229" type="curve" smooth="yes"/>
-      <point x="452" y="229"/>
-      <point x="478" y="254"/>
-      <point x="478" y="291" type="curve" smooth="yes"/>
-      <point x="478" y="323"/>
-      <point x="458" y="342"/>
-      <point x="425" y="342" type="curve" smooth="yes"/>
-      <point x="387" y="342"/>
-      <point x="358" y="319"/>
-      <point x="358" y="281" type="curve" smooth="yes"/>
-      <point x="358" y="253"/>
-      <point x="381" y="229"/>
+      <point x="412" y="204.0" type="curve" smooth="yes"/>
+      <point x="464" y="204.0"/>
+      <point x="499" y="234.0"/>
+      <point x="499" y="280.0" type="curve" smooth="yes"/>
+      <point x="499" y="320.0"/>
+      <point x="472" y="348"/>
+      <point x="427" y="348.0" type="curve" smooth="yes"/>
+      <point x="372" y="348.0"/>
+      <point x="337" y="315.0"/>
+      <point x="337" y="268.0" type="curve" smooth="yes"/>
+      <point x="337" y="233.0"/>
+      <point x="369" y="204.0"/>
     </contour>
     <contour>
-      <point x="406" y="164.0" type="curve" smooth="yes"/>
-      <point x="333" y="164.0"/>
-      <point x="279" y="212.0"/>
-      <point x="279" y="272.0" type="curve" smooth="yes"/>
-      <point x="279" y="329.0"/>
-      <point x="316" y="365.0"/>
-      <point x="360" y="381.0" type="curve"/>
-      <point x="343" y="394.0"/>
-      <point x="323" y="420.0"/>
-      <point x="323" y="447.0" type="curve" smooth="yes"/>
-      <point x="323" y="515.0"/>
-      <point x="374" y="558.0"/>
-      <point x="463" y="558.0" type="curve" smooth="yes"/>
-      <point x="528" y="558.0"/>
-      <point x="571" y="521.0"/>
-      <point x="571" y="462.0" type="curve" smooth="yes"/>
-      <point x="571" y="420.0"/>
-      <point x="550" y="392.0"/>
-      <point x="515" y="372.0" type="curve"/>
-      <point x="541" y="357.0"/>
-      <point x="556" y="330.0"/>
-      <point x="556" y="296.0" type="curve" smooth="yes"/>
-      <point x="556" y="215.0"/>
-      <point x="497" y="164.0"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="288" y="212"/>
+      <point x="288" y="272" type="curve" smooth="yes"/>
+      <point x="288" y="329"/>
+      <point x="332" y="363"/>
+      <point x="374" y="377" type="curve"/>
+      <point x="353" y="389"/>
+      <point x="329" y="420"/>
+      <point x="329.0" y="453" type="curve" smooth="yes"/>
+      <point x="329" y="506"/>
+      <point x="375" y="558"/>
+      <point x="457" y="558.0" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="566" y="514"/>
+      <point x="566" y="462" type="curve" smooth="yes"/>
+      <point x="566" y="420"/>
+      <point x="535" y="385"/>
+      <point x="488" y="371" type="curve"/>
+      <point x="521" y="358"/>
+      <point x="546" y="327"/>
+      <point x="546.0" y="285" type="curve" smooth="yes"/>
+      <point x="546" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="440" y="399" type="curve" smooth="yes"/>
-      <point x="476" y="399"/>
-      <point x="498" y="420"/>
-      <point x="498" y="451" type="curve" smooth="yes"/>
-      <point x="498" y="474"/>
-      <point x="482" y="496"/>
-      <point x="452" y="496" type="curve" smooth="yes"/>
-      <point x="417" y="496"/>
-      <point x="395" y="475"/>
-      <point x="395" y="443" type="curve" smooth="yes"/>
-      <point x="395" y="419"/>
-      <point x="412" y="399"/>
+      <point x="439" y="388.0" type="curve" smooth="yes"/>
+      <point x="488" y="388.0"/>
+      <point x="518" y="415.0"/>
+      <point x="518" y="455.0" type="curve" smooth="yes"/>
+      <point x="518" y="485.0"/>
+      <point x="497" y="515.0"/>
+      <point x="456" y="515.0" type="curve" smooth="yes"/>
+      <point x="407" y="515.0"/>
+      <point x="376" y="486.0"/>
+      <point x="376" y="445.0" type="curve" smooth="yes"/>
+      <point x="376" y="414.0"/>
+      <point x="401" y="388.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="248.0"/>
-      <point x="492.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="317.0"/>
-      <point x="465.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="343.0"/>
-      <point x="359.0" y="318.0"/>
-      <point x="359.0" y="283.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="247.0"/>
-      <point x="387.0" y="222.0"/>
+      <point x="413" y="229" type="curve" smooth="yes"/>
+      <point x="452" y="229"/>
+      <point x="478" y="254"/>
+      <point x="478" y="291" type="curve" smooth="yes"/>
+      <point x="478" y="323"/>
+      <point x="458" y="342"/>
+      <point x="425" y="342" type="curve" smooth="yes"/>
+      <point x="387" y="342"/>
+      <point x="358" y="319"/>
+      <point x="358" y="281" type="curve" smooth="yes"/>
+      <point x="358" y="253"/>
+      <point x="381" y="229"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="406" y="164.0" type="curve" smooth="yes"/>
+      <point x="333" y="164.0"/>
+      <point x="279" y="212.0"/>
+      <point x="279" y="272.0" type="curve" smooth="yes"/>
+      <point x="279" y="329.0"/>
+      <point x="316" y="365.0"/>
+      <point x="360" y="381.0" type="curve"/>
+      <point x="343" y="394.0"/>
+      <point x="323" y="420.0"/>
+      <point x="323" y="447.0" type="curve" smooth="yes"/>
+      <point x="323" y="515.0"/>
+      <point x="374" y="558.0"/>
+      <point x="463" y="558.0" type="curve" smooth="yes"/>
+      <point x="528" y="558.0"/>
+      <point x="571" y="521.0"/>
+      <point x="571" y="462.0" type="curve" smooth="yes"/>
+      <point x="571" y="420.0"/>
+      <point x="550" y="392.0"/>
+      <point x="515" y="372.0" type="curve"/>
+      <point x="541" y="357.0"/>
+      <point x="556" y="330.0"/>
+      <point x="556" y="296.0" type="curve" smooth="yes"/>
+      <point x="556" y="215.0"/>
+      <point x="497" y="164.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="458.0" y="397.0"/>
-      <point x="480.0" y="417.0"/>
-      <point x="480.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="477.0"/>
-      <point x="458.0" y="498.0"/>
-      <point x="426.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="394.0" y="498.0"/>
-      <point x="371.0" y="477.0"/>
-      <point x="371.0" y="447.0" type="curve" smooth="yes"/>
-      <point x="371.0" y="417.0"/>
-      <point x="394.0" y="397.0"/>
+      <point x="440" y="399" type="curve" smooth="yes"/>
+      <point x="476" y="399"/>
+      <point x="498" y="420"/>
+      <point x="498" y="451" type="curve" smooth="yes"/>
+      <point x="498" y="474"/>
+      <point x="482" y="496"/>
+      <point x="452" y="496" type="curve" smooth="yes"/>
+      <point x="417" y="496"/>
+      <point x="395" y="475"/>
+      <point x="395" y="443" type="curve" smooth="yes"/>
+      <point x="395" y="419"/>
+      <point x="412" y="399"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="183.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="331.0"/>
-      <point x="327.0" y="388.0"/>
-      <point x="327.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="327.0" y="541.0"/>
-      <point x="289.0" y="589.0"/>
-      <point x="228.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="589.0"/>
-      <point x="163.0" y="574.0"/>
-      <point x="149.0" y="560.0" type="curve"/>
-      <point x="181.0" y="665.0" type="line"/>
-      <point x="344.0" y="665.0" type="line"/>
-      <point x="353.0" y="716.0" type="line"/>
-      <point x="147.0" y="716.0" type="line"/>
-      <point x="91.0" y="521.0" type="line"/>
-      <point x="135.0" y="499.0" type="line"/>
-      <point x="146.0" y="521.0"/>
-      <point x="173.0" y="543.0"/>
-      <point x="212.0" y="543.0" type="curve" smooth="yes"/>
-      <point x="250.0" y="543.0"/>
-      <point x="275.0" y="519.0"/>
-      <point x="275.0" y="465.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="411.0"/>
-      <point x="253.0" y="378.0"/>
-      <point x="189.0" y="378.0" type="curve" smooth="yes"/>
-      <point x="149.0" y="378.0"/>
-      <point x="116.0" y="396.0"/>
-      <point x="108.0" y="443.0" type="curve"/>
-      <point x="58.0" y="435.0" type="line"/>
-      <point x="67.0" y="370.0"/>
-      <point x="121.0" y="331.0"/>
+      <point x="183" y="331" type="curve" smooth="yes"/>
+      <point x="269" y="331"/>
+      <point x="327" y="388"/>
+      <point x="327" y="481" type="curve" smooth="yes"/>
+      <point x="327" y="541"/>
+      <point x="289" y="584"/>
+      <point x="228" y="584" type="curve" smooth="yes"/>
+      <point x="190" y="584"/>
+      <point x="159" y="570"/>
+      <point x="142" y="556" type="curve"/>
+      <point x="174" y="670" type="line"/>
+      <point x="340" y="670" type="line"/>
+      <point x="348" y="716" type="line"/>
+      <point x="142" y="716" type="line"/>
+      <point x="86" y="521" type="line"/>
+      <point x="130" y="503" type="line"/>
+      <point x="148" y="527"/>
+      <point x="175" y="543"/>
+      <point x="210" y="543" type="curve" smooth="yes"/>
+      <point x="250" y="543"/>
+      <point x="276" y="516"/>
+      <point x="276" y="472" type="curve" smooth="yes"/>
+      <point x="276" y="421"/>
+      <point x="251" y="380"/>
+      <point x="188" y="380" type="curve" smooth="yes"/>
+      <point x="142" y="380"/>
+      <point x="118" y="407"/>
+      <point x="111" y="446" type="curve"/>
+      <point x="58" y="435" type="line"/>
+      <point x="67" y="370"/>
+      <point x="121" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -20,34 +20,34 @@
     <contour>
       <point x="399" y="156" type="curve" smooth="yes"/>
       <point x="337" y="156"/>
-      <point x="283" y="195"/>
-      <point x="274" y="260" type="curve"/>
-      <point x="343" y="275" type="line"/>
-      <point x="348" y="245"/>
-      <point x="368" y="224"/>
-      <point x="405" y="224" type="curve" smooth="yes"/>
-      <point x="456" y="224"/>
-      <point x="476" y="255"/>
-      <point x="476" y="295" type="curve" smooth="yes"/>
-      <point x="476" y="328"/>
-      <point x="454" y="349"/>
-      <point x="422" y="349" type="curve" smooth="yes"/>
-      <point x="394" y="349"/>
-      <point x="373" y="337"/>
-      <point x="359" y="319" type="curve"/>
-      <point x="302" y="346" type="line"/>
-      <point x="358" y="541" type="line"/>
+      <point x="285" y="191"/>
+      <point x="275" y="255" type="curve"/>
+      <point x="318" y="264.0" type="line"/>
+      <point x="326" y="224.0"/>
+      <point x="362" y="196.0"/>
+      <point x="409" y="196.0" type="curve" smooth="yes"/>
+      <point x="475" y="196.0"/>
+      <point x="502" y="240.0"/>
+      <point x="502" y="294.0" type="curve" smooth="yes"/>
+      <point x="502" y="340.0"/>
+      <point x="472" y="372.0"/>
+      <point x="431" y="372.0" type="curve" smooth="yes"/>
+      <point x="396" y="372.0"/>
+      <point x="367" y="352.0"/>
+      <point x="349" y="327.0" type="curve"/>
+      <point x="308" y="346" type="line"/>
+      <point x="365" y="541" type="line"/>
       <point x="569" y="541" type="line"/>
-      <point x="553" y="474" type="line"/>
-      <point x="403" y="474" type="line"/>
-      <point x="379" y="392" type="line"/>
-      <point x="396" y="406"/>
-      <point x="414" y="414"/>
-      <point x="444" y="414" type="curve" smooth="yes"/>
-      <point x="510" y="414"/>
-      <point x="553" y="366"/>
-      <point x="553" y="306" type="curve" smooth="yes"/>
-      <point x="553" y="213"/>
+      <point x="560" y="497" type="line"/>
+      <point x="392" y="497" type="line"/>
+      <point x="357" y="379" type="line"/>
+      <point x="374" y="392"/>
+      <point x="407" y="410"/>
+      <point x="441" y="410" type="curve" smooth="yes"/>
+      <point x="507" y="410"/>
+      <point x="547" y="366"/>
+      <point x="547" y="306" type="curve" smooth="yes"/>
+      <point x="547" y="213"/>
       <point x="490" y="156"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="356.0" y="280.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="388.0" y="222.0"/>
-      <point x="426.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="465.0" y="222.0"/>
-      <point x="492.0" y="249.0"/>
-      <point x="492.0" y="294.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="339.0"/>
-      <point x="465.0" y="365.0"/>
-      <point x="426.0" y="365.0" type="curve" smooth="yes"/>
-      <point x="397.0" y="365.0"/>
-      <point x="375.0" y="352.0"/>
-      <point x="361.0" y="330.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
-      <point x="537.0" y="548.0" type="line"/>
-      <point x="537.0" y="492.0" type="line"/>
-      <point x="382.0" y="492.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
-      <point x="508.0" y="163.0"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="343" y="275" type="line"/>
+      <point x="348" y="245"/>
+      <point x="368" y="224"/>
+      <point x="405" y="224" type="curve" smooth="yes"/>
+      <point x="456" y="224"/>
+      <point x="476" y="255"/>
+      <point x="476" y="295" type="curve" smooth="yes"/>
+      <point x="476" y="328"/>
+      <point x="454" y="349"/>
+      <point x="422" y="349" type="curve" smooth="yes"/>
+      <point x="394" y="349"/>
+      <point x="373" y="337"/>
+      <point x="359" y="319" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="553" y="474" type="line"/>
+      <point x="403" y="474" type="line"/>
+      <point x="379" y="392" type="line"/>
+      <point x="396" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="553" y="366"/>
+      <point x="553" y="306" type="curve" smooth="yes"/>
+      <point x="553" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="59.0" y="426.0" type="line"/>
-      <point x="350.0" y="426.0" type="line"/>
-      <point x="357.0" y="468.0" type="line"/>
-      <point x="134.0" y="468.0" type="line"/>
-      <point x="271.0" y="634.0" type="line"/>
-      <point x="277.0" y="634.0" type="line"/>
-      <point x="223.0" y="338.0" type="line"/>
-      <point x="276.0" y="338.0" type="line"/>
-      <point x="342.0" y="716.0" type="line"/>
-      <point x="286.0" y="716.0" type="line"/>
-      <point x="65.0" y="460.0" type="line"/>
+      <point x="60" y="426" type="line"/>
+      <point x="351" y="426" type="line"/>
+      <point x="358" y="472" type="line"/>
+      <point x="134" y="472" type="line"/>
+      <point x="275" y="642" type="line"/>
+      <point x="279" y="641" type="line"/>
+      <point x="226" y="338" type="line"/>
+      <point x="277" y="338" type="line"/>
+      <point x="343" y="716" type="line"/>
+      <point x="286" y="716" type="line"/>
+      <point x="65" y="460" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="331.0" y="305.0" type="line"/>
-      <point x="433.0" y="305.0" type="line"/>
-      <point x="433.0" y="450.0" type="line"/>
-      <point x="429.0" y="450.0" type="line"/>
+      <point x="338" y="313" type="line"/>
+      <point x="432" y="313" type="line"/>
+      <point x="456" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="433.0" y="171.0" type="line"/>
-      <point x="433.0" y="249.0" type="line"/>
-      <point x="256.0" y="249.0" type="line"/>
-      <point x="256.0" y="293.0" type="line"/>
-      <point x="437.0" y="549.0" type="line"/>
-      <point x="498.0" y="549.0" type="line"/>
-      <point x="498.0" y="305.0" type="line"/>
-      <point x="547.0" y="305.0" type="line"/>
-      <point x="547.0" y="249.0" type="line"/>
-      <point x="498.0" y="249.0" type="line"/>
-      <point x="498.0" y="171.0" type="line"/>
+      <point x="407" y="175" type="line"/>
+      <point x="420" y="249" type="line"/>
+      <point x="246" y="249" type="line"/>
+      <point x="255" y="302" type="line"/>
+      <point x="471" y="553" type="line"/>
+      <point x="547" y="553" type="line"/>
+      <point x="505" y="313" type="line"/>
+      <point x="553" y="313" type="line"/>
+      <point x="541" y="249" type="line"/>
+      <point x="494" y="249" type="line"/>
+      <point x="481" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="338" y="313" type="line"/>
-      <point x="432" y="313" type="line"/>
-      <point x="456" y="454" type="line"/>
-      <point x="456" y="454" type="line"/>
+      <point x="325" y="303" type="line"/>
+      <point x="443" y="303" type="line"/>
+      <point x="472" y="464" type="line"/>
+      <point x="463" y="464" type="line"/>
     </contour>
     <contour>
-      <point x="407" y="175" type="line"/>
-      <point x="420" y="249" type="line"/>
-      <point x="246" y="249" type="line"/>
-      <point x="255" y="302" type="line"/>
-      <point x="471" y="553" type="line"/>
-      <point x="547" y="553" type="line"/>
-      <point x="505" y="313" type="line"/>
-      <point x="553" y="313" type="line"/>
-      <point x="541" y="249" type="line"/>
-      <point x="494" y="249" type="line"/>
-      <point x="481" y="175" type="line"/>
+      <point x="421" y="175" type="line"/>
+      <point x="436" y="263" type="line"/>
+      <point x="258" y="263" type="line"/>
+      <point x="265" y="297" type="line"/>
+      <point x="496" y="553" type="line"/>
+      <point x="532" y="553" type="line"/>
+      <point x="487" y="303" type="line"/>
+      <point x="546" y="303" type="line"/>
+      <point x="539" y="263" type="line"/>
+      <point x="481" y="263" type="line"/>
+      <point x="466" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="141.0" y="332.0" type="line"/>
-      <point x="199.0" y="351.0"/>
-      <point x="248.0" y="384.0"/>
-      <point x="281.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="330.0" y="475.0"/>
-      <point x="348.0" y="540.0"/>
-      <point x="348.0" y="586.0" type="curve" smooth="yes"/>
-      <point x="348.0" y="682.0"/>
-      <point x="299.0" y="724.0"/>
-      <point x="236.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="147.0" y="724.0"/>
-      <point x="88.0" y="662.0"/>
-      <point x="88.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="88.0" y="523.0"/>
-      <point x="130.0" y="479.0"/>
-      <point x="193.0" y="479.0" type="curve" smooth="yes"/>
-      <point x="224.0" y="479.0"/>
-      <point x="275.0" y="492.0"/>
-      <point x="298.0" y="521.0" type="curve"/>
-      <point x="276.0" y="462.0"/>
-      <point x="189.0" y="399.0"/>
-      <point x="129.0" y="375.0" type="curve"/>
+      <point x="141" y="330" type="line"/>
+      <point x="199" y="349"/>
+      <point x="246" y="382"/>
+      <point x="280" y="418" type="curve" smooth="yes"/>
+      <point x="331" y="473"/>
+      <point x="352" y="538"/>
+      <point x="352" y="584" type="curve" smooth="yes"/>
+      <point x="352" y="680"/>
+      <point x="299" y="722"/>
+      <point x="236" y="722" type="curve" smooth="yes"/>
+      <point x="147" y="722"/>
+      <point x="86" y="660"/>
+      <point x="86" y="579" type="curve" smooth="yes"/>
+      <point x="86" y="521"/>
+      <point x="125" y="475"/>
+      <point x="184" y="475" type="curve" smooth="yes"/>
+      <point x="215" y="475"/>
+      <point x="267" y="490"/>
+      <point x="291" y="519" type="curve"/>
+      <point x="268" y="447"/>
+      <point x="190" y="395"/>
+      <point x="124" y="371" type="curve"/>
     </contour>
     <contour>
-      <point x="210.0" y="520.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="520.0"/>
-      <point x="141.0" y="548.0"/>
-      <point x="141.0" y="588.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="641.0"/>
-      <point x="171.0" y="675.0"/>
-      <point x="227.0" y="675.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="675.0"/>
-      <point x="295.0" y="647.0"/>
-      <point x="295.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="295.0" y="553.0"/>
-      <point x="266.0" y="520.0"/>
+      <point x="208" y="517" type="curve" smooth="yes"/>
+      <point x="165" y="517"/>
+      <point x="138" y="549"/>
+      <point x="138" y="584" type="curve" smooth="yes"/>
+      <point x="138" y="635"/>
+      <point x="174" y="674"/>
+      <point x="229" y="674" type="curve" smooth="yes"/>
+      <point x="272" y="674"/>
+      <point x="299" y="642"/>
+      <point x="299" y="605" type="curve" smooth="yes"/>
+      <point x="299" y="555"/>
+      <point x="263" y="517"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="366" y="159" type="curve"/>
-      <point x="343" y="214" type="line"/>
-      <point x="403" y="238"/>
-      <point x="476" y="287"/>
-      <point x="496" y="336" type="curve"/>
-      <point x="476" y="314"/>
-      <point x="439" y="303"/>
-      <point x="408" y="303" type="curve" smooth="yes"/>
-      <point x="339" y="303"/>
-      <point x="302" y="352"/>
-      <point x="302" y="410" type="curve" smooth="yes"/>
-      <point x="302" y="491"/>
-      <point x="371" y="553"/>
-      <point x="460" y="553" type="curve" smooth="yes"/>
-      <point x="523" y="553"/>
-      <point x="582" y="511"/>
-      <point x="582" y="415" type="curve" smooth="yes"/>
-      <point x="582" y="369"/>
-      <point x="558" y="301"/>
-      <point x="507" y="246" type="curve" smooth="yes"/>
-      <point x="473" y="210"/>
-      <point x="424" y="178"/>
+      <point x="364.0" y="161.0" type="curve"/>
+      <point x="350.0" y="198.0" type="line"/>
+      <point x="411.0" y="223.0"/>
+      <point x="490.0" y="280.0"/>
+      <point x="517.0" y="351.0" type="curve"/>
+      <point x="487.0" y="316.0"/>
+      <point x="438.0" y="303.0"/>
+      <point x="407.0" y="303.0" type="curve" smooth="yes"/>
+      <point x="350.0" y="303.0"/>
+      <point x="309.0" y="352.0"/>
+      <point x="309.0" y="410.0" type="curve" smooth="yes"/>
+      <point x="309.0" y="491.0"/>
+      <point x="370.0" y="553.0"/>
+      <point x="459.0" y="553.0" type="curve" smooth="yes"/>
+      <point x="522.0" y="553.0"/>
+      <point x="573.0" y="511.0"/>
+      <point x="573.0" y="432.0" type="curve" smooth="yes"/>
+      <point x="573.0" y="370.0"/>
+      <point x="548.0" y="307.0"/>
+      <point x="497.0" y="252.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="216.0"/>
+      <point x="418.0" y="180.0"/>
     </contour>
     <contour>
-      <point x="435" y="364" type="curve" smooth="yes"/>
-      <point x="478" y="364"/>
-      <point x="502" y="395"/>
-      <point x="502" y="434" type="curve" smooth="yes"/>
-      <point x="502" y="463"/>
-      <point x="484" y="489"/>
-      <point x="450" y="489" type="curve" smooth="yes"/>
-      <point x="407" y="489"/>
-      <point x="382" y="457"/>
-      <point x="382" y="418" type="curve" smooth="yes"/>
-      <point x="382" y="390"/>
-      <point x="401" y="364"/>
+      <point x="430.0" y="341.0" type="curve" smooth="yes"/>
+      <point x="488.0" y="341.0"/>
+      <point x="524.0" y="387.0"/>
+      <point x="524.0" y="438.0" type="curve" smooth="yes"/>
+      <point x="524.0" y="476.0"/>
+      <point x="500.0" y="509.0"/>
+      <point x="452.0" y="509.0" type="curve" smooth="yes"/>
+      <point x="396.0" y="509.0"/>
+      <point x="356.0" y="468.0"/>
+      <point x="356.0" y="416.0" type="curve" smooth="yes"/>
+      <point x="356.0" y="381.0"/>
+      <point x="381.0" y="341.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="415.0" y="171.0" type="curve"/>
-      <point x="338.0" y="171.0" type="line"/>
-      <point x="371.0" y="218.0"/>
-      <point x="405.0" y="266.0"/>
-      <point x="438.0" y="313.0" type="curve"/>
-      <point x="432.0" y="310.0"/>
-      <point x="420.0" y="307.0"/>
-      <point x="406.0" y="307.0" type="curve" smooth="yes"/>
-      <point x="339.0" y="307.0"/>
-      <point x="289.0" y="361.0"/>
-      <point x="289.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="503.0"/>
-      <point x="349.0" y="557.0"/>
-      <point x="421.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="497.0" y="557.0"/>
-      <point x="555.0" y="504.0"/>
-      <point x="555.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="555.0" y="383.0"/>
-      <point x="538.0" y="351.0"/>
-      <point x="513.0" y="313.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="266.0"/>
-      <point x="448.0" y="218.0"/>
+      <point x="366" y="159" type="curve"/>
+      <point x="343" y="214" type="line"/>
+      <point x="403" y="238"/>
+      <point x="476" y="287"/>
+      <point x="496" y="336" type="curve"/>
+      <point x="476" y="314"/>
+      <point x="439" y="303"/>
+      <point x="408" y="303" type="curve" smooth="yes"/>
+      <point x="339" y="303"/>
+      <point x="302" y="352"/>
+      <point x="302" y="410" type="curve" smooth="yes"/>
+      <point x="302" y="491"/>
+      <point x="371" y="553"/>
+      <point x="460" y="553" type="curve" smooth="yes"/>
+      <point x="523" y="553"/>
+      <point x="582" y="511"/>
+      <point x="582" y="415" type="curve" smooth="yes"/>
+      <point x="582" y="369"/>
+      <point x="558" y="301"/>
+      <point x="507" y="246" type="curve" smooth="yes"/>
+      <point x="473" y="210"/>
+      <point x="424" y="178"/>
     </contour>
     <contour>
-      <point x="422.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="363.0"/>
-      <point x="488.0" y="393.0"/>
-      <point x="488.0" y="430.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="467.0"/>
-      <point x="463.0" y="498.0"/>
-      <point x="422.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="381.0" y="498.0"/>
-      <point x="356.0" y="467.0"/>
-      <point x="356.0" y="430.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="393.0"/>
-      <point x="381.0" y="363.0"/>
+      <point x="435" y="364" type="curve" smooth="yes"/>
+      <point x="478" y="364"/>
+      <point x="502" y="395"/>
+      <point x="502" y="434" type="curve" smooth="yes"/>
+      <point x="502" y="463"/>
+      <point x="484" y="489"/>
+      <point x="450" y="489" type="curve" smooth="yes"/>
+      <point x="407" y="489"/>
+      <point x="382" y="457"/>
+      <point x="382" y="418" type="curve" smooth="yes"/>
+      <point x="382" y="390"/>
+      <point x="401" y="364"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="135.0" y="338.0" type="line"/>
-      <point x="192.0" y="338.0" type="line"/>
-      <point x="258.0" y="716.0" type="line"/>
-      <point x="210.0" y="716.0" type="line"/>
-      <point x="100.0" y="644.0" type="line"/>
-      <point x="80.0" y="570.0" type="line"/>
-      <point x="188.0" y="637.0" type="line"/>
+      <point x="137" y="338" type="line"/>
+      <point x="190" y="338" type="line"/>
+      <point x="256" y="716" type="line"/>
+      <point x="210" y="716" type="line"/>
+      <point x="100" y="644" type="line"/>
+      <point x="92" y="588" type="line"/>
+      <point x="194" y="652" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406.0" y="171.0" type="line"/>
-      <point x="406.0" y="462.0" type="line"/>
-      <point x="317.0" y="398.0" type="line"/>
-      <point x="317.0" y="477.0" type="line"/>
-      <point x="415.0" y="549.0" type="line"/>
-      <point x="471.0" y="549.0" type="line"/>
-      <point x="471.0" y="171.0" type="line"/>
+      <point x="368" y="176" type="line"/>
+      <point x="416" y="452" type="line"/>
+      <point x="321" y="391" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="443" y="554" type="line"/>
+      <point x="509" y="554" type="line"/>
+      <point x="443" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="368" y="176" type="line"/>
-      <point x="416" y="452" type="line"/>
-      <point x="321" y="391" type="line"/>
+      <point x="383" y="176" type="line"/>
+      <point x="439" y="493" type="line"/>
+      <point x="331" y="422" type="line"/>
       <point x="338" y="482" type="line"/>
-      <point x="443" y="554" type="line"/>
-      <point x="509" y="554" type="line"/>
-      <point x="443" y="176" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="494" y="554" type="line"/>
+      <point x="428" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -4,6 +4,6 @@
   <unicode hex="2780"/>
   <outline>
     <component base="one.numerator" xOffset="243" yOffset="-169"/>
-    <component base="SansSerifCircle" yOffset="1"/>
+    <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="175.0" y="338.0" type="line"/>
-      <point x="194.0" y="466.0"/>
-      <point x="255.0" y="582.0"/>
-      <point x="353.0" y="661.0" type="curve"/>
-      <point x="362.0" y="716.0" type="line"/>
-      <point x="107.0" y="716.0" type="line"/>
-      <point x="99.0" y="667.0" type="line"/>
-      <point x="298.0" y="667.0" type="line"/>
-      <point x="224.0" y="609.0"/>
-      <point x="139.0" y="486.0"/>
-      <point x="111.0" y="333.0" type="curve"/>
+      <point x="165" y="338" type="line"/>
+      <point x="184" y="466"/>
+      <point x="258" y="591"/>
+      <point x="355" y="670" type="curve"/>
+      <point x="362" y="716" type="line"/>
+      <point x="107" y="716" type="line"/>
+      <point x="98" y="665" type="line"/>
+      <point x="294" y="665" type="line"/>
+      <point x="220" y="607"/>
+      <point x="135" y="491"/>
+      <point x="108" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="368.0" y="171.0" type="line"/>
-      <point x="368.0" y="324.0"/>
-      <point x="431.0" y="427.0"/>
-      <point x="489.0" y="490.0" type="curve"/>
-      <point x="306.0" y="490.0" type="line"/>
-      <point x="306.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="406" y="164" type="curve"/>
+      <point x="323" y="164" type="line"/>
+      <point x="350" y="317"/>
+      <point x="417" y="415"/>
+      <point x="491" y="473" type="curve"/>
+      <point x="315" y="473" type="line"/>
+      <point x="327" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="577" y="482" type="line"/>
+      <point x="479" y="403"/>
+      <point x="425" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406" y="164" type="curve"/>
-      <point x="323" y="164" type="line"/>
-      <point x="350" y="317"/>
-      <point x="417" y="415"/>
-      <point x="491" y="473" type="curve"/>
-      <point x="315" y="473" type="line"/>
-      <point x="327" y="542" type="line"/>
+      <point x="390" y="164" type="curve"/>
+      <point x="338" y="164" type="line"/>
+      <point x="365" y="317"/>
+      <point x="454" y="441"/>
+      <point x="528" y="499" type="curve"/>
+      <point x="324" y="499" type="line"/>
+      <point x="332" y="542" type="line"/>
       <point x="587" y="542" type="line"/>
-      <point x="577" y="482" type="line"/>
-      <point x="479" y="403"/>
-      <point x="425" y="292"/>
+      <point x="579" y="497" type="line"/>
+      <point x="481" y="418"/>
+      <point x="409" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="176.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="265.0" y="330.0"/>
-      <point x="324.0" y="392.0"/>
-      <point x="324.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="324.0" y="531.0"/>
-      <point x="290.0" y="575.0"/>
-      <point x="221.0" y="575.0" type="curve" smooth="yes"/>
-      <point x="190.0" y="575.0"/>
-      <point x="137.0" y="562.0"/>
-      <point x="113.0" y="533.0" type="curve"/>
-      <point x="135.0" y="592.0"/>
-      <point x="223.0" y="655.0"/>
-      <point x="283.0" y="679.0" type="curve"/>
-      <point x="271.0" y="722.0" type="line"/>
-      <point x="213.0" y="703.0"/>
-      <point x="165.0" y="671.0"/>
-      <point x="132.0" y="634.0" type="curve" smooth="yes"/>
-      <point x="82.0" y="578.0"/>
-      <point x="64.0" y="514.0"/>
-      <point x="64.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="64.0" y="372.0"/>
-      <point x="113.0" y="330.0"/>
+      <point x="176" y="330" type="curve" smooth="yes"/>
+      <point x="265" y="330"/>
+      <point x="326" y="392"/>
+      <point x="326" y="473" type="curve" smooth="yes"/>
+      <point x="326" y="531"/>
+      <point x="297" y="577"/>
+      <point x="228" y="577" type="curve" smooth="yes"/>
+      <point x="197" y="577"/>
+      <point x="145" y="562"/>
+      <point x="121" y="533" type="curve"/>
+      <point x="144" y="605"/>
+      <point x="222" y="657"/>
+      <point x="288" y="681" type="curve"/>
+      <point x="271" y="722" type="line"/>
+      <point x="213" y="703"/>
+      <point x="166" y="670"/>
+      <point x="132" y="634" type="curve" smooth="yes"/>
+      <point x="81" y="579"/>
+      <point x="62" y="514"/>
+      <point x="62" y="468" type="curve" smooth="yes"/>
+      <point x="62" y="372"/>
+      <point x="113" y="330"/>
     </contour>
     <contour>
-      <point x="185.0" y="379.0" type="curve" smooth="yes"/>
-      <point x="139.0" y="379.0"/>
-      <point x="117.0" y="407.0"/>
-      <point x="117.0" y="448.0" type="curve" smooth="yes"/>
-      <point x="117.0" y="501.0"/>
-      <point x="146.0" y="534.0"/>
-      <point x="202.0" y="534.0" type="curve" smooth="yes"/>
-      <point x="248.0" y="534.0"/>
-      <point x="271.0" y="506.0"/>
-      <point x="271.0" y="466.0" type="curve" smooth="yes"/>
-      <point x="271.0" y="413.0"/>
-      <point x="241.0" y="379.0"/>
+      <point x="183" y="378" type="curve" smooth="yes"/>
+      <point x="140" y="378"/>
+      <point x="114" y="410"/>
+      <point x="114" y="447" type="curve" smooth="yes"/>
+      <point x="114" y="497"/>
+      <point x="149" y="535"/>
+      <point x="204" y="535" type="curve" smooth="yes"/>
+      <point x="247" y="535"/>
+      <point x="274" y="503"/>
+      <point x="274" y="468" type="curve" smooth="yes"/>
+      <point x="274" y="417"/>
+      <point x="238" y="378"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421.0" y="222.0" type="curve" smooth="yes"/>
-      <point x="462.0" y="222.0"/>
-      <point x="487.0" y="253.0"/>
-      <point x="487.0" y="290.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="327.0"/>
-      <point x="462.0" y="357.0"/>
-      <point x="421.0" y="357.0" type="curve" smooth="yes"/>
-      <point x="380.0" y="357.0"/>
-      <point x="355.0" y="327.0"/>
-      <point x="355.0" y="290.0" type="curve" smooth="yes"/>
-      <point x="355.0" y="253.0"/>
-      <point x="380.0" y="222.0"/>
+      <point x="421" y="235" type="curve" smooth="yes"/>
+      <point x="464" y="235"/>
+      <point x="489" y="267"/>
+      <point x="489" y="306" type="curve" smooth="yes"/>
+      <point x="489" y="334"/>
+      <point x="470" y="360"/>
+      <point x="436" y="360" type="curve" smooth="yes"/>
+      <point x="393" y="360"/>
+      <point x="369" y="329"/>
+      <point x="369" y="290" type="curve" smooth="yes"/>
+      <point x="369" y="261"/>
+      <point x="387" y="235"/>
     </contour>
     <contour>
-      <point x="422.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="346.0" y="163.0"/>
-      <point x="288.0" y="216.0"/>
-      <point x="288.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="288.0" y="337.0"/>
-      <point x="305.0" y="369.0"/>
-      <point x="330.0" y="407.0" type="curve" smooth="yes"/>
-      <point x="363.0" y="455.0"/>
-      <point x="395.0" y="503.0"/>
-      <point x="428.0" y="549.0" type="curve"/>
-      <point x="505.0" y="549.0" type="line"/>
-      <point x="472.0" y="502.0"/>
-      <point x="438.0" y="454.0"/>
-      <point x="405.0" y="407.0" type="curve"/>
-      <point x="411.0" y="410.0"/>
-      <point x="423.0" y="413.0"/>
-      <point x="437.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="504.0" y="413.0"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="217.0"/>
-      <point x="494.0" y="163.0"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="289" y="213"/>
+      <point x="289" y="309" type="curve" smooth="yes"/>
+      <point x="289" y="355"/>
+      <point x="313" y="423"/>
+      <point x="364" y="478" type="curve" smooth="yes"/>
+      <point x="398" y="514"/>
+      <point x="447" y="546"/>
+      <point x="505" y="565" type="curve"/>
+      <point x="528" y="510" type="line"/>
+      <point x="468" y="486"/>
+      <point x="395" y="437"/>
+      <point x="375" y="388" type="curve"/>
+      <point x="395" y="410"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="532" y="421"/>
+      <point x="569" y="372"/>
+      <point x="569" y="314" type="curve" smooth="yes"/>
+      <point x="569" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,41 +18,41 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="235" type="curve" smooth="yes"/>
-      <point x="464" y="235"/>
-      <point x="489" y="267"/>
-      <point x="489" y="306" type="curve" smooth="yes"/>
-      <point x="489" y="334"/>
-      <point x="470" y="360"/>
-      <point x="436" y="360" type="curve" smooth="yes"/>
-      <point x="393" y="360"/>
-      <point x="369" y="329"/>
-      <point x="369" y="290" type="curve" smooth="yes"/>
-      <point x="369" y="261"/>
-      <point x="387" y="235"/>
+      <point x="418" y="215.0" type="curve" smooth="yes"/>
+      <point x="474" y="215"/>
+      <point x="514" y="256.0"/>
+      <point x="514" y="308.0" type="curve" smooth="yes"/>
+      <point x="514" y="343.0"/>
+      <point x="489" y="383.0"/>
+      <point x="440" y="383.0" type="curve" smooth="yes"/>
+      <point x="382" y="383"/>
+      <point x="346" y="337.0"/>
+      <point x="346" y="286.0" type="curve" smooth="yes"/>
+      <point x="346" y="248.0"/>
+      <point x="370" y="215.0"/>
     </contour>
     <contour>
       <point x="411" y="171" type="curve" smooth="yes"/>
       <point x="348" y="171"/>
-      <point x="289" y="213"/>
-      <point x="289" y="309" type="curve" smooth="yes"/>
-      <point x="289" y="355"/>
-      <point x="313" y="423"/>
-      <point x="364" y="478" type="curve" smooth="yes"/>
-      <point x="398" y="514"/>
-      <point x="447" y="546"/>
-      <point x="505" y="565" type="curve"/>
-      <point x="528" y="510" type="line"/>
-      <point x="468" y="486"/>
-      <point x="395" y="437"/>
-      <point x="375" y="388" type="curve"/>
-      <point x="395" y="410"/>
+      <point x="297" y="213"/>
+      <point x="297.0" y="292" type="curve" smooth="yes"/>
+      <point x="297" y="354"/>
+      <point x="322" y="417"/>
+      <point x="373" y="472" type="curve" smooth="yes"/>
+      <point x="407" y="508"/>
+      <point x="452" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="520" y="526" type="line"/>
+      <point x="459" y="501"/>
+      <point x="380" y="444"/>
+      <point x="353" y="373" type="curve"/>
+      <point x="383" y="408"/>
       <point x="432" y="421"/>
       <point x="463" y="421" type="curve" smooth="yes"/>
-      <point x="532" y="421"/>
-      <point x="569" y="372"/>
-      <point x="569" y="314" type="curve" smooth="yes"/>
-      <point x="569" y="233"/>
+      <point x="520" y="421"/>
+      <point x="561" y="372"/>
+      <point x="561" y="314" type="curve" smooth="yes"/>
+      <point x="561" y="233"/>
       <point x="500" y="171"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="198.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="272.0" y="330.0"/>
-      <point x="326.0" y="380.0"/>
-      <point x="326.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="493.0"/>
-      <point x="307.0" y="522.0"/>
-      <point x="283.0" y="534.0" type="curve"/>
-      <point x="317.0" y="553.0"/>
-      <point x="344.0" y="577.0"/>
-      <point x="344.0" y="627.0" type="curve" smooth="yes"/>
-      <point x="344.0" y="681.0"/>
-      <point x="305.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="724.0"/>
-      <point x="120.0" y="686.0"/>
-      <point x="103.0" y="628.0" type="curve"/>
-      <point x="156.0" y="621.0" type="line"/>
-      <point x="167.0" y="649.0"/>
-      <point x="188.0" y="676.0"/>
-      <point x="228.0" y="676.0" type="curve" smooth="yes"/>
-      <point x="270.0" y="676.0"/>
-      <point x="291.0" y="653.0"/>
-      <point x="291.0" y="617.0" type="curve" smooth="yes"/>
-      <point x="291.0" y="583.0"/>
-      <point x="269.0" y="557.0"/>
-      <point x="211.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="201.0" y="557.0"/>
-      <point x="192.0" y="557.0"/>
-      <point x="182.0" y="557.0" type="curve"/>
-      <point x="174.0" y="511.0" type="line"/>
-      <point x="180.0" y="511.0"/>
-      <point x="195.0" y="511.0"/>
-      <point x="205.0" y="511.0" type="curve" smooth="yes"/>
-      <point x="250.0" y="511.0"/>
-      <point x="273.0" y="479.0"/>
-      <point x="273.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="405.0"/>
-      <point x="248.0" y="379.0"/>
-      <point x="194.0" y="379.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="379.0"/>
-      <point x="123.0" y="402.0"/>
-      <point x="116.0" y="450.0" type="curve"/>
-      <point x="62.0" y="443.0" type="line"/>
-      <point x="70.0" y="369.0"/>
-      <point x="128.0" y="330.0"/>
+      <point x="195" y="330.0" type="curve" smooth="yes"/>
+      <point x="275" y="330"/>
+      <point x="325" y="383"/>
+      <point x="325.0" y="451" type="curve" smooth="yes"/>
+      <point x="325" y="493"/>
+      <point x="303" y="521"/>
+      <point x="270" y="534" type="curve"/>
+      <point x="316" y="550"/>
+      <point x="342" y="577"/>
+      <point x="342" y="627" type="curve" smooth="yes"/>
+      <point x="342" y="681"/>
+      <point x="305" y="724"/>
+      <point x="238" y="724" type="curve" smooth="yes"/>
+      <point x="164" y="724"/>
+      <point x="123" y="686"/>
+      <point x="106" y="628" type="curve"/>
+      <point x="156" y="619" type="line"/>
+      <point x="168" y="653"/>
+      <point x="189" y="676"/>
+      <point x="232" y="676" type="curve" smooth="yes"/>
+      <point x="267.0" y="676"/>
+      <point x="291" y="655"/>
+      <point x="291" y="621" type="curve" smooth="yes"/>
+      <point x="291" y="582"/>
+      <point x="270" y="556"/>
+      <point x="213" y="556" type="curve" smooth="yes"/>
+      <point x="203" y="556"/>
+      <point x="192" y="556"/>
+      <point x="181" y="556" type="curve"/>
+      <point x="174" y="511" type="line"/>
+      <point x="180" y="511"/>
+      <point x="196" y="511"/>
+      <point x="207" y="511" type="curve" smooth="yes"/>
+      <point x="250" y="511"/>
+      <point x="273.0" y="477"/>
+      <point x="273.0" y="448" type="curve" smooth="yes"/>
+      <point x="273.0" y="407"/>
+      <point x="248" y="378"/>
+      <point x="195" y="378" type="curve" smooth="yes"/>
+      <point x="150" y="378"/>
+      <point x="125" y="405"/>
+      <point x="117" y="453" type="curve"/>
+      <point x="65" y="443" type="line"/>
+      <point x="74" y="373"/>
+      <point x="128" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="352.0" y="284.0" type="line"/>
-      <point x="360.0" y="240.0"/>
-      <point x="387.0" y="219.0"/>
-      <point x="423.0" y="219.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="219.0"/>
-      <point x="487.0" y="241.0"/>
-      <point x="487.0" y="279.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="311.0"/>
-      <point x="461.0" y="335.0"/>
-      <point x="419.0" y="335.0" type="curve" smooth="yes"/>
-      <point x="409.0" y="335.0"/>
-      <point x="398.0" y="335.0"/>
-      <point x="388.0" y="335.0" type="curve"/>
-      <point x="388.0" y="391.0" type="line"/>
-      <point x="396.0" y="391.0"/>
-      <point x="404.0" y="391.0"/>
-      <point x="412.0" y="391.0" type="curve"/>
-      <point x="447.0" y="391.0"/>
-      <point x="474.0" y="407.0"/>
-      <point x="474.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="475.0"/>
-      <point x="454.0" y="495.0"/>
-      <point x="421.0" y="495.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="495.0"/>
-      <point x="367.0" y="472.0"/>
-      <point x="359.0" y="447.0" type="curve"/>
-      <point x="296.0" y="458.0" type="line"/>
-      <point x="306.0" y="513.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="282" y="201"/>
+      <point x="274" y="275" type="curve"/>
+      <point x="345" y="288" type="line"/>
+      <point x="352" y="250"/>
+      <point x="372" y="229"/>
+      <point x="411" y="229" type="curve" smooth="yes"/>
+      <point x="455" y="229"/>
+      <point x="475" y="247"/>
+      <point x="475" y="284" type="curve" smooth="yes"/>
+      <point x="475" y="311"/>
+      <point x="458" y="332"/>
+      <point x="421" y="332" type="curve" smooth="yes"/>
+      <point x="411" y="332"/>
+      <point x="396" y="332"/>
+      <point x="390" y="332" type="curve"/>
+      <point x="400" y="398" type="line"/>
+      <point x="410" y="398"/>
+      <point x="419" y="398"/>
+      <point x="429" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="492" y="418"/>
+      <point x="492" y="449" type="curve" smooth="yes"/>
+      <point x="492" y="476"/>
+      <point x="476" y="489"/>
+      <point x="446" y="489" type="curve" smooth="yes"/>
+      <point x="409" y="489"/>
+      <point x="394" y="475"/>
+      <point x="383" y="447" type="curve"/>
+      <point x="315" y="460" type="line"/>
+      <point x="332" y="518"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="569" y="513"/>
+      <point x="569" y="459" type="curve" smooth="yes"/>
+      <point x="569" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="552" y="325"/>
+      <point x="552" y="291" type="curve" smooth="yes"/>
+      <point x="552" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406" y="162" type="curve" smooth="yes"/>
-      <point x="345" y="162"/>
-      <point x="282" y="201"/>
-      <point x="274" y="275" type="curve"/>
-      <point x="345" y="288" type="line"/>
-      <point x="352" y="250"/>
-      <point x="372" y="229"/>
-      <point x="411" y="229" type="curve" smooth="yes"/>
-      <point x="455" y="229"/>
-      <point x="475" y="247"/>
-      <point x="475" y="284" type="curve" smooth="yes"/>
-      <point x="475" y="311"/>
-      <point x="458" y="332"/>
-      <point x="421" y="332" type="curve" smooth="yes"/>
-      <point x="411" y="332"/>
-      <point x="396" y="332"/>
-      <point x="390" y="332" type="curve"/>
-      <point x="400" y="398" type="line"/>
-      <point x="410" y="398"/>
-      <point x="419" y="398"/>
-      <point x="429" y="398" type="curve" smooth="yes"/>
-      <point x="479" y="398"/>
-      <point x="492" y="418"/>
-      <point x="492" y="449" type="curve" smooth="yes"/>
-      <point x="492" y="476"/>
-      <point x="476" y="489"/>
-      <point x="446" y="489" type="curve" smooth="yes"/>
-      <point x="409" y="489"/>
-      <point x="394" y="475"/>
-      <point x="383" y="447" type="curve"/>
-      <point x="315" y="460" type="line"/>
-      <point x="332" y="518"/>
+      <point x="419" y="162" type="curve" smooth="yes"/>
+      <point x="350" y="162"/>
+      <point x="289" y="201"/>
+      <point x="281" y="275" type="curve"/>
+      <point x="328" y="278.0" type="line"/>
+      <point x="337" y="234.0"/>
+      <point x="367" y="203"/>
+      <point x="419" y="203.0" type="curve" smooth="yes"/>
+      <point x="465" y="203.0"/>
+      <point x="497" y="233.0"/>
+      <point x="497" y="276.0" type="curve" smooth="yes"/>
+      <point x="497" y="307.0"/>
+      <point x="470" y="337.0"/>
+      <point x="426" y="337.0" type="curve" smooth="yes"/>
+      <point x="413" y="337.0"/>
+      <point x="396" y="337.0"/>
+      <point x="388" y="337.0" type="curve"/>
+      <point x="393.0" y="380" type="line"/>
+      <point x="405.0" y="380"/>
+      <point x="417.0" y="380"/>
+      <point x="429.0" y="380" type="curve" smooth="yes"/>
+      <point x="488.0" y="380"/>
+      <point x="512.0" y="408"/>
+      <point x="512.0" y="452" type="curve" smooth="yes"/>
+      <point x="512.0" y="489"/>
+      <point x="484.0" y="513"/>
+      <point x="449.0" y="513" type="curve" smooth="yes"/>
+      <point x="405.0" y="513"/>
+      <point x="378.0" y="486"/>
+      <point x="365.0" y="450" type="curve"/>
+      <point x="320" y="461" type="line"/>
+      <point x="337" y="515"/>
       <point x="381" y="556"/>
       <point x="455" y="556" type="curve" smooth="yes"/>
       <point x="522" y="556"/>
-      <point x="569" y="513"/>
-      <point x="569" y="459" type="curve" smooth="yes"/>
-      <point x="569" y="409"/>
-      <point x="538" y="385"/>
-      <point x="507" y="366" type="curve"/>
-      <point x="531" y="354"/>
-      <point x="552" y="325"/>
-      <point x="552" y="291" type="curve" smooth="yes"/>
-      <point x="552" y="212"/>
+      <point x="561" y="513"/>
+      <point x="561" y="459" type="curve" smooth="yes"/>
+      <point x="561" y="409"/>
+      <point x="521" y="374"/>
+      <point x="484" y="362" type="curve"/>
+      <point x="510" y="351"/>
+      <point x="543" y="325"/>
+      <point x="543.0" y="282" type="curve" smooth="yes"/>
+      <point x="543" y="212"/>
       <point x="492" y="162"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="49.0" y="338.0" type="line"/>
-      <point x="296.0" y="338.0" type="line"/>
-      <point x="304.0" y="387.0" type="line"/>
-      <point x="134.0" y="387.0" type="line"/>
-      <point x="184.0" y="420.0"/>
-      <point x="252.0" y="468.0"/>
-      <point x="286.0" y="506.0" type="curve" smooth="yes"/>
-      <point x="318.0" y="541.0"/>
-      <point x="334.0" y="570.0"/>
-      <point x="334.0" y="618.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="679.0"/>
-      <point x="302.0" y="724.0"/>
-      <point x="229.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="148.0" y="724.0"/>
-      <point x="103.0" y="679.0"/>
-      <point x="89.0" y="608.0" type="curve"/>
-      <point x="143.0" y="601.0" type="line"/>
-      <point x="148.0" y="639.0"/>
-      <point x="182.0" y="673.0"/>
-      <point x="218.0" y="673.0" type="curve" smooth="yes"/>
-      <point x="259.0" y="673.0"/>
-      <point x="278.0" y="653.0"/>
-      <point x="278.0" y="615.0" type="curve" smooth="yes"/>
-      <point x="278.0" y="591.0"/>
-      <point x="262.0" y="568.0"/>
-      <point x="239.0" y="539.0" type="curve" smooth="yes"/>
-      <point x="206.0" y="501.0"/>
-      <point x="148.0" y="449.0"/>
-      <point x="57.0" y="387.0" type="curve"/>
+      <point x="49" y="338" type="line"/>
+      <point x="296" y="338" type="line"/>
+      <point x="306" y="387" type="line"/>
+      <point x="115" y="387" type="line"/>
+      <point x="168" y="415"/>
+      <point x="247" y="470"/>
+      <point x="281" y="508" type="curve" smooth="yes"/>
+      <point x="313" y="543"/>
+      <point x="339" y="570"/>
+      <point x="339" y="618" type="curve" smooth="yes"/>
+      <point x="339" y="679"/>
+      <point x="302" y="724"/>
+      <point x="229" y="724" type="curve" smooth="yes"/>
+      <point x="148" y="724"/>
+      <point x="103" y="679"/>
+      <point x="89" y="608" type="curve"/>
+      <point x="139" y="599.0" type="line"/>
+      <point x="146" y="645.0"/>
+      <point x="183" y="673.0"/>
+      <point x="221" y="673.0" type="curve" smooth="yes"/>
+      <point x="258" y="673.0"/>
+      <point x="281" y="650.0"/>
+      <point x="281" y="617.0" type="curve" smooth="yes"/>
+      <point x="281" y="591.0"/>
+      <point x="267" y="562"/>
+      <point x="243" y="535" type="curve" smooth="yes"/>
+      <point x="210" y="498"/>
+      <point x="147" y="452"/>
+      <point x="56" y="390" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="281" y="177" type="line"/>
-      <point x="292" y="239" type="line"/>
-      <point x="383" y="301"/>
-      <point x="435" y="344"/>
-      <point x="468" y="381" type="curve" smooth="yes"/>
-      <point x="492" y="408"/>
-      <point x="501" y="430"/>
-      <point x="501" y="454" type="curve" smooth="yes"/>
-      <point x="501" y="481"/>
-      <point x="485" y="495"/>
-      <point x="452" y="495" type="curve" smooth="yes"/>
-      <point x="420" y="495"/>
-      <point x="395" y="476"/>
-      <point x="388" y="434" type="curve"/>
-      <point x="318" y="448" type="line"/>
-      <point x="332" y="519"/>
+      <point x="291" y="222" type="line"/>
+      <point x="380" y="290"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="519" y="432.0"/>
+      <point x="519.0" y="465" type="curve" smooth="yes"/>
+      <point x="519" y="496.0"/>
+      <point x="494" y="519.0"/>
+      <point x="453" y="519.0" type="curve" smooth="yes"/>
+      <point x="413" y="519.0"/>
+      <point x="377" y="488.0"/>
+      <point x="368" y="439.0" type="curve"/>
+      <point x="324" y="445" type="line"/>
+      <point x="338" y="516"/>
       <point x="380" y="563"/>
       <point x="461" y="563" type="curve" smooth="yes"/>
-      <point x="534" y="563"/>
-      <point x="575" y="518"/>
-      <point x="575" y="457" type="curve" smooth="yes"/>
-      <point x="575" y="409"/>
-      <point x="551" y="375"/>
-      <point x="519" y="340" type="curve" smooth="yes"/>
-      <point x="485" y="302"/>
-      <point x="445" y="277"/>
-      <point x="395" y="244" type="curve"/>
-      <point x="538" y="244" type="line"/>
+      <point x="526" y="563"/>
+      <point x="569" y="521"/>
+      <point x="569.0" y="467" type="curve" smooth="yes"/>
+      <point x="569" y="418"/>
+      <point x="535" y="385"/>
+      <point x="503" y="350" type="curve" smooth="yes"/>
+      <point x="469" y="312"/>
+      <point x="386" y="245"/>
+      <point x="355" y="218" type="curve"/>
+      <point x="536" y="218" type="line"/>
       <point x="528" y="177" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306.0" y="171.0" type="line"/>
-      <point x="306.0" y="227.0" type="line"/>
-      <point x="372.0" y="277.0"/>
-      <point x="418.0" y="314.0"/>
-      <point x="447.0" y="348.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="379.0"/>
-      <point x="485.0" y="408.0"/>
-      <point x="485.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="478.0"/>
-      <point x="459.0" y="498.0"/>
-      <point x="427.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="389.0" y="498.0"/>
-      <point x="369.0" y="470.0"/>
-      <point x="364.0" y="430.0" type="curve"/>
-      <point x="298.0" y="441.0" type="line"/>
-      <point x="304.0" y="512.0"/>
-      <point x="359.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="436.0" y="255.0"/>
-      <point x="402.0" y="230.0" type="curve"/>
-      <point x="553.0" y="230.0" type="line"/>
-      <point x="553.0" y="171.0" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="292" y="239" type="line"/>
+      <point x="383" y="301"/>
+      <point x="435" y="344"/>
+      <point x="468" y="381" type="curve" smooth="yes"/>
+      <point x="492" y="408"/>
+      <point x="501" y="430"/>
+      <point x="501" y="454" type="curve" smooth="yes"/>
+      <point x="501" y="481"/>
+      <point x="485" y="495"/>
+      <point x="452" y="495" type="curve" smooth="yes"/>
+      <point x="420" y="495"/>
+      <point x="395" y="476"/>
+      <point x="388" y="434" type="curve"/>
+      <point x="318" y="448" type="line"/>
+      <point x="332" y="519"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="534" y="563"/>
+      <point x="575" y="518"/>
+      <point x="575" y="457" type="curve" smooth="yes"/>
+      <point x="575" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="445" y="277"/>
+      <point x="395" y="244" type="curve"/>
+      <point x="538" y="244" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -3,7 +3,7 @@
   <advance width="851"/>
   <unicode hex="2781"/>
   <outline>
-    <component base="two.numerator" xOffset="236" yOffset="-173"/>
+    <component base="two.numerator" xOffset="236" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="43.0" y="68.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="379"/>
   <outline>
     <contour>
-      <point x="209.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="326.0" y="330.0"/>
-      <point x="389.0" y="438.0"/>
-      <point x="389.0" y="561.0" type="curve" smooth="yes"/>
-      <point x="389.0" y="656.0"/>
-      <point x="346.0" y="724.0"/>
-      <point x="263.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="724.0"/>
-      <point x="83.0" y="610.0"/>
-      <point x="83.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="83.0" y="398.0"/>
-      <point x="130.0" y="330.0"/>
+      <point x="209" y="329" type="curve" smooth="yes"/>
+      <point x="325" y="329"/>
+      <point x="394" y="438"/>
+      <point x="394" y="561" type="curve" smooth="yes"/>
+      <point x="394" y="656"/>
+      <point x="344" y="725"/>
+      <point x="263" y="725" type="curve" smooth="yes"/>
+      <point x="143" y="725"/>
+      <point x="78" y="610"/>
+      <point x="78" y="492" type="curve" smooth="yes"/>
+      <point x="78" y="398"/>
+      <point x="132" y="329"/>
     </contour>
     <contour>
-      <point x="217.0" y="381.0" type="curve" smooth="yes"/>
-      <point x="161.0" y="381.0"/>
-      <point x="140.0" y="421.0"/>
-      <point x="140.0" y="497.0" type="curve" smooth="yes"/>
-      <point x="140.0" y="597.0"/>
-      <point x="178.0" y="675.0"/>
-      <point x="255.0" y="675.0" type="curve" smooth="yes"/>
-      <point x="311.0" y="675.0"/>
-      <point x="333.0" y="634.0"/>
-      <point x="333.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="333.0" y="461.0"/>
-      <point x="296.0" y="381.0"/>
+      <point x="216" y="378.0" type="curve" smooth="yes"/>
+      <point x="167" y="378.0"/>
+      <point x="138" y="423.0"/>
+      <point x="138" y="493.0" type="curve" smooth="yes"/>
+      <point x="138" y="589.0"/>
+      <point x="185" y="673.0"/>
+      <point x="256" y="673.0" type="curve" smooth="yes"/>
+      <point x="304" y="673.0"/>
+      <point x="334" y="628.0"/>
+      <point x="334" y="557.0" type="curve" smooth="yes"/>
+      <point x="334" y="466.0"/>
+      <point x="289" y="378.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="222" type="curve" smooth="yes"/>
-      <point x="465" y="222"/>
-      <point x="492" y="248"/>
-      <point x="492" y="283" type="curve" smooth="yes"/>
-      <point x="492" y="317"/>
-      <point x="465" y="343"/>
-      <point x="426" y="343" type="curve" smooth="yes"/>
-      <point x="387" y="343"/>
-      <point x="359" y="318"/>
-      <point x="359" y="283" type="curve" smooth="yes"/>
-      <point x="359" y="247"/>
-      <point x="387" y="222"/>
+      <point x="412" y="223" type="curve" smooth="yes"/>
+      <point x="456" y="223"/>
+      <point x="485" y="249"/>
+      <point x="485" y="289" type="curve" smooth="yes"/>
+      <point x="485" y="323"/>
+      <point x="462" y="344"/>
+      <point x="425" y="344" type="curve" smooth="yes"/>
+      <point x="382" y="344"/>
+      <point x="350" y="319"/>
+      <point x="350" y="278" type="curve" smooth="yes"/>
+      <point x="350" y="248"/>
+      <point x="376" y="223"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="352" y="163"/>
-      <point x="292" y="208"/>
-      <point x="292" y="280" type="curve" smooth="yes"/>
-      <point x="292" y="321"/>
-      <point x="312" y="353"/>
-      <point x="346" y="373" type="curve"/>
-      <point x="323" y="388"/>
-      <point x="304" y="418"/>
-      <point x="304" y="450" type="curve" smooth="yes"/>
-      <point x="304" y="515"/>
-      <point x="358" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="494" y="557"/>
-      <point x="547" y="515"/>
-      <point x="547" y="450" type="curve" smooth="yes"/>
-      <point x="547" y="419"/>
-      <point x="527" y="388"/>
-      <point x="505" y="373" type="curve"/>
-      <point x="539" y="353"/>
-      <point x="559" y="321"/>
-      <point x="559" y="280" type="curve" smooth="yes"/>
-      <point x="559" y="206"/>
-      <point x="500" y="163"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="282" y="212"/>
+      <point x="282" y="272" type="curve" smooth="yes"/>
+      <point x="282" y="329"/>
+      <point x="318" y="365"/>
+      <point x="361" y="381" type="curve"/>
+      <point x="344" y="394"/>
+      <point x="325" y="420"/>
+      <point x="325" y="447" type="curve" smooth="yes"/>
+      <point x="325" y="515"/>
+      <point x="375" y="558"/>
+      <point x="462" y="558" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="568" y="521"/>
+      <point x="568" y="462" type="curve" smooth="yes"/>
+      <point x="568" y="420"/>
+      <point x="547" y="392"/>
+      <point x="513" y="372" type="curve"/>
+      <point x="538" y="357"/>
+      <point x="553" y="330"/>
+      <point x="553" y="296" type="curve" smooth="yes"/>
+      <point x="553" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="426" y="397" type="curve" smooth="yes"/>
-      <point x="458" y="397"/>
-      <point x="480" y="417"/>
-      <point x="480" y="447" type="curve" smooth="yes"/>
-      <point x="480" y="477"/>
-      <point x="458" y="498"/>
-      <point x="426" y="498" type="curve" smooth="yes"/>
-      <point x="394" y="498"/>
-      <point x="371" y="477"/>
-      <point x="371" y="447" type="curve" smooth="yes"/>
-      <point x="371" y="417"/>
-      <point x="394" y="397"/>
+      <point x="440" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="502" y="420"/>
+      <point x="502" y="452" type="curve" smooth="yes"/>
+      <point x="502" y="476"/>
+      <point x="485" y="499"/>
+      <point x="453" y="499" type="curve" smooth="yes"/>
+      <point x="415" y="499"/>
+      <point x="391" y="477"/>
+      <point x="391" y="444" type="curve" smooth="yes"/>
+      <point x="391" y="419"/>
+      <point x="410" y="398"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="356" y="163"/>
-      <point x="304" y="202"/>
-      <point x="292" y="267" type="curve"/>
-      <point x="356" y="280" type="line"/>
-      <point x="363" y="248"/>
-      <point x="388" y="222"/>
-      <point x="426" y="222" type="curve" smooth="yes"/>
-      <point x="465" y="222"/>
-      <point x="492" y="249"/>
-      <point x="492" y="294" type="curve" smooth="yes"/>
-      <point x="492" y="339"/>
-      <point x="465" y="365"/>
-      <point x="426" y="365" type="curve" smooth="yes"/>
-      <point x="397" y="365"/>
-      <point x="375" y="352"/>
-      <point x="361" y="330" type="curve"/>
-      <point x="305" y="353" type="line"/>
-      <point x="330" y="548" type="line"/>
-      <point x="537" y="548" type="line"/>
-      <point x="537" y="492" type="line"/>
-      <point x="382" y="492" type="line"/>
-      <point x="367" y="395" type="line"/>
-      <point x="381" y="411"/>
-      <point x="406" y="421"/>
-      <point x="436" y="421" type="curve" smooth="yes"/>
-      <point x="513" y="421"/>
-      <point x="558" y="371"/>
-      <point x="558" y="293" type="curve" smooth="yes"/>
-      <point x="558" y="218"/>
-      <point x="508" y="163"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="338" y="273" type="line"/>
+      <point x="344" y="239"/>
+      <point x="365" y="215"/>
+      <point x="405" y="215" type="curve" smooth="yes"/>
+      <point x="459" y="215"/>
+      <point x="481" y="251"/>
+      <point x="481" y="296" type="curve" smooth="yes"/>
+      <point x="481" y="334"/>
+      <point x="457" y="358"/>
+      <point x="423" y="358" type="curve" smooth="yes"/>
+      <point x="393" y="358"/>
+      <point x="370" y="344"/>
+      <point x="355" y="323" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="559" y="485" type="line"/>
+      <point x="406" y="485" type="line"/>
+      <point x="376" y="392" type="line"/>
+      <point x="393" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="548" y="366"/>
+      <point x="548" y="306" type="curve" smooth="yes"/>
+      <point x="548" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="331" y="305" type="line"/>
-      <point x="433" y="305" type="line"/>
-      <point x="433" y="450" type="line"/>
-      <point x="429" y="450" type="line"/>
+      <point x="337" y="309" type="line"/>
+      <point x="435" y="309" type="line"/>
+      <point x="460" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="433" y="171" type="line"/>
-      <point x="433" y="249" type="line"/>
-      <point x="256" y="249" type="line"/>
-      <point x="256" y="293" type="line"/>
-      <point x="437" y="549" type="line"/>
-      <point x="498" y="549" type="line"/>
-      <point x="498" y="305" type="line"/>
-      <point x="547" y="305" type="line"/>
-      <point x="547" y="249" type="line"/>
-      <point x="498" y="249" type="line"/>
-      <point x="498" y="171" type="line"/>
+      <point x="411" y="175" type="line"/>
+      <point x="425" y="253" type="line"/>
+      <point x="247" y="253" type="line"/>
+      <point x="255" y="297" type="line"/>
+      <point x="476" y="553" type="line"/>
+      <point x="542" y="553" type="line"/>
+      <point x="499" y="309" type="line"/>
+      <point x="548" y="309" type="line"/>
+      <point x="538" y="253" type="line"/>
+      <point x="490" y="253" type="line"/>
+      <point x="476" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="415" y="171" type="curve"/>
-      <point x="338" y="171" type="line"/>
-      <point x="371" y="218"/>
-      <point x="405" y="266"/>
-      <point x="438" y="313" type="curve"/>
-      <point x="432" y="310"/>
-      <point x="420" y="307"/>
-      <point x="406" y="307" type="curve" smooth="yes"/>
-      <point x="339" y="307"/>
-      <point x="289" y="361"/>
-      <point x="289" y="431" type="curve" smooth="yes"/>
-      <point x="289" y="503"/>
-      <point x="349" y="557"/>
-      <point x="421" y="557" type="curve" smooth="yes"/>
-      <point x="497" y="557"/>
-      <point x="555" y="504"/>
-      <point x="555" y="431" type="curve" smooth="yes"/>
-      <point x="555" y="383"/>
-      <point x="538" y="351"/>
-      <point x="513" y="313" type="curve"/>
-      <point x="480" y="266"/>
-      <point x="448" y="218"/>
+      <point x="364" y="161" type="curve"/>
+      <point x="344" y="210" type="line"/>
+      <point x="404" y="234"/>
+      <point x="477" y="284"/>
+      <point x="499" y="343" type="curve"/>
+      <point x="475" y="314"/>
+      <point x="440" y="303"/>
+      <point x="409" y="303" type="curve" smooth="yes"/>
+      <point x="346" y="303"/>
+      <point x="306" y="352"/>
+      <point x="306" y="410" type="curve" smooth="yes"/>
+      <point x="306" y="491"/>
+      <point x="370" y="553"/>
+      <point x="459" y="553" type="curve" smooth="yes"/>
+      <point x="522" y="553"/>
+      <point x="576" y="511"/>
+      <point x="576" y="415" type="curve" smooth="yes"/>
+      <point x="576" y="369"/>
+      <point x="555" y="304"/>
+      <point x="503" y="249" type="curve" smooth="yes"/>
+      <point x="469" y="213"/>
+      <point x="422" y="180"/>
     </contour>
     <contour>
-      <point x="422" y="363" type="curve" smooth="yes"/>
-      <point x="463" y="363"/>
-      <point x="488" y="393"/>
-      <point x="488" y="430" type="curve" smooth="yes"/>
-      <point x="488" y="467"/>
-      <point x="463" y="498"/>
-      <point x="422" y="498" type="curve" smooth="yes"/>
-      <point x="381" y="498"/>
-      <point x="356" y="467"/>
-      <point x="356" y="430" type="curve" smooth="yes"/>
-      <point x="356" y="393"/>
-      <point x="381" y="363"/>
+      <point x="433" y="359" type="curve" smooth="yes"/>
+      <point x="479" y="359"/>
+      <point x="508" y="392"/>
+      <point x="508" y="435" type="curve" smooth="yes"/>
+      <point x="508" y="466"/>
+      <point x="486" y="494"/>
+      <point x="450" y="494" type="curve" smooth="yes"/>
+      <point x="404" y="494"/>
+      <point x="374" y="460"/>
+      <point x="374" y="417" type="curve" smooth="yes"/>
+      <point x="374" y="387"/>
+      <point x="397" y="359"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="406" y="171" type="line"/>
-      <point x="406" y="462" type="line"/>
-      <point x="317" y="398" type="line"/>
-      <point x="317" y="477" type="line"/>
-      <point x="415" y="549" type="line"/>
-      <point x="471" y="549" type="line"/>
-      <point x="471" y="171" type="line"/>
+      <point x="373" y="176" type="line"/>
+      <point x="423" y="464" type="line"/>
+      <point x="323" y="400" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="504" y="554" type="line"/>
+      <point x="438" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440" y="171" type="curve"/>
-      <point x="368" y="171" type="line"/>
-      <point x="368" y="324"/>
-      <point x="431" y="427"/>
-      <point x="489" y="490" type="curve"/>
-      <point x="306" y="490" type="line"/>
-      <point x="306" y="549" type="line"/>
-      <point x="561" y="549" type="line"/>
-      <point x="561" y="494" type="line"/>
-      <point x="477" y="414"/>
-      <point x="440" y="293"/>
+      <point x="400" y="164" type="curve"/>
+      <point x="328" y="164" type="line"/>
+      <point x="355" y="317"/>
+      <point x="431" y="425"/>
+      <point x="505" y="483" type="curve"/>
+      <point x="322" y="483" type="line"/>
+      <point x="332" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="578" y="487" type="line"/>
+      <point x="480" y="408"/>
+      <point x="419" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="222" type="curve" smooth="yes"/>
-      <point x="462" y="222"/>
-      <point x="487" y="253"/>
-      <point x="487" y="290" type="curve" smooth="yes"/>
-      <point x="487" y="327"/>
-      <point x="462" y="357"/>
-      <point x="421" y="357" type="curve" smooth="yes"/>
-      <point x="380" y="357"/>
-      <point x="355" y="327"/>
-      <point x="355" y="290" type="curve" smooth="yes"/>
-      <point x="355" y="253"/>
-      <point x="380" y="222"/>
+      <point x="420" y="230" type="curve" smooth="yes"/>
+      <point x="466" y="230"/>
+      <point x="496" y="264"/>
+      <point x="496" y="307" type="curve" smooth="yes"/>
+      <point x="496" y="337"/>
+      <point x="473" y="365"/>
+      <point x="437" y="365" type="curve" smooth="yes"/>
+      <point x="391" y="365"/>
+      <point x="362" y="332"/>
+      <point x="362" y="289" type="curve" smooth="yes"/>
+      <point x="362" y="258"/>
+      <point x="384" y="230"/>
     </contour>
     <contour>
-      <point x="422" y="163" type="curve" smooth="yes"/>
-      <point x="346" y="163"/>
-      <point x="288" y="216"/>
-      <point x="288" y="289" type="curve" smooth="yes"/>
-      <point x="288" y="337"/>
-      <point x="305" y="369"/>
-      <point x="330" y="407" type="curve"/>
-      <point x="363" y="455"/>
-      <point x="395" y="503"/>
-      <point x="428" y="549" type="curve"/>
-      <point x="505" y="549" type="line"/>
-      <point x="472" y="502"/>
-      <point x="438" y="454"/>
-      <point x="405" y="407" type="curve"/>
-      <point x="411" y="410"/>
-      <point x="423" y="413"/>
-      <point x="437" y="413" type="curve" smooth="yes"/>
-      <point x="504" y="413"/>
-      <point x="554" y="359"/>
-      <point x="554" y="289" type="curve" smooth="yes"/>
-      <point x="554" y="217"/>
-      <point x="494" y="163"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="294" y="213"/>
+      <point x="294" y="309" type="curve" smooth="yes"/>
+      <point x="294" y="355"/>
+      <point x="316" y="420"/>
+      <point x="367" y="475" type="curve" smooth="yes"/>
+      <point x="401" y="511"/>
+      <point x="448" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="526" y="514" type="line"/>
+      <point x="466" y="490"/>
+      <point x="393" y="440"/>
+      <point x="371" y="381" type="curve"/>
+      <point x="395" y="410"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="532" y="421"/>
+      <point x="564" y="372"/>
+      <point x="564" y="314" type="curve" smooth="yes"/>
+      <point x="564" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423" y="160" type="curve" smooth="yes"/>
-      <point x="353" y="160"/>
-      <point x="298" y="199"/>
-      <point x="288" y="273" type="curve"/>
-      <point x="352" y="284" type="line"/>
-      <point x="360" y="240"/>
-      <point x="387" y="219"/>
-      <point x="423" y="219" type="curve" smooth="yes"/>
-      <point x="460" y="219"/>
-      <point x="487" y="241"/>
-      <point x="487" y="279" type="curve" smooth="yes"/>
-      <point x="487" y="311"/>
-      <point x="461" y="335"/>
-      <point x="419" y="335" type="curve"/>
-      <point x="409" y="335.0"/>
-      <point x="398" y="335.0"/>
-      <point x="388" y="335" type="curve"/>
-      <point x="388" y="391" type="line"/>
-      <point x="396" y="391.0"/>
-      <point x="404" y="391.0"/>
-      <point x="412" y="391" type="curve"/>
-      <point x="447" y="391"/>
-      <point x="474" y="407"/>
-      <point x="474" y="446" type="curve" smooth="yes"/>
-      <point x="474" y="475"/>
-      <point x="454" y="495"/>
-      <point x="421" y="495" type="curve" smooth="yes"/>
-      <point x="387" y="495"/>
-      <point x="367" y="472"/>
-      <point x="359" y="447" type="curve"/>
-      <point x="296" y="458" type="line"/>
-      <point x="306" y="513"/>
-      <point x="350" y="554"/>
-      <point x="421" y="554" type="curve" smooth="yes"/>
-      <point x="492" y="554"/>
-      <point x="541" y="514"/>
-      <point x="541" y="453" type="curve" smooth="yes"/>
-      <point x="541" y="416"/>
-      <point x="522" y="387"/>
-      <point x="495" y="366" type="curve"/>
-      <point x="531" y="352"/>
-      <point x="553" y="324"/>
-      <point x="553" y="276" type="curve" smooth="yes"/>
-      <point x="553" y="205"/>
-      <point x="497" y="160"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="287" y="201"/>
+      <point x="279" y="275" type="curve"/>
+      <point x="343" y="286" type="line"/>
+      <point x="350" y="248"/>
+      <point x="372" y="221"/>
+      <point x="411" y="221" type="curve" smooth="yes"/>
+      <point x="455" y="221"/>
+      <point x="480" y="247"/>
+      <point x="480" y="284" type="curve" smooth="yes"/>
+      <point x="480" y="311"/>
+      <point x="458" y="337"/>
+      <point x="421" y="337" type="curve" smooth="yes"/>
+      <point x="411" y="337"/>
+      <point x="396" y="337"/>
+      <point x="390" y="337" type="curve"/>
+      <point x="400" y="393" type="line"/>
+      <point x="410" y="393"/>
+      <point x="419" y="393"/>
+      <point x="429" y="393" type="curve" smooth="yes"/>
+      <point x="479" y="393"/>
+      <point x="497" y="415"/>
+      <point x="497" y="449" type="curve" smooth="yes"/>
+      <point x="497" y="478"/>
+      <point x="476" y="497"/>
+      <point x="446" y="497" type="curve" smooth="yes"/>
+      <point x="409" y="497"/>
+      <point x="392" y="477"/>
+      <point x="381" y="449" type="curve"/>
+      <point x="320" y="460" type="line"/>
+      <point x="337" y="518"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="564" y="513"/>
+      <point x="564" y="459" type="curve" smooth="yes"/>
+      <point x="564" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="547" y="325"/>
+      <point x="547" y="291" type="curve" smooth="yes"/>
+      <point x="547" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425" y="-16" type="curve" smooth="yes"/>
-      <point x="631" y="-16"/>
-      <point x="799" y="152"/>
-      <point x="799" y="358" type="curve" smooth="yes"/>
-      <point x="799" y="564"/>
-      <point x="631" y="732"/>
-      <point x="425" y="732" type="curve" smooth="yes"/>
-      <point x="219" y="732"/>
-      <point x="51" y="564"/>
-      <point x="51" y="358" type="curve" smooth="yes"/>
-      <point x="51" y="152"/>
-      <point x="219" y="-16"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306" y="171" type="line"/>
-      <point x="306" y="227" type="line"/>
-      <point x="372" y="277"/>
-      <point x="418" y="314"/>
-      <point x="447" y="348" type="curve" smooth="yes"/>
-      <point x="473" y="379"/>
-      <point x="485" y="408"/>
-      <point x="485" y="440" type="curve" smooth="yes"/>
-      <point x="485" y="478"/>
-      <point x="459" y="498"/>
-      <point x="427" y="498" type="curve" smooth="yes"/>
-      <point x="389" y="498"/>
-      <point x="369" y="470"/>
-      <point x="364" y="430" type="curve"/>
-      <point x="298" y="441" type="line"/>
-      <point x="304" y="512"/>
-      <point x="359" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="503" y="557"/>
-      <point x="551" y="513"/>
-      <point x="551" y="443" type="curve" smooth="yes"/>
-      <point x="551" y="392"/>
-      <point x="528" y="349"/>
-      <point x="492" y="309" type="curve" smooth="yes"/>
-      <point x="467" y="281"/>
-      <point x="436" y="255"/>
-      <point x="402" y="230" type="curve"/>
-      <point x="553" y="230" type="line"/>
-      <point x="553" y="171" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="291" y="233" type="line"/>
+      <point x="382" y="295"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="505" y="430"/>
+      <point x="505" y="454" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="485" y="504"/>
+      <point x="452" y="504" type="curve" smooth="yes"/>
+      <point x="420" y="504"/>
+      <point x="392" y="478"/>
+      <point x="385" y="436" type="curve"/>
+      <point x="321" y="447" type="line"/>
+      <point x="335" y="518"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="534" y="563"/>
+      <point x="571" y="518"/>
+      <point x="571" y="457" type="curve" smooth="yes"/>
+      <point x="571" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="439" y="269"/>
+      <point x="389" y="236" type="curve"/>
+      <point x="538" y="236" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -3,7 +3,7 @@
   <advance width="851"/>
   <unicode hex="2781"/>
   <outline>
-    <component base="two.numerator" xOffset="236" yOffset="-173"/>
+    <component base="two.numerator" xOffset="236" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="42" y="88" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="851"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="425" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="799" y="152"/>
+      <point x="799" y="358" type="curve" smooth="yes"/>
+      <point x="799" y="564"/>
+      <point x="631" y="732"/>
+      <point x="425" y="732" type="curve" smooth="yes"/>
+      <point x="219" y="732"/>
+      <point x="51" y="564"/>
+      <point x="51" y="358" type="curve" smooth="yes"/>
+      <point x="51" y="152"/>
+      <point x="219" y="-16"/>
     </contour>
     <contour>
-      <point x="425.0" y="69.0" type="curve" smooth="yes"/>
-      <point x="268.0" y="69.0"/>
-      <point x="136.0" y="201.0"/>
-      <point x="136.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="136.0" y="518.0"/>
-      <point x="268.0" y="647.0"/>
-      <point x="425.0" y="647.0" type="curve" smooth="yes"/>
-      <point x="586.0" y="647.0"/>
-      <point x="714.0" y="518.0"/>
-      <point x="714.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="714.0" y="201.0"/>
-      <point x="586.0" y="69.0"/>
+      <point x="425" y="68" type="curve" smooth="yes"/>
+      <point x="267" y="68"/>
+      <point x="135" y="200"/>
+      <point x="135" y="358" type="curve" smooth="yes"/>
+      <point x="135" y="519"/>
+      <point x="267" y="648"/>
+      <point x="425" y="648" type="curve" smooth="yes"/>
+      <point x="587" y="648"/>
+      <point x="715" y="519"/>
+      <point x="715" y="358" type="curve" smooth="yes"/>
+      <point x="715" y="200"/>
+      <point x="587" y="68"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="323"/>
   <outline>
     <contour>
-      <point x="182.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="330.0"/>
-      <point x="334.0" y="384.0"/>
-      <point x="334.0" y="457.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="496.0"/>
-      <point x="313.0" y="526.0"/>
-      <point x="289.0" y="538.0" type="curve"/>
-      <point x="329.0" y="558.0"/>
-      <point x="349.0" y="586.0"/>
-      <point x="349.0" y="628.0" type="curve" smooth="yes"/>
-      <point x="349.0" y="689.0"/>
-      <point x="310.0" y="724.0"/>
-      <point x="238.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="141.0" y="724.0"/>
-      <point x="96.0" y="681.0"/>
-      <point x="96.0" y="619.0" type="curve" smooth="yes"/>
-      <point x="96.0" y="586.0"/>
-      <point x="116.0" y="561.0"/>
-      <point x="137.0" y="547.0" type="curve"/>
-      <point x="94.0" y="531.0"/>
-      <point x="53.0" y="495.0"/>
-      <point x="53.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="378.0"/>
-      <point x="100.0" y="330.0"/>
+      <point x="182" y="330.0" type="curve" smooth="yes"/>
+      <point x="274" y="330.0"/>
+      <point x="333" y="381.0"/>
+      <point x="333" y="462.0" type="curve" smooth="yes"/>
+      <point x="333" y="496.0"/>
+      <point x="318" y="523.0"/>
+      <point x="291" y="538.0" type="curve"/>
+      <point x="327" y="558.0"/>
+      <point x="348" y="586.0"/>
+      <point x="348" y="628.0" type="curve" smooth="yes"/>
+      <point x="348" y="687.0"/>
+      <point x="304" y="724.0"/>
+      <point x="239" y="724.0" type="curve" smooth="yes"/>
+      <point x="149" y="724.0"/>
+      <point x="99" y="681.0"/>
+      <point x="99" y="613.0" type="curve" smooth="yes"/>
+      <point x="99" y="586.0"/>
+      <point x="118" y="560.0"/>
+      <point x="135" y="547.0" type="curve"/>
+      <point x="91" y="531.0"/>
+      <point x="54.0" y="495.0"/>
+      <point x="54.0" y="438.0" type="curve" smooth="yes"/>
+      <point x="54.0" y="378.0"/>
+      <point x="108" y="330.0"/>
     </contour>
     <contour>
-      <point x="188.0" y="399.0" type="curve" smooth="yes"/>
-      <point x="152.0" y="399.0"/>
-      <point x="138.0" y="421.0"/>
-      <point x="138.0" y="446.0" type="curve" smooth="yes"/>
-      <point x="138.0" y="478.0"/>
-      <point x="158.0" y="500.0"/>
-      <point x="201.0" y="500.0" type="curve" smooth="yes"/>
-      <point x="237.0" y="500.0"/>
-      <point x="252.0" y="484.0"/>
-      <point x="252.0" y="455.0" type="curve" smooth="yes"/>
-      <point x="252.0" y="424.0"/>
-      <point x="232.0" y="399.0"/>
+      <point x="189" y="393" type="curve" smooth="yes"/>
+      <point x="157" y="393"/>
+      <point x="132" y="416"/>
+      <point x="132" y="444" type="curve" smooth="yes"/>
+      <point x="132" y="483"/>
+      <point x="162" y="506"/>
+      <point x="200" y="506" type="curve" smooth="yes"/>
+      <point x="232" y="506"/>
+      <point x="254" y="487"/>
+      <point x="254" y="455" type="curve" smooth="yes"/>
+      <point x="254" y="417"/>
+      <point x="227" y="393"/>
     </contour>
     <contour>
-      <point x="215.0" y="568.0" type="curve" smooth="yes"/>
-      <point x="185.0" y="568.0"/>
-      <point x="167.0" y="583.0"/>
-      <point x="167.0" y="608.0" type="curve" smooth="yes"/>
-      <point x="167.0" y="641.0"/>
-      <point x="191.0" y="655.0"/>
-      <point x="229.0" y="655.0" type="curve" smooth="yes"/>
-      <point x="261.0" y="655.0"/>
-      <point x="278.0" y="638.0"/>
-      <point x="278.0" y="614.0" type="curve" smooth="yes"/>
-      <point x="278.0" y="582.0"/>
-      <point x="254.0" y="568.0"/>
+      <point x="217.0" y="567" type="curve" smooth="yes"/>
+      <point x="191.0" y="567"/>
+      <point x="174.0" y="586"/>
+      <point x="174.0" y="608" type="curve" smooth="yes"/>
+      <point x="174.0" y="638"/>
+      <point x="195.0" y="658"/>
+      <point x="228.0" y="658" type="curve" smooth="yes"/>
+      <point x="255.0" y="658"/>
+      <point x="270.0" y="638"/>
+      <point x="270.0" y="616" type="curve" smooth="yes"/>
+      <point x="270.0" y="587"/>
+      <point x="250.0" y="567"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="412" y="204.0" type="curve" smooth="yes"/>
-      <point x="464" y="204.0"/>
-      <point x="499" y="234.0"/>
-      <point x="499" y="280.0" type="curve" smooth="yes"/>
-      <point x="499" y="320.0"/>
-      <point x="472" y="348"/>
-      <point x="427" y="348.0" type="curve" smooth="yes"/>
-      <point x="372" y="348.0"/>
-      <point x="337" y="315.0"/>
-      <point x="337" y="268.0" type="curve" smooth="yes"/>
-      <point x="337" y="233.0"/>
-      <point x="369" y="204.0"/>
+      <point x="413" y="229" type="curve" smooth="yes"/>
+      <point x="452" y="229"/>
+      <point x="478" y="254"/>
+      <point x="478" y="291" type="curve" smooth="yes"/>
+      <point x="478" y="323"/>
+      <point x="458" y="342"/>
+      <point x="425" y="342" type="curve" smooth="yes"/>
+      <point x="387" y="342"/>
+      <point x="358" y="319"/>
+      <point x="358" y="281" type="curve" smooth="yes"/>
+      <point x="358" y="253"/>
+      <point x="381" y="229"/>
     </contour>
     <contour>
-      <point x="406" y="164" type="curve" smooth="yes"/>
-      <point x="334" y="164"/>
-      <point x="288" y="212"/>
-      <point x="288" y="272" type="curve" smooth="yes"/>
-      <point x="288" y="329"/>
-      <point x="332" y="363"/>
-      <point x="374" y="377" type="curve"/>
-      <point x="353" y="389"/>
-      <point x="329" y="420"/>
-      <point x="329.0" y="453" type="curve" smooth="yes"/>
-      <point x="329" y="506"/>
-      <point x="375" y="558"/>
-      <point x="457" y="558.0" type="curve" smooth="yes"/>
-      <point x="526" y="558"/>
-      <point x="566" y="514"/>
-      <point x="566" y="462" type="curve" smooth="yes"/>
-      <point x="566" y="420"/>
-      <point x="535" y="385"/>
-      <point x="488" y="371" type="curve"/>
-      <point x="521" y="358"/>
-      <point x="546" y="327"/>
-      <point x="546.0" y="285" type="curve" smooth="yes"/>
-      <point x="546" y="215"/>
-      <point x="496" y="164"/>
+      <point x="406" y="164.0" type="curve" smooth="yes"/>
+      <point x="333" y="164.0"/>
+      <point x="279" y="212.0"/>
+      <point x="279" y="272.0" type="curve" smooth="yes"/>
+      <point x="279" y="329.0"/>
+      <point x="316" y="365.0"/>
+      <point x="360" y="381.0" type="curve"/>
+      <point x="343" y="394.0"/>
+      <point x="323" y="420.0"/>
+      <point x="323" y="447.0" type="curve" smooth="yes"/>
+      <point x="323" y="515.0"/>
+      <point x="374" y="558.0"/>
+      <point x="463" y="558.0" type="curve" smooth="yes"/>
+      <point x="528" y="558.0"/>
+      <point x="571" y="521.0"/>
+      <point x="571" y="462.0" type="curve" smooth="yes"/>
+      <point x="571" y="420.0"/>
+      <point x="550" y="392.0"/>
+      <point x="515" y="372.0" type="curve"/>
+      <point x="541" y="357.0"/>
+      <point x="556" y="330.0"/>
+      <point x="556" y="296.0" type="curve" smooth="yes"/>
+      <point x="556" y="215.0"/>
+      <point x="497" y="164.0"/>
     </contour>
     <contour>
-      <point x="439" y="388.0" type="curve" smooth="yes"/>
-      <point x="488" y="388.0"/>
-      <point x="518" y="415.0"/>
-      <point x="518" y="455.0" type="curve" smooth="yes"/>
-      <point x="518" y="485.0"/>
-      <point x="497" y="515.0"/>
-      <point x="456" y="515.0" type="curve" smooth="yes"/>
-      <point x="407" y="515.0"/>
-      <point x="376" y="486.0"/>
-      <point x="376" y="445.0" type="curve" smooth="yes"/>
-      <point x="376" y="414.0"/>
-      <point x="401" y="388.0"/>
+      <point x="440" y="399" type="curve" smooth="yes"/>
+      <point x="476" y="399"/>
+      <point x="498" y="420"/>
+      <point x="498" y="451" type="curve" smooth="yes"/>
+      <point x="498" y="474"/>
+      <point x="482" y="496"/>
+      <point x="452" y="496" type="curve" smooth="yes"/>
+      <point x="417" y="496"/>
+      <point x="395" y="475"/>
+      <point x="395" y="443" type="curve" smooth="yes"/>
+      <point x="395" y="419"/>
+      <point x="412" y="399"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eight.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2791"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="427.0" y="231.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="231.0"/>
-      <point x="487.0" y="256.0"/>
-      <point x="487.0" y="287.0" type="curve" smooth="yes"/>
-      <point x="487.0" y="319.0"/>
-      <point x="462.0" y="343.0"/>
-      <point x="426.0" y="343.0" type="curve" smooth="yes"/>
-      <point x="390.0" y="343.0"/>
-      <point x="365.0" y="320.0"/>
-      <point x="365.0" y="288.0" type="curve" smooth="yes"/>
-      <point x="365.0" y="255.0"/>
-      <point x="391.0" y="231.0"/>
+      <point x="412" y="204.0" type="curve" smooth="yes"/>
+      <point x="464" y="204.0"/>
+      <point x="499" y="234.0"/>
+      <point x="499" y="280.0" type="curve" smooth="yes"/>
+      <point x="499" y="320.0"/>
+      <point x="472" y="348"/>
+      <point x="427" y="348.0" type="curve" smooth="yes"/>
+      <point x="372" y="348.0"/>
+      <point x="337" y="315.0"/>
+      <point x="337" y="268.0" type="curve" smooth="yes"/>
+      <point x="337" y="233.0"/>
+      <point x="369" y="204.0"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="352.0" y="163.0"/>
-      <point x="292.0" y="208.0"/>
-      <point x="292.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="321.0"/>
-      <point x="312.0" y="353.0"/>
-      <point x="346.0" y="373.0" type="curve"/>
-      <point x="323.0" y="388.0"/>
-      <point x="304.0" y="418.0"/>
-      <point x="304.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="304.0" y="515.0"/>
-      <point x="358.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="494.0" y="557.0"/>
-      <point x="547.0" y="515.0"/>
-      <point x="547.0" y="450.0" type="curve" smooth="yes"/>
-      <point x="547.0" y="419.0"/>
-      <point x="527.0" y="388.0"/>
-      <point x="505.0" y="373.0" type="curve"/>
-      <point x="539.0" y="353.0"/>
-      <point x="559.0" y="321.0"/>
-      <point x="559.0" y="280.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="206.0"/>
-      <point x="500.0" y="163.0"/>
+      <point x="406" y="164" type="curve" smooth="yes"/>
+      <point x="334" y="164"/>
+      <point x="288" y="212"/>
+      <point x="288" y="272" type="curve" smooth="yes"/>
+      <point x="288" y="329"/>
+      <point x="332" y="363"/>
+      <point x="374" y="377" type="curve"/>
+      <point x="353" y="389"/>
+      <point x="329" y="420"/>
+      <point x="329.0" y="453" type="curve" smooth="yes"/>
+      <point x="329" y="506"/>
+      <point x="375" y="558"/>
+      <point x="457" y="558.0" type="curve" smooth="yes"/>
+      <point x="526" y="558"/>
+      <point x="566" y="514"/>
+      <point x="566" y="462" type="curve" smooth="yes"/>
+      <point x="566" y="420"/>
+      <point x="535" y="385"/>
+      <point x="488" y="371" type="curve"/>
+      <point x="521" y="358"/>
+      <point x="546" y="327"/>
+      <point x="546.0" y="285" type="curve" smooth="yes"/>
+      <point x="546" y="215"/>
+      <point x="496" y="164"/>
     </contour>
     <contour>
-      <point x="426.0" y="397.0" type="curve" smooth="yes"/>
-      <point x="454.0" y="397.0"/>
-      <point x="473.0" y="415.0"/>
-      <point x="473.0" y="442.0" type="curve" smooth="yes"/>
-      <point x="473.0" y="470.0"/>
-      <point x="453.0" y="489.0"/>
-      <point x="425.0" y="489.0" type="curve" smooth="yes"/>
-      <point x="396.0" y="489.0"/>
-      <point x="376.0" y="470.0"/>
-      <point x="376.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="376.0" y="415.0"/>
-      <point x="397.0" y="397.0"/>
+      <point x="439" y="388.0" type="curve" smooth="yes"/>
+      <point x="488" y="388.0"/>
+      <point x="518" y="415.0"/>
+      <point x="518" y="455.0" type="curve" smooth="yes"/>
+      <point x="518" y="485.0"/>
+      <point x="497" y="515.0"/>
+      <point x="456" y="515.0" type="curve" smooth="yes"/>
+      <point x="407" y="515.0"/>
+      <point x="376" y="486.0"/>
+      <point x="376" y="445.0" type="curve" smooth="yes"/>
+      <point x="376" y="414.0"/>
+      <point x="401" y="388.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="183.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="285.0" y="331.0"/>
-      <point x="338.0" y="388.0"/>
-      <point x="338.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="541.0"/>
-      <point x="294.0" y="589.0"/>
-      <point x="233.0" y="589.0" type="curve" smooth="yes"/>
-      <point x="198.0" y="589.0"/>
-      <point x="176.0" y="580.0"/>
-      <point x="167.0" y="573.0" type="curve"/>
-      <point x="192.0" y="646.0" type="line"/>
-      <point x="343.0" y="646.0" type="line"/>
-      <point x="353.0" y="716.0" type="line"/>
-      <point x="132.0" y="716.0" type="line"/>
-      <point x="76.0" y="521.0" type="line"/>
-      <point x="141.0" y="488.0" type="line"/>
-      <point x="152.0" y="504.0"/>
-      <point x="177.0" y="523.0"/>
-      <point x="208.0" y="523.0" type="curve" smooth="yes"/>
-      <point x="238.0" y="523.0"/>
-      <point x="252.0" y="498.0"/>
-      <point x="252.0" y="465.0" type="curve" smooth="yes"/>
-      <point x="252.0" y="429.0"/>
-      <point x="243.0" y="402.0"/>
-      <point x="189.0" y="402.0" type="curve" smooth="yes"/>
-      <point x="149.0" y="402.0"/>
-      <point x="134.0" y="426.0"/>
-      <point x="129.0" y="454.0" type="curve"/>
-      <point x="54.0" y="441.0" type="line"/>
-      <point x="61.0" y="380.0"/>
-      <point x="109.0" y="331.0"/>
+      <point x="188" y="331.0" type="curve" smooth="yes"/>
+      <point x="277" y="331"/>
+      <point x="337" y="388"/>
+      <point x="337" y="481" type="curve" smooth="yes"/>
+      <point x="337" y="541"/>
+      <point x="299" y="593"/>
+      <point x="230" y="593" type="curve" smooth="yes"/>
+      <point x="200" y="593"/>
+      <point x="180" y="585"/>
+      <point x="167" y="574" type="curve"/>
+      <point x="191" y="647" type="line"/>
+      <point x="340" y="647" type="line"/>
+      <point x="353" y="716" type="line"/>
+      <point x="136" y="716" type="line"/>
+      <point x="79" y="521" type="line"/>
+      <point x="148" y="495" type="line"/>
+      <point x="161" y="514"/>
+      <point x="180" y="526"/>
+      <point x="206" y="526" type="curve" smooth="yes"/>
+      <point x="235" y="526"/>
+      <point x="255" y="505"/>
+      <point x="255" y="471" type="curve" smooth="yes"/>
+      <point x="255" y="431"/>
+      <point x="236" y="400"/>
+      <point x="190" y="400" type="curve" smooth="yes"/>
+      <point x="157" y="400"/>
+      <point x="139" y="420"/>
+      <point x="133" y="451" type="curve"/>
+      <point x="55" y="435" type="line"/>
+      <point x="64" y="370"/>
+      <point x="118" y="331"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -1,54 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="five.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278E"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="426.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="163.0"/>
-      <point x="304.0" y="202.0"/>
-      <point x="292.0" y="267.0" type="curve"/>
-      <point x="363.0" y="282.0" type="line"/>
-      <point x="370.0" y="253.0"/>
-      <point x="392.0" y="229.0"/>
-      <point x="427.0" y="229.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="229.0"/>
-      <point x="485.0" y="253.0"/>
-      <point x="485.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="485.0" y="334.0"/>
-      <point x="460.0" y="358.0"/>
-      <point x="425.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="398.0" y="358.0"/>
-      <point x="379.0" y="346.0"/>
-      <point x="366.0" y="326.0" type="curve"/>
-      <point x="305.0" y="353.0" type="line"/>
-      <point x="330.0" y="548.0" type="line"/>
-      <point x="537.0" y="548.0" type="line"/>
-      <point x="534.0" y="480.0" type="line"/>
-      <point x="379.0" y="480.0" type="line"/>
-      <point x="367.0" y="395.0" type="line"/>
-      <point x="381.0" y="411.0"/>
-      <point x="406.0" y="421.0"/>
-      <point x="436.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="513.0" y="421.0"/>
-      <point x="558.0" y="371.0"/>
-      <point x="558.0" y="293.0" type="curve" smooth="yes"/>
-      <point x="558.0" y="218.0"/>
-      <point x="508.0" y="163.0"/>
+      <point x="399" y="156" type="curve" smooth="yes"/>
+      <point x="337" y="156"/>
+      <point x="285" y="191"/>
+      <point x="275" y="255" type="curve"/>
+      <point x="318" y="264.0" type="line"/>
+      <point x="326" y="224.0"/>
+      <point x="362" y="196.0"/>
+      <point x="409" y="196.0" type="curve" smooth="yes"/>
+      <point x="475" y="196.0"/>
+      <point x="502" y="240.0"/>
+      <point x="502" y="294.0" type="curve" smooth="yes"/>
+      <point x="502" y="340.0"/>
+      <point x="472" y="372.0"/>
+      <point x="431" y="372.0" type="curve" smooth="yes"/>
+      <point x="396" y="372.0"/>
+      <point x="367" y="352.0"/>
+      <point x="349" y="327.0" type="curve"/>
+      <point x="308" y="346" type="line"/>
+      <point x="365" y="541" type="line"/>
+      <point x="569" y="541" type="line"/>
+      <point x="560" y="497" type="line"/>
+      <point x="392" y="497" type="line"/>
+      <point x="357" y="379" type="line"/>
+      <point x="374" y="392"/>
+      <point x="407" y="410"/>
+      <point x="441" y="410" type="curve" smooth="yes"/>
+      <point x="507" y="410"/>
+      <point x="547" y="366"/>
+      <point x="547" y="306" type="curve" smooth="yes"/>
+      <point x="547" y="213"/>
+      <point x="490" y="156"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -20,34 +20,34 @@
     <contour>
       <point x="399" y="156" type="curve" smooth="yes"/>
       <point x="337" y="156"/>
-      <point x="285" y="191"/>
-      <point x="275" y="255" type="curve"/>
-      <point x="318" y="264.0" type="line"/>
-      <point x="326" y="224.0"/>
-      <point x="362" y="196.0"/>
-      <point x="409" y="196.0" type="curve" smooth="yes"/>
-      <point x="475" y="196.0"/>
-      <point x="502" y="240.0"/>
-      <point x="502" y="294.0" type="curve" smooth="yes"/>
-      <point x="502" y="340.0"/>
-      <point x="472" y="372.0"/>
-      <point x="431" y="372.0" type="curve" smooth="yes"/>
-      <point x="396" y="372.0"/>
-      <point x="367" y="352.0"/>
-      <point x="349" y="327.0" type="curve"/>
-      <point x="308" y="346" type="line"/>
-      <point x="365" y="541" type="line"/>
+      <point x="283" y="195"/>
+      <point x="274" y="260" type="curve"/>
+      <point x="343" y="275" type="line"/>
+      <point x="348" y="245"/>
+      <point x="368" y="224"/>
+      <point x="405" y="224" type="curve" smooth="yes"/>
+      <point x="456" y="224"/>
+      <point x="476" y="255"/>
+      <point x="476" y="295" type="curve" smooth="yes"/>
+      <point x="476" y="328"/>
+      <point x="454" y="349"/>
+      <point x="422" y="349" type="curve" smooth="yes"/>
+      <point x="394" y="349"/>
+      <point x="373" y="337"/>
+      <point x="359" y="319" type="curve"/>
+      <point x="302" y="346" type="line"/>
+      <point x="358" y="541" type="line"/>
       <point x="569" y="541" type="line"/>
-      <point x="560" y="497" type="line"/>
-      <point x="392" y="497" type="line"/>
-      <point x="357" y="379" type="line"/>
-      <point x="374" y="392"/>
-      <point x="407" y="410"/>
-      <point x="441" y="410" type="curve" smooth="yes"/>
-      <point x="507" y="410"/>
-      <point x="547" y="366"/>
-      <point x="547" y="306" type="curve" smooth="yes"/>
-      <point x="547" y="213"/>
+      <point x="553" y="474" type="line"/>
+      <point x="403" y="474" type="line"/>
+      <point x="379" y="392" type="line"/>
+      <point x="396" y="406"/>
+      <point x="414" y="414"/>
+      <point x="444" y="414" type="curve" smooth="yes"/>
+      <point x="510" y="414"/>
+      <point x="553" y="366"/>
+      <point x="553" y="306" type="curve" smooth="yes"/>
+      <point x="553" y="213"/>
       <point x="490" y="156"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="352"/>
   <outline>
     <contour>
-      <point x="54.0" y="406.0" type="line"/>
-      <point x="345.0" y="406.0" type="line"/>
-      <point x="361.0" y="482.0" type="line"/>
-      <point x="165.0" y="482.0" type="line"/>
-      <point x="254.0" y="593.0" type="line"/>
-      <point x="257.0" y="593.0" type="line"/>
-      <point x="211.0" y="338.0" type="line"/>
-      <point x="297.0" y="338.0" type="line"/>
-      <point x="363.0" y="716.0" type="line"/>
-      <point x="277.0" y="716.0" type="line"/>
-      <point x="69.0" y="474.0" type="line"/>
+      <point x="56" y="408" type="line"/>
+      <point x="347" y="408" type="line"/>
+      <point x="358" y="472" type="line"/>
+      <point x="151" y="472" type="line"/>
+      <point x="257" y="602" type="line"/>
+      <point x="261" y="602" type="line"/>
+      <point x="214" y="338" type="line"/>
+      <point x="291" y="338" type="line"/>
+      <point x="357" y="716" type="line"/>
+      <point x="278" y="716" type="line"/>
+      <point x="67" y="474" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -1,40 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="four.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278D"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="338.0" y="308.0" type="line"/>
-      <point x="423.0" y="308.0" type="line"/>
-      <point x="420.0" y="430.0" type="line"/>
-      <point x="420.0" y="430.0" type="line"/>
+      <point x="325" y="303" type="line"/>
+      <point x="443" y="303" type="line"/>
+      <point x="472" y="464" type="line"/>
+      <point x="463" y="464" type="line"/>
     </contour>
     <contour>
-      <point x="423.0" y="171.0" type="line"/>
-      <point x="421.0" y="243.0" type="line"/>
-      <point x="254.0" y="243.0" type="line"/>
-      <point x="256.0" y="296.0" type="line"/>
-      <point x="433.0" y="549.0" type="line"/>
-      <point x="503.0" y="549.0" type="line"/>
-      <point x="503.0" y="308.0" type="line"/>
-      <point x="547.0" y="308.0" type="line"/>
-      <point x="545.0" y="243.0" type="line"/>
-      <point x="501.0" y="243.0" type="line"/>
-      <point x="503.0" y="171.0" type="line"/>
+      <point x="421" y="175" type="line"/>
+      <point x="436" y="263" type="line"/>
+      <point x="258" y="263" type="line"/>
+      <point x="265" y="297" type="line"/>
+      <point x="496" y="553" type="line"/>
+      <point x="532" y="553" type="line"/>
+      <point x="487" y="303" type="line"/>
+      <point x="546" y="303" type="line"/>
+      <point x="539" y="263" type="line"/>
+      <point x="481" y="263" type="line"/>
+      <point x="466" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="325" y="303" type="line"/>
-      <point x="443" y="303" type="line"/>
-      <point x="472" y="464" type="line"/>
-      <point x="463" y="464" type="line"/>
+      <point x="338" y="313" type="line"/>
+      <point x="432" y="313" type="line"/>
+      <point x="456" y="454" type="line"/>
+      <point x="456" y="454" type="line"/>
     </contour>
     <contour>
-      <point x="421" y="175" type="line"/>
-      <point x="436" y="263" type="line"/>
-      <point x="258" y="263" type="line"/>
-      <point x="265" y="297" type="line"/>
-      <point x="496" y="553" type="line"/>
-      <point x="532" y="553" type="line"/>
-      <point x="487" y="303" type="line"/>
-      <point x="546" y="303" type="line"/>
-      <point x="539" y="263" type="line"/>
-      <point x="481" y="263" type="line"/>
-      <point x="466" y="175" type="line"/>
+      <point x="407" y="175" type="line"/>
+      <point x="420" y="249" type="line"/>
+      <point x="246" y="249" type="line"/>
+      <point x="255" y="302" type="line"/>
+      <point x="471" y="553" type="line"/>
+      <point x="547" y="553" type="line"/>
+      <point x="505" y="313" type="line"/>
+      <point x="553" y="313" type="line"/>
+      <point x="541" y="249" type="line"/>
+      <point x="494" y="249" type="line"/>
+      <point x="481" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="324"/>
   <outline>
     <contour>
-      <point x="146.0" y="330.0" type="line"/>
-      <point x="204.0" y="349.0"/>
-      <point x="254.0" y="385.0"/>
-      <point x="288.0" y="421.0" type="curve" smooth="yes"/>
-      <point x="338.0" y="474.0"/>
-      <point x="356.0" y="546.0"/>
-      <point x="356.0" y="586.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="682.0"/>
-      <point x="296.0" y="724.0"/>
-      <point x="233.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="136.0" y="724.0"/>
-      <point x="78.0" y="660.0"/>
-      <point x="78.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="78.0" y="512.0"/>
-      <point x="125.0" y="473.0"/>
-      <point x="180.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="211.0" y="473.0"/>
-      <point x="242.0" y="483.0"/>
-      <point x="262.0" y="509.0" type="curve"/>
-      <point x="246.0" y="456.0"/>
-      <point x="175.0" y="412.0"/>
-      <point x="115.0" y="388.0" type="curve"/>
+      <point x="139.0" y="330.0" type="line"/>
+      <point x="197.0" y="349.0"/>
+      <point x="247.0" y="380.0"/>
+      <point x="281.0" y="416.0" type="curve" smooth="yes"/>
+      <point x="332.0" y="471.0"/>
+      <point x="355.0" y="538.0"/>
+      <point x="355.0" y="584.0" type="curve" smooth="yes"/>
+      <point x="355.0" y="680.0"/>
+      <point x="300.0" y="722.0"/>
+      <point x="236.0" y="722.0" type="curve" smooth="yes"/>
+      <point x="145.0" y="722.0"/>
+      <point x="81.0" y="660.0"/>
+      <point x="81.0" y="579.0" type="curve" smooth="yes"/>
+      <point x="81.0" y="521.0"/>
+      <point x="113.0" y="472.0"/>
+      <point x="182.0" y="472.0" type="curve" smooth="yes"/>
+      <point x="213.0" y="472.0"/>
+      <point x="244.0" y="484.0"/>
+      <point x="254.0" y="492.0" type="curve"/>
+      <point x="241.0" y="460.0"/>
+      <point x="172.0" y="416.0"/>
+      <point x="113.0" y="390.0" type="curve"/>
     </contour>
     <contour>
-      <point x="211.0" y="539.0" type="curve" smooth="yes"/>
-      <point x="177.0" y="539.0"/>
-      <point x="156.0" y="558.0"/>
-      <point x="156.0" y="588.0" type="curve" smooth="yes"/>
-      <point x="156.0" y="631.0"/>
-      <point x="178.0" y="656.0"/>
-      <point x="224.0" y="656.0" type="curve" smooth="yes"/>
-      <point x="258.0" y="656.0"/>
-      <point x="274.0" y="634.0"/>
-      <point x="274.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="274.0" y="563.0"/>
-      <point x="250.0" y="539.0"/>
+      <point x="209.0" y="535.0" type="curve" smooth="yes"/>
+      <point x="178.0" y="535.0"/>
+      <point x="159.0" y="560.0"/>
+      <point x="159.0" y="587.0" type="curve" smooth="yes"/>
+      <point x="159.0" y="626.0"/>
+      <point x="184.0" y="656.0"/>
+      <point x="223.0" y="656.0" type="curve" smooth="yes"/>
+      <point x="257.0" y="656.0"/>
+      <point x="276.0" y="631.0"/>
+      <point x="276.0" y="603.0" type="curve" smooth="yes"/>
+      <point x="276.0" y="564.0"/>
+      <point x="248.0" y="535.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="364.0" y="161.0" type="curve"/>
-      <point x="350.0" y="198.0" type="line"/>
-      <point x="411.0" y="223.0"/>
-      <point x="490.0" y="280.0"/>
-      <point x="517.0" y="351.0" type="curve"/>
-      <point x="487.0" y="316.0"/>
-      <point x="438.0" y="303.0"/>
-      <point x="407.0" y="303.0" type="curve" smooth="yes"/>
-      <point x="350.0" y="303.0"/>
-      <point x="309.0" y="352.0"/>
-      <point x="309.0" y="410.0" type="curve" smooth="yes"/>
-      <point x="309.0" y="491.0"/>
-      <point x="370.0" y="553.0"/>
-      <point x="459.0" y="553.0" type="curve" smooth="yes"/>
-      <point x="522.0" y="553.0"/>
-      <point x="573.0" y="511.0"/>
-      <point x="573.0" y="432.0" type="curve" smooth="yes"/>
-      <point x="573.0" y="370.0"/>
-      <point x="548.0" y="307.0"/>
-      <point x="497.0" y="252.0" type="curve" smooth="yes"/>
-      <point x="463.0" y="216.0"/>
-      <point x="418.0" y="180.0"/>
+      <point x="366" y="159" type="curve"/>
+      <point x="343" y="214" type="line"/>
+      <point x="403" y="238"/>
+      <point x="476" y="287"/>
+      <point x="496" y="336" type="curve"/>
+      <point x="476" y="314"/>
+      <point x="439" y="303"/>
+      <point x="408" y="303" type="curve" smooth="yes"/>
+      <point x="339" y="303"/>
+      <point x="302" y="352"/>
+      <point x="302" y="410" type="curve" smooth="yes"/>
+      <point x="302" y="491"/>
+      <point x="371" y="553"/>
+      <point x="460" y="553" type="curve" smooth="yes"/>
+      <point x="523" y="553"/>
+      <point x="582" y="511"/>
+      <point x="582" y="415" type="curve" smooth="yes"/>
+      <point x="582" y="369"/>
+      <point x="558" y="301"/>
+      <point x="507" y="246" type="curve" smooth="yes"/>
+      <point x="473" y="210"/>
+      <point x="424" y="178"/>
     </contour>
     <contour>
-      <point x="430.0" y="341.0" type="curve" smooth="yes"/>
-      <point x="488.0" y="341.0"/>
-      <point x="524.0" y="387.0"/>
-      <point x="524.0" y="438.0" type="curve" smooth="yes"/>
-      <point x="524.0" y="476.0"/>
-      <point x="500.0" y="509.0"/>
-      <point x="452.0" y="509.0" type="curve" smooth="yes"/>
-      <point x="396.0" y="509.0"/>
-      <point x="356.0" y="468.0"/>
-      <point x="356.0" y="416.0" type="curve" smooth="yes"/>
-      <point x="356.0" y="381.0"/>
-      <point x="381.0" y="341.0"/>
+      <point x="435" y="364" type="curve" smooth="yes"/>
+      <point x="478" y="364"/>
+      <point x="502" y="395"/>
+      <point x="502" y="434" type="curve" smooth="yes"/>
+      <point x="502" y="463"/>
+      <point x="484" y="489"/>
+      <point x="450" y="489" type="curve" smooth="yes"/>
+      <point x="407" y="489"/>
+      <point x="382" y="457"/>
+      <point x="382" y="418" type="curve" smooth="yes"/>
+      <point x="382" y="390"/>
+      <point x="401" y="364"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nine.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2792"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="419.0" y="168.0" type="curve"/>
-      <point x="333.0" y="176.0" type="line"/>
-      <point x="366.0" y="223.0"/>
-      <point x="400.0" y="271.0"/>
-      <point x="428.0" y="309.0" type="curve"/>
-      <point x="426.0" y="309.0"/>
-      <point x="420.0" y="307.0"/>
-      <point x="406.0" y="307.0" type="curve" smooth="yes"/>
-      <point x="339.0" y="307.0"/>
-      <point x="289.0" y="361.0"/>
-      <point x="289.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="289.0" y="503.0"/>
-      <point x="349.0" y="557.0"/>
-      <point x="421.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="497.0" y="557.0"/>
-      <point x="559.0" y="504.0"/>
-      <point x="559.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="559.0" y="383.0"/>
-      <point x="542.0" y="348.0"/>
-      <point x="517.0" y="310.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="263.0"/>
-      <point x="452.0" y="215.0"/>
+      <point x="364.0" y="161.0" type="curve"/>
+      <point x="350.0" y="198.0" type="line"/>
+      <point x="411.0" y="223.0"/>
+      <point x="490.0" y="280.0"/>
+      <point x="517.0" y="351.0" type="curve"/>
+      <point x="487.0" y="316.0"/>
+      <point x="438.0" y="303.0"/>
+      <point x="407.0" y="303.0" type="curve" smooth="yes"/>
+      <point x="350.0" y="303.0"/>
+      <point x="309.0" y="352.0"/>
+      <point x="309.0" y="410.0" type="curve" smooth="yes"/>
+      <point x="309.0" y="491.0"/>
+      <point x="370.0" y="553.0"/>
+      <point x="459.0" y="553.0" type="curve" smooth="yes"/>
+      <point x="522.0" y="553.0"/>
+      <point x="573.0" y="511.0"/>
+      <point x="573.0" y="432.0" type="curve" smooth="yes"/>
+      <point x="573.0" y="370.0"/>
+      <point x="548.0" y="307.0"/>
+      <point x="497.0" y="252.0" type="curve" smooth="yes"/>
+      <point x="463.0" y="216.0"/>
+      <point x="418.0" y="180.0"/>
     </contour>
     <contour>
-      <point x="423.0" y="369.0" type="curve" smooth="yes"/>
-      <point x="461.0" y="369.0"/>
-      <point x="484.0" y="396.0"/>
-      <point x="484.0" y="429.0" type="curve" smooth="yes"/>
-      <point x="484.0" y="463.0"/>
-      <point x="461.0" y="492.0"/>
-      <point x="422.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="383.0" y="492.0"/>
-      <point x="360.0" y="464.0"/>
-      <point x="360.0" y="431.0" type="curve" smooth="yes"/>
-      <point x="360.0" y="396.0"/>
-      <point x="383.0" y="369.0"/>
+      <point x="430.0" y="341.0" type="curve" smooth="yes"/>
+      <point x="488.0" y="341.0"/>
+      <point x="524.0" y="387.0"/>
+      <point x="524.0" y="438.0" type="curve" smooth="yes"/>
+      <point x="524.0" y="476.0"/>
+      <point x="500.0" y="509.0"/>
+      <point x="452.0" y="509.0" type="curve" smooth="yes"/>
+      <point x="396.0" y="509.0"/>
+      <point x="356.0" y="468.0"/>
+      <point x="356.0" y="416.0" type="curve" smooth="yes"/>
+      <point x="356.0" y="381.0"/>
+      <point x="381.0" y="341.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="250"/>
   <outline>
     <contour>
-      <point x="120.0" y="338.0" type="line"/>
-      <point x="210.0" y="338.0" type="line"/>
-      <point x="276.0" y="716.0" type="line"/>
-      <point x="183.0" y="716.0" type="line"/>
-      <point x="71.0" y="645.0" type="line"/>
-      <point x="67.0" y="539.0" type="line"/>
-      <point x="167.0" y="603.0" type="line"/>
+      <point x="120" y="338" type="line"/>
+      <point x="205" y="338" type="line"/>
+      <point x="271" y="716" type="line"/>
+      <point x="203" y="716" type="line"/>
+      <point x="99" y="653" type="line"/>
+      <point x="81" y="550" type="line"/>
+      <point x="167" y="607" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="one.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278A"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="396.0" y="171.0" type="line"/>
-      <point x="393.0" y="439.0" type="line"/>
-      <point x="304.0" y="375.0" type="line"/>
-      <point x="296.0" y="468.0" type="line"/>
-      <point x="405.0" y="549.0" type="line"/>
-      <point x="481.0" y="549.0" type="line"/>
-      <point x="481.0" y="171.0" type="line"/>
+      <point x="383" y="176" type="line"/>
+      <point x="439" y="493" type="line"/>
+      <point x="331" y="422" type="line"/>
+      <point x="338" y="482" type="line"/>
+      <point x="448" y="554" type="line"/>
+      <point x="494" y="554" type="line"/>
+      <point x="428" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="383" y="176" type="line"/>
-      <point x="439" y="493" type="line"/>
-      <point x="331" y="422" type="line"/>
+      <point x="368" y="176" type="line"/>
+      <point x="416" y="452" type="line"/>
+      <point x="321" y="391" type="line"/>
       <point x="338" y="482" type="line"/>
-      <point x="448" y="554" type="line"/>
-      <point x="494" y="554" type="line"/>
-      <point x="428" y="176" type="line"/>
+      <point x="443" y="554" type="line"/>
+      <point x="509" y="554" type="line"/>
+      <point x="443" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/one.sansS_erifC_ircled.glif
@@ -4,6 +4,6 @@
   <unicode hex="2780"/>
   <outline>
     <component base="one.numerator" xOffset="243" yOffset="-169"/>
-    <component base="SansSerifCircle" yOffset="1"/>
+    <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="311"/>
   <outline>
     <contour>
-      <point x="192.0" y="336.0" type="line"/>
-      <point x="204.0" y="460.0"/>
-      <point x="251.0" y="565.0"/>
-      <point x="349.0" y="644.0" type="curve"/>
-      <point x="362.0" y="716.0" type="line"/>
-      <point x="107.0" y="716.0" type="line"/>
-      <point x="97.0" y="637.0" type="line"/>
-      <point x="256.0" y="637.0" type="line"/>
-      <point x="182.0" y="579.0"/>
-      <point x="131.0" y="502.0"/>
-      <point x="104.0" y="349.0" type="curve"/>
+      <point x="188" y="338" type="line"/>
+      <point x="204" y="457"/>
+      <point x="253" y="574"/>
+      <point x="351" y="653" type="curve"/>
+      <point x="362" y="716" type="line"/>
+      <point x="107" y="716" type="line"/>
+      <point x="94" y="642" type="line"/>
+      <point x="253" y="642" type="line"/>
+      <point x="194" y="591"/>
+      <point x="124" y="491"/>
+      <point x="97" y="338" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="390" y="164" type="curve"/>
-      <point x="338" y="164" type="line"/>
-      <point x="365" y="317"/>
-      <point x="454" y="441"/>
-      <point x="528" y="499" type="curve"/>
-      <point x="324" y="499" type="line"/>
-      <point x="332" y="542" type="line"/>
+      <point x="406" y="164" type="curve"/>
+      <point x="323" y="164" type="line"/>
+      <point x="350" y="317"/>
+      <point x="417" y="415"/>
+      <point x="491" y="473" type="curve"/>
+      <point x="315" y="473" type="line"/>
+      <point x="327" y="542" type="line"/>
       <point x="587" y="542" type="line"/>
-      <point x="579" y="497" type="line"/>
-      <point x="481" y="418"/>
-      <point x="409" y="292"/>
+      <point x="577" y="482" type="line"/>
+      <point x="479" y="403"/>
+      <point x="425" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="seven.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="2790"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="440.0" y="171.0" type="curve"/>
-      <point x="358.0" y="178.0" type="line"/>
-      <point x="358.0" y="331.0"/>
-      <point x="411.0" y="417.0"/>
-      <point x="469.0" y="480.0" type="curve"/>
-      <point x="296.0" y="480.0" type="line"/>
-      <point x="299.0" y="549.0" type="line"/>
-      <point x="561.0" y="549.0" type="line"/>
-      <point x="561.0" y="494.0" type="line"/>
-      <point x="477.0" y="414.0"/>
-      <point x="440.0" y="293.0"/>
+      <point x="390" y="164" type="curve"/>
+      <point x="338" y="164" type="line"/>
+      <point x="365" y="317"/>
+      <point x="454" y="441"/>
+      <point x="528" y="499" type="curve"/>
+      <point x="324" y="499" type="line"/>
+      <point x="332" y="542" type="line"/>
+      <point x="587" y="542" type="line"/>
+      <point x="579" y="497" type="line"/>
+      <point x="481" y="418"/>
+      <point x="409" y="292"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="320"/>
   <outline>
     <contour>
-      <point x="176.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="273.0" y="330.0"/>
-      <point x="331.0" y="394.0"/>
-      <point x="331.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="331.0" y="542.0"/>
-      <point x="292.0" y="581.0"/>
-      <point x="231.0" y="581.0" type="curve" smooth="yes"/>
-      <point x="200.0" y="581.0"/>
-      <point x="167.0" y="571.0"/>
-      <point x="146.0" y="545.0" type="curve"/>
-      <point x="162.0" y="598.0"/>
-      <point x="234.0" y="642.0"/>
-      <point x="294.0" y="666.0" type="curve"/>
-      <point x="263.0" y="724.0" type="line"/>
-      <point x="205.0" y="705.0"/>
-      <point x="156.0" y="670.0"/>
-      <point x="122.0" y="634.0" type="curve" smooth="yes"/>
-      <point x="71.0" y="579.0"/>
-      <point x="53.0" y="508.0"/>
-      <point x="53.0" y="468.0" type="curve" smooth="yes"/>
-      <point x="53.0" y="372.0"/>
-      <point x="113.0" y="330.0"/>
+      <point x="174" y="330.0" type="curve" smooth="yes"/>
+      <point x="265" y="330.0"/>
+      <point x="329" y="392"/>
+      <point x="329" y="473" type="curve" smooth="yes"/>
+      <point x="329" y="531"/>
+      <point x="297" y="580"/>
+      <point x="228" y="580" type="curve" smooth="yes"/>
+      <point x="197" y="580"/>
+      <point x="166" y="568"/>
+      <point x="156" y="560" type="curve"/>
+      <point x="169" y="592"/>
+      <point x="238" y="636"/>
+      <point x="297" y="662" type="curve"/>
+      <point x="271" y="722" type="line"/>
+      <point x="213" y="703"/>
+      <point x="163" y="672"/>
+      <point x="129" y="636" type="curve" smooth="yes"/>
+      <point x="78" y="581"/>
+      <point x="55" y="514.0"/>
+      <point x="55" y="468.0" type="curve" smooth="yes"/>
+      <point x="55" y="372.0"/>
+      <point x="110" y="330.0"/>
     </contour>
     <contour>
-      <point x="185.0" y="398.0" type="curve" smooth="yes"/>
-      <point x="151.0" y="398.0"/>
-      <point x="135.0" y="420.0"/>
-      <point x="135.0" y="448.0" type="curve" smooth="yes"/>
-      <point x="135.0" y="491.0"/>
-      <point x="159.0" y="515.0"/>
-      <point x="198.0" y="515.0" type="curve" smooth="yes"/>
-      <point x="232.0" y="515.0"/>
-      <point x="253.0" y="496.0"/>
-      <point x="253.0" y="466.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="423.0"/>
-      <point x="231.0" y="398.0"/>
+      <point x="187" y="396.0" type="curve" smooth="yes"/>
+      <point x="153" y="396.0"/>
+      <point x="134" y="421.0"/>
+      <point x="134" y="449.0" type="curve" smooth="yes"/>
+      <point x="134" y="488.0"/>
+      <point x="162" y="517.0"/>
+      <point x="201" y="517.0" type="curve" smooth="yes"/>
+      <point x="232" y="517.0"/>
+      <point x="251" y="492.0"/>
+      <point x="251" y="465.0" type="curve" smooth="yes"/>
+      <point x="251" y="426.0"/>
+      <point x="226" y="396"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -1,59 +1,59 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278F"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="422.0" y="228.0" type="curve" smooth="yes"/>
-      <point x="460.0" y="228.0"/>
-      <point x="483.0" y="256.0"/>
-      <point x="483.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="483.0" y="323.0"/>
-      <point x="459.0" y="351.0"/>
-      <point x="420.0" y="351.0" type="curve" smooth="yes"/>
-      <point x="382.0" y="351.0"/>
-      <point x="359.0" y="324.0"/>
-      <point x="359.0" y="291.0" type="curve" smooth="yes"/>
-      <point x="359.0" y="257.0"/>
-      <point x="383.0" y="228.0"/>
+      <point x="418" y="215.0" type="curve" smooth="yes"/>
+      <point x="474" y="215"/>
+      <point x="514" y="256.0"/>
+      <point x="514" y="308.0" type="curve" smooth="yes"/>
+      <point x="514" y="343.0"/>
+      <point x="489" y="383.0"/>
+      <point x="440" y="383.0" type="curve" smooth="yes"/>
+      <point x="382" y="383"/>
+      <point x="346" y="337.0"/>
+      <point x="346" y="286.0" type="curve" smooth="yes"/>
+      <point x="346" y="248.0"/>
+      <point x="370" y="215.0"/>
     </contour>
     <contour>
-      <point x="422.0" y="163.0" type="curve" smooth="yes"/>
-      <point x="346.0" y="163.0"/>
-      <point x="284.0" y="216.0"/>
-      <point x="284.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="284.0" y="337.0"/>
-      <point x="300.0" y="373.0"/>
-      <point x="325.0" y="411.0" type="curve" smooth="yes"/>
-      <point x="358.0" y="459.0"/>
-      <point x="390.0" y="507.0"/>
-      <point x="423.0" y="553.0" type="curve"/>
-      <point x="510.0" y="545.0" type="line"/>
-      <point x="477.0" y="498.0"/>
-      <point x="443.0" y="450.0"/>
-      <point x="417.0" y="412.0" type="curve"/>
-      <point x="421.0" y="412.0"/>
-      <point x="427.0" y="413.0"/>
-      <point x="439.0" y="413.0" type="curve" smooth="yes"/>
-      <point x="507.0" y="413.0"/>
-      <point x="554.0" y="359.0"/>
-      <point x="554.0" y="289.0" type="curve" smooth="yes"/>
-      <point x="554.0" y="217.0"/>
-      <point x="494.0" y="163.0"/>
+      <point x="411" y="171" type="curve" smooth="yes"/>
+      <point x="348" y="171"/>
+      <point x="297" y="213"/>
+      <point x="297.0" y="292" type="curve" smooth="yes"/>
+      <point x="297" y="354"/>
+      <point x="322" y="417"/>
+      <point x="373" y="472" type="curve" smooth="yes"/>
+      <point x="407" y="508"/>
+      <point x="452" y="544"/>
+      <point x="506" y="563" type="curve"/>
+      <point x="520" y="526" type="line"/>
+      <point x="459" y="501"/>
+      <point x="380" y="444"/>
+      <point x="353" y="373" type="curve"/>
+      <point x="383" y="408"/>
+      <point x="432" y="421"/>
+      <point x="463" y="421" type="curve" smooth="yes"/>
+      <point x="520" y="421"/>
+      <point x="561" y="372"/>
+      <point x="561" y="314" type="curve" smooth="yes"/>
+      <point x="561" y="233"/>
+      <point x="500" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,41 +18,41 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="418" y="215.0" type="curve" smooth="yes"/>
-      <point x="474" y="215"/>
-      <point x="514" y="256.0"/>
-      <point x="514" y="308.0" type="curve" smooth="yes"/>
-      <point x="514" y="343.0"/>
-      <point x="489" y="383.0"/>
-      <point x="440" y="383.0" type="curve" smooth="yes"/>
-      <point x="382" y="383"/>
-      <point x="346" y="337.0"/>
-      <point x="346" y="286.0" type="curve" smooth="yes"/>
-      <point x="346" y="248.0"/>
-      <point x="370" y="215.0"/>
+      <point x="421" y="235" type="curve" smooth="yes"/>
+      <point x="464" y="235"/>
+      <point x="489" y="267"/>
+      <point x="489" y="306" type="curve" smooth="yes"/>
+      <point x="489" y="334"/>
+      <point x="470" y="360"/>
+      <point x="436" y="360" type="curve" smooth="yes"/>
+      <point x="393" y="360"/>
+      <point x="369" y="329"/>
+      <point x="369" y="290" type="curve" smooth="yes"/>
+      <point x="369" y="261"/>
+      <point x="387" y="235"/>
     </contour>
     <contour>
       <point x="411" y="171" type="curve" smooth="yes"/>
       <point x="348" y="171"/>
-      <point x="297" y="213"/>
-      <point x="297.0" y="292" type="curve" smooth="yes"/>
-      <point x="297" y="354"/>
-      <point x="322" y="417"/>
-      <point x="373" y="472" type="curve" smooth="yes"/>
-      <point x="407" y="508"/>
-      <point x="452" y="544"/>
-      <point x="506" y="563" type="curve"/>
-      <point x="520" y="526" type="line"/>
-      <point x="459" y="501"/>
-      <point x="380" y="444"/>
-      <point x="353" y="373" type="curve"/>
-      <point x="383" y="408"/>
+      <point x="289" y="213"/>
+      <point x="289" y="309" type="curve" smooth="yes"/>
+      <point x="289" y="355"/>
+      <point x="313" y="423"/>
+      <point x="364" y="478" type="curve" smooth="yes"/>
+      <point x="398" y="514"/>
+      <point x="447" y="546"/>
+      <point x="505" y="565" type="curve"/>
+      <point x="528" y="510" type="line"/>
+      <point x="468" y="486"/>
+      <point x="395" y="437"/>
+      <point x="375" y="388" type="curve"/>
+      <point x="395" y="410"/>
       <point x="432" y="421"/>
       <point x="463" y="421" type="curve" smooth="yes"/>
-      <point x="520" y="421"/>
-      <point x="561" y="372"/>
-      <point x="561" y="314" type="curve" smooth="yes"/>
-      <point x="561" y="233"/>
+      <point x="532" y="421"/>
+      <point x="569" y="372"/>
+      <point x="569" y="314" type="curve" smooth="yes"/>
+      <point x="569" y="233"/>
       <point x="500" y="171"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="328"/>
   <outline>
     <contour>
-      <point x="189.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="275.0" y="330.0"/>
-      <point x="345.0" y="380.0"/>
-      <point x="345.0" y="459.0" type="curve" smooth="yes"/>
-      <point x="345.0" y="493.0"/>
-      <point x="329.0" y="522.0"/>
-      <point x="305.0" y="534.0" type="curve"/>
-      <point x="348.0" y="557.0"/>
-      <point x="362.0" y="577.0"/>
-      <point x="362.0" y="627.0" type="curve" smooth="yes"/>
-      <point x="362.0" y="681.0"/>
-      <point x="315.0" y="724.0"/>
-      <point x="249.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="164.0" y="724.0"/>
-      <point x="120.0" y="686.0"/>
-      <point x="103.0" y="628.0" type="curve"/>
-      <point x="171.0" y="613.0" type="line"/>
-      <point x="183.0" y="642.0"/>
-      <point x="201.0" y="649.0"/>
-      <point x="225.0" y="649.0" type="curve" smooth="yes"/>
-      <point x="255.0" y="649.0"/>
-      <point x="268.0" y="629.0"/>
-      <point x="268.0" y="608.0" type="curve" smooth="yes"/>
-      <point x="268.0" y="589.0"/>
-      <point x="262.0" y="571.0"/>
-      <point x="212.0" y="571.0" type="curve" smooth="yes"/>
-      <point x="202.0" y="571.0"/>
-      <point x="193.0" y="571.0"/>
-      <point x="183.0" y="571.0" type="curve"/>
-      <point x="173.0" y="501.0" type="line"/>
-      <point x="179.0" y="501.0"/>
-      <point x="194.0" y="501.0"/>
-      <point x="204.0" y="501.0" type="curve" smooth="yes"/>
-      <point x="241.0" y="501.0"/>
-      <point x="253.0" y="469.0"/>
-      <point x="253.0" y="452.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="426.0"/>
-      <point x="238.0" y="409.0"/>
-      <point x="201.0" y="409.0" type="curve" smooth="yes"/>
-      <point x="155.0" y="409.0"/>
-      <point x="145.0" y="437.0"/>
-      <point x="141.0" y="462.0" type="curve"/>
-      <point x="62.0" y="443.0" type="line"/>
-      <point x="70.0" y="369.0"/>
-      <point x="128.0" y="330.0"/>
+      <point x="189" y="330" type="curve" smooth="yes"/>
+      <point x="279" y="330"/>
+      <point x="334" y="380"/>
+      <point x="334" y="459" type="curve" smooth="yes"/>
+      <point x="334" y="493"/>
+      <point x="306" y="526"/>
+      <point x="279" y="534" type="curve"/>
+      <point x="316" y="548"/>
+      <point x="351" y="577"/>
+      <point x="351" y="627" type="curve" smooth="yes"/>
+      <point x="351" y="681"/>
+      <point x="309" y="724.0"/>
+      <point x="237" y="724.0" type="curve" smooth="yes"/>
+      <point x="162" y="724"/>
+      <point x="117" y="685"/>
+      <point x="100" y="626" type="curve"/>
+      <point x="170" y="613" type="line"/>
+      <point x="179" y="638"/>
+      <point x="194" y="656"/>
+      <point x="227" y="656" type="curve" smooth="yes"/>
+      <point x="254" y="656"/>
+      <point x="270" y="639"/>
+      <point x="270" y="613" type="curve" smooth="yes"/>
+      <point x="270" y="582"/>
+      <point x="255" y="564"/>
+      <point x="211" y="564" type="curve" smooth="yes"/>
+      <point x="202" y="564"/>
+      <point x="182" y="564"/>
+      <point x="173" y="564" type="curve"/>
+      <point x="164.0" y="498" type="line"/>
+      <point x="169.0" y="498"/>
+      <point x="192.0" y="498"/>
+      <point x="201.0" y="498" type="curve" smooth="yes"/>
+      <point x="234.0" y="498"/>
+      <point x="252.0" y="477"/>
+      <point x="252.0" y="454" type="curve" smooth="yes"/>
+      <point x="252.0" y="421"/>
+      <point x="231" y="399"/>
+      <point x="191" y="399" type="curve" smooth="yes"/>
+      <point x="157" y="399"/>
+      <point x="136" y="424"/>
+      <point x="130" y="460" type="curve"/>
+      <point x="59" y="446" type="line"/>
+      <point x="67" y="370"/>
+      <point x="127" y="330"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -1,68 +1,68 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="three.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278C"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="423.0" y="160.0" type="curve" smooth="yes"/>
-      <point x="353.0" y="160.0"/>
-      <point x="298.0" y="199.0"/>
-      <point x="288.0" y="273.0" type="curve"/>
-      <point x="356.0" y="287.0" type="line"/>
-      <point x="363.0" y="248.0"/>
-      <point x="387.0" y="229.0"/>
-      <point x="420.0" y="229.0" type="curve" smooth="yes"/>
-      <point x="453.0" y="229.0"/>
-      <point x="477.0" y="248.0"/>
-      <point x="477.0" y="282.0" type="curve" smooth="yes"/>
-      <point x="477.0" y="311.0"/>
-      <point x="461.0" y="331.0"/>
-      <point x="419.0" y="331.0" type="curve" smooth="yes"/>
-      <point x="409.0" y="331.0"/>
-      <point x="398.0" y="331.0"/>
-      <point x="388.0" y="331.0" type="curve"/>
-      <point x="388.0" y="395.0" type="line"/>
-      <point x="395.0" y="395.0"/>
-      <point x="404.0" y="395.0"/>
-      <point x="411.0" y="395.0" type="curve"/>
-      <point x="442.0" y="395.0"/>
-      <point x="466.0" y="405.0"/>
-      <point x="466.0" y="440.0" type="curve" smooth="yes"/>
-      <point x="466.0" y="466.0"/>
-      <point x="448.0" y="485.0"/>
-      <point x="418.0" y="485.0" type="curve" smooth="yes"/>
-      <point x="388.0" y="485.0"/>
-      <point x="370.0" y="464.0"/>
-      <point x="363.0" y="441.0" type="curve"/>
-      <point x="291.0" y="455.0" type="line"/>
-      <point x="301.0" y="510.0"/>
-      <point x="350.0" y="554.0"/>
-      <point x="421.0" y="554.0" type="curve" smooth="yes"/>
-      <point x="492.0" y="554.0"/>
-      <point x="541.0" y="514.0"/>
-      <point x="541.0" y="453.0" type="curve" smooth="yes"/>
-      <point x="541.0" y="416.0"/>
-      <point x="522.0" y="387.0"/>
-      <point x="495.0" y="366.0" type="curve"/>
-      <point x="531.0" y="352.0"/>
-      <point x="553.0" y="324.0"/>
-      <point x="553.0" y="276.0" type="curve" smooth="yes"/>
-      <point x="553.0" y="205.0"/>
-      <point x="497.0" y="160.0"/>
+      <point x="419" y="162" type="curve" smooth="yes"/>
+      <point x="350" y="162"/>
+      <point x="289" y="201"/>
+      <point x="281" y="275" type="curve"/>
+      <point x="328" y="278.0" type="line"/>
+      <point x="337" y="234.0"/>
+      <point x="367" y="203"/>
+      <point x="419" y="203.0" type="curve" smooth="yes"/>
+      <point x="465" y="203.0"/>
+      <point x="497" y="233.0"/>
+      <point x="497" y="276.0" type="curve" smooth="yes"/>
+      <point x="497" y="307.0"/>
+      <point x="470" y="337.0"/>
+      <point x="426" y="337.0" type="curve" smooth="yes"/>
+      <point x="413" y="337.0"/>
+      <point x="396" y="337.0"/>
+      <point x="388" y="337.0" type="curve"/>
+      <point x="393.0" y="380" type="line"/>
+      <point x="405.0" y="380"/>
+      <point x="417.0" y="380"/>
+      <point x="429.0" y="380" type="curve" smooth="yes"/>
+      <point x="488.0" y="380"/>
+      <point x="512.0" y="408"/>
+      <point x="512.0" y="452" type="curve" smooth="yes"/>
+      <point x="512.0" y="489"/>
+      <point x="484.0" y="513"/>
+      <point x="449.0" y="513" type="curve" smooth="yes"/>
+      <point x="405.0" y="513"/>
+      <point x="378.0" y="486"/>
+      <point x="365.0" y="450" type="curve"/>
+      <point x="320" y="461" type="line"/>
+      <point x="337" y="515"/>
+      <point x="381" y="556"/>
+      <point x="455" y="556" type="curve" smooth="yes"/>
+      <point x="522" y="556"/>
+      <point x="561" y="513"/>
+      <point x="561" y="459" type="curve" smooth="yes"/>
+      <point x="561" y="409"/>
+      <point x="521" y="374"/>
+      <point x="484" y="362" type="curve"/>
+      <point x="510" y="351"/>
+      <point x="543" y="325"/>
+      <point x="543.0" y="282" type="curve" smooth="yes"/>
+      <point x="543" y="212"/>
+      <point x="492" y="162"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="419" y="162" type="curve" smooth="yes"/>
-      <point x="350" y="162"/>
-      <point x="289" y="201"/>
-      <point x="281" y="275" type="curve"/>
-      <point x="328" y="278.0" type="line"/>
-      <point x="337" y="234.0"/>
-      <point x="367" y="203"/>
-      <point x="419" y="203.0" type="curve" smooth="yes"/>
-      <point x="465" y="203.0"/>
-      <point x="497" y="233.0"/>
-      <point x="497" y="276.0" type="curve" smooth="yes"/>
-      <point x="497" y="307.0"/>
-      <point x="470" y="337.0"/>
-      <point x="426" y="337.0" type="curve" smooth="yes"/>
-      <point x="413" y="337.0"/>
-      <point x="396" y="337.0"/>
-      <point x="388" y="337.0" type="curve"/>
-      <point x="393.0" y="380" type="line"/>
-      <point x="405.0" y="380"/>
-      <point x="417.0" y="380"/>
-      <point x="429.0" y="380" type="curve" smooth="yes"/>
-      <point x="488.0" y="380"/>
-      <point x="512.0" y="408"/>
-      <point x="512.0" y="452" type="curve" smooth="yes"/>
-      <point x="512.0" y="489"/>
-      <point x="484.0" y="513"/>
-      <point x="449.0" y="513" type="curve" smooth="yes"/>
-      <point x="405.0" y="513"/>
-      <point x="378.0" y="486"/>
-      <point x="365.0" y="450" type="curve"/>
-      <point x="320" y="461" type="line"/>
-      <point x="337" y="515"/>
+      <point x="406" y="162" type="curve" smooth="yes"/>
+      <point x="345" y="162"/>
+      <point x="282" y="201"/>
+      <point x="274" y="275" type="curve"/>
+      <point x="345" y="288" type="line"/>
+      <point x="352" y="250"/>
+      <point x="372" y="229"/>
+      <point x="411" y="229" type="curve" smooth="yes"/>
+      <point x="455" y="229"/>
+      <point x="475" y="247"/>
+      <point x="475" y="284" type="curve" smooth="yes"/>
+      <point x="475" y="311"/>
+      <point x="458" y="332"/>
+      <point x="421" y="332" type="curve" smooth="yes"/>
+      <point x="411" y="332"/>
+      <point x="396" y="332"/>
+      <point x="390" y="332" type="curve"/>
+      <point x="400" y="398" type="line"/>
+      <point x="410" y="398"/>
+      <point x="419" y="398"/>
+      <point x="429" y="398" type="curve" smooth="yes"/>
+      <point x="479" y="398"/>
+      <point x="492" y="418"/>
+      <point x="492" y="449" type="curve" smooth="yes"/>
+      <point x="492" y="476"/>
+      <point x="476" y="489"/>
+      <point x="446" y="489" type="curve" smooth="yes"/>
+      <point x="409" y="489"/>
+      <point x="394" y="475"/>
+      <point x="383" y="447" type="curve"/>
+      <point x="315" y="460" type="line"/>
+      <point x="332" y="518"/>
       <point x="381" y="556"/>
       <point x="455" y="556" type="curve" smooth="yes"/>
       <point x="522" y="556"/>
-      <point x="561" y="513"/>
-      <point x="561" y="459" type="curve" smooth="yes"/>
-      <point x="561" y="409"/>
-      <point x="521" y="374"/>
-      <point x="484" y="362" type="curve"/>
-      <point x="510" y="351"/>
-      <point x="543" y="325"/>
-      <point x="543.0" y="282" type="curve" smooth="yes"/>
-      <point x="543" y="212"/>
+      <point x="569" y="513"/>
+      <point x="569" y="459" type="curve" smooth="yes"/>
+      <point x="569" y="409"/>
+      <point x="538" y="385"/>
+      <point x="507" y="366" type="curve"/>
+      <point x="531" y="354"/>
+      <point x="552" y="325"/>
+      <point x="552" y="291" type="curve" smooth="yes"/>
+      <point x="552" y="212"/>
       <point x="492" y="162"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -3,35 +3,35 @@
   <advance width="317"/>
   <outline>
     <contour>
-      <point x="49.0" y="338.0" type="line"/>
-      <point x="296.0" y="338.0" type="line"/>
-      <point x="311.0" y="417.0" type="line"/>
-      <point x="194.0" y="417.0" type="line"/>
-      <point x="244.0" y="450.0"/>
-      <point x="268.0" y="463.0"/>
-      <point x="302.0" y="501.0" type="curve" smooth="yes"/>
-      <point x="334.0" y="536.0"/>
-      <point x="349.0" y="570.0"/>
-      <point x="349.0" y="618.0" type="curve" smooth="yes"/>
-      <point x="349.0" y="679.0"/>
-      <point x="311.0" y="724.0"/>
-      <point x="229.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="148.0" y="724.0"/>
-      <point x="98.0" y="683.0"/>
-      <point x="84.0" y="612.0" type="curve"/>
-      <point x="162.0" y="594.0" type="line"/>
-      <point x="169.0" y="627.0"/>
-      <point x="188.0" y="645.0"/>
-      <point x="212.0" y="645.0" type="curve" smooth="yes"/>
-      <point x="244.0" y="645.0"/>
-      <point x="253.0" y="625.0"/>
-      <point x="253.0" y="606.0" type="curve" smooth="yes"/>
-      <point x="253.0" y="591.0"/>
-      <point x="253.0" y="576.0"/>
-      <point x="229.0" y="549.0" type="curve" smooth="yes"/>
-      <point x="196.0" y="512.0"/>
-      <point x="154.0" y="476.0"/>
-      <point x="63.0" y="414.0" type="curve"/>
+      <point x="49" y="338" type="line"/>
+      <point x="296" y="338" type="line"/>
+      <point x="310" y="407" type="line"/>
+      <point x="178" y="407" type="line"/>
+      <point x="210" y="427"/>
+      <point x="256" y="462"/>
+      <point x="290" y="500" type="curve" smooth="yes"/>
+      <point x="322" y="535"/>
+      <point x="344" y="568"/>
+      <point x="344" y="619" type="curve" smooth="yes"/>
+      <point x="344" y="680"/>
+      <point x="302" y="724"/>
+      <point x="229" y="724" type="curve" smooth="yes"/>
+      <point x="148" y="724"/>
+      <point x="96" y="680"/>
+      <point x="82" y="609" type="curve"/>
+      <point x="174" y="592" type="line"/>
+      <point x="181" y="634"/>
+      <point x="205" y="651"/>
+      <point x="227" y="651.0" type="curve" smooth="yes"/>
+      <point x="246" y="651"/>
+      <point x="265" y="646"/>
+      <point x="265" y="615" type="curve" smooth="yes"/>
+      <point x="265" y="591"/>
+      <point x="254" y="565"/>
+      <point x="234" y="543" type="curve" smooth="yes"/>
+      <point x="200" y="506"/>
+      <point x="137" y="460"/>
+      <point x="57" y="403" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="281" y="177" type="line"/>
-      <point x="291" y="222" type="line"/>
-      <point x="380" y="290"/>
-      <point x="438" y="341"/>
-      <point x="471" y="378" type="curve" smooth="yes"/>
-      <point x="495" y="405"/>
-      <point x="519" y="432.0"/>
-      <point x="519.0" y="465" type="curve" smooth="yes"/>
-      <point x="519" y="496.0"/>
-      <point x="494" y="519.0"/>
-      <point x="453" y="519.0" type="curve" smooth="yes"/>
-      <point x="413" y="519.0"/>
-      <point x="377" y="488.0"/>
-      <point x="368" y="439.0" type="curve"/>
-      <point x="324" y="445" type="line"/>
-      <point x="338" y="516"/>
+      <point x="292" y="239" type="line"/>
+      <point x="383" y="301"/>
+      <point x="435" y="344"/>
+      <point x="468" y="381" type="curve" smooth="yes"/>
+      <point x="492" y="408"/>
+      <point x="501" y="430"/>
+      <point x="501" y="454" type="curve" smooth="yes"/>
+      <point x="501" y="481"/>
+      <point x="485" y="495"/>
+      <point x="452" y="495" type="curve" smooth="yes"/>
+      <point x="420" y="495"/>
+      <point x="395" y="476"/>
+      <point x="388" y="434" type="curve"/>
+      <point x="318" y="448" type="line"/>
+      <point x="332" y="519"/>
       <point x="380" y="563"/>
       <point x="461" y="563" type="curve" smooth="yes"/>
-      <point x="526" y="563"/>
-      <point x="569" y="521"/>
-      <point x="569.0" y="467" type="curve" smooth="yes"/>
-      <point x="569" y="418"/>
-      <point x="535" y="385"/>
-      <point x="503" y="350" type="curve" smooth="yes"/>
-      <point x="469" y="312"/>
-      <point x="386" y="245"/>
-      <point x="355" y="218" type="curve"/>
-      <point x="536" y="218" type="line"/>
+      <point x="534" y="563"/>
+      <point x="575" y="518"/>
+      <point x="575" y="457" type="curve" smooth="yes"/>
+      <point x="575" y="409"/>
+      <point x="551" y="375"/>
+      <point x="519" y="340" type="curve" smooth="yes"/>
+      <point x="485" y="302"/>
+      <point x="445" y="277"/>
+      <point x="395" y="244" type="curve"/>
+      <point x="538" y="244" type="line"/>
       <point x="528" y="177" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="two.sansSerifBlackCircled" format="2">
-  <advance width="851"/>
+  <advance width="837"/>
   <unicode hex="278B"/>
   <outline>
     <contour>
-      <point x="425.0" y="-16.0" type="curve" smooth="yes"/>
-      <point x="631.0" y="-16.0"/>
-      <point x="799.0" y="152.0"/>
-      <point x="799.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="799.0" y="564.0"/>
-      <point x="631.0" y="732.0"/>
-      <point x="425.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="219.0" y="732.0"/>
-      <point x="51.0" y="564.0"/>
-      <point x="51.0" y="358.0" type="curve" smooth="yes"/>
-      <point x="51.0" y="152.0"/>
-      <point x="219.0" y="-16.0"/>
+      <point x="437" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="811" y="152"/>
+      <point x="811" y="358" type="curve" smooth="yes"/>
+      <point x="811" y="564"/>
+      <point x="643" y="732"/>
+      <point x="437" y="732" type="curve" smooth="yes"/>
+      <point x="231" y="732"/>
+      <point x="63" y="564"/>
+      <point x="63" y="358" type="curve" smooth="yes"/>
+      <point x="63" y="152"/>
+      <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="306.0" y="171.0" type="line"/>
-      <point x="308.0" y="242.0" type="line"/>
-      <point x="374.0" y="292.0"/>
-      <point x="419.0" y="331.0"/>
-      <point x="445.0" y="363.0" type="curve" smooth="yes"/>
-      <point x="466.0" y="391.0"/>
-      <point x="474.0" y="411.0"/>
-      <point x="474.0" y="435.0" type="curve" smooth="yes"/>
-      <point x="474.0" y="465.0"/>
-      <point x="452.0" y="481.0"/>
-      <point x="425.0" y="481.0" type="curve" smooth="yes"/>
-      <point x="393.0" y="481.0"/>
-      <point x="377.0" y="458.0"/>
-      <point x="375.0" y="429.0" type="curve"/>
-      <point x="298.0" y="441.0" type="line"/>
-      <point x="304.0" y="512.0"/>
-      <point x="359.0" y="557.0"/>
-      <point x="426.0" y="557.0" type="curve" smooth="yes"/>
-      <point x="503.0" y="557.0"/>
-      <point x="551.0" y="513.0"/>
-      <point x="551.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="551.0" y="392.0"/>
-      <point x="528.0" y="349.0"/>
-      <point x="492.0" y="309.0" type="curve" smooth="yes"/>
-      <point x="467.0" y="281.0"/>
-      <point x="453.0" y="268.0"/>
-      <point x="419.0" y="243.0" type="curve"/>
-      <point x="564.0" y="243.0" type="line"/>
-      <point x="560.0" y="171.0" type="line"/>
+      <point x="281" y="177" type="line"/>
+      <point x="291" y="222" type="line"/>
+      <point x="380" y="290"/>
+      <point x="438" y="341"/>
+      <point x="471" y="378" type="curve" smooth="yes"/>
+      <point x="495" y="405"/>
+      <point x="519" y="432.0"/>
+      <point x="519.0" y="465" type="curve" smooth="yes"/>
+      <point x="519" y="496.0"/>
+      <point x="494" y="519.0"/>
+      <point x="453" y="519.0" type="curve" smooth="yes"/>
+      <point x="413" y="519.0"/>
+      <point x="377" y="488.0"/>
+      <point x="368" y="439.0" type="curve"/>
+      <point x="324" y="445" type="line"/>
+      <point x="338" y="516"/>
+      <point x="380" y="563"/>
+      <point x="461" y="563" type="curve" smooth="yes"/>
+      <point x="526" y="563"/>
+      <point x="569" y="521"/>
+      <point x="569.0" y="467" type="curve" smooth="yes"/>
+      <point x="569" y="418"/>
+      <point x="535" y="385"/>
+      <point x="503" y="350" type="curve" smooth="yes"/>
+      <point x="469" y="312"/>
+      <point x="386" y="245"/>
+      <point x="355" y="218" type="curve"/>
+      <point x="536" y="218" type="line"/>
+      <point x="528" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.sansS_erifC_ircled.glif
@@ -3,7 +3,7 @@
   <advance width="851"/>
   <unicode hex="2781"/>
   <outline>
-    <component base="two.numerator" xOffset="236" yOffset="-173"/>
+    <component base="two.numerator" xOffset="236" yOffset="-169"/>
     <component base="SansSerifCircle"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="45.0" y="105.0" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="379"/>
   <outline>
     <contour>
-      <point x="209.0" y="330.0" type="curve" smooth="yes"/>
-      <point x="337.0" y="330.0"/>
-      <point x="411.0" y="438.0"/>
-      <point x="411.0" y="561.0" type="curve" smooth="yes"/>
-      <point x="411.0" y="656.0"/>
-      <point x="356.0" y="724.0"/>
-      <point x="263.0" y="724.0" type="curve" smooth="yes"/>
-      <point x="142.0" y="724.0"/>
-      <point x="61.0" y="610.0"/>
-      <point x="61.0" y="492.0" type="curve" smooth="yes"/>
-      <point x="61.0" y="398.0"/>
-      <point x="130.0" y="330.0"/>
+      <point x="208" y="330.0" type="curve" smooth="yes"/>
+      <point x="329" y="330.0"/>
+      <point x="401" y="438.0"/>
+      <point x="401" y="561.0" type="curve" smooth="yes"/>
+      <point x="401" y="656.0"/>
+      <point x="349" y="724.0"/>
+      <point x="264" y="724.0" type="curve" smooth="yes"/>
+      <point x="139" y="724.0"/>
+      <point x="71" y="610.0"/>
+      <point x="71" y="492.0" type="curve" smooth="yes"/>
+      <point x="71" y="398.0"/>
+      <point x="127" y="330.0"/>
     </contour>
     <contour>
-      <point x="217.0" y="409.0" type="curve" smooth="yes"/>
-      <point x="185.0" y="409.0"/>
-      <point x="159.0" y="431.0"/>
-      <point x="159.0" y="497.0" type="curve" smooth="yes"/>
-      <point x="159.0" y="586.0"/>
-      <point x="188.0" y="645.0"/>
-      <point x="248.0" y="645.0" type="curve" smooth="yes"/>
-      <point x="292.0" y="645.0"/>
-      <point x="314.0" y="623.0"/>
-      <point x="314.0" y="556.0" type="curve" smooth="yes"/>
-      <point x="314.0" y="471.0"/>
-      <point x="286.0" y="409.0"/>
+      <point x="220" y="405" type="curve" smooth="yes"/>
+      <point x="179" y="405"/>
+      <point x="156" y="442"/>
+      <point x="156" y="501" type="curve" smooth="yes"/>
+      <point x="156" y="579"/>
+      <point x="195" y="648"/>
+      <point x="252" y="648" type="curve" smooth="yes"/>
+      <point x="293" y="648"/>
+      <point x="316" y="612"/>
+      <point x="316" y="552" type="curve" smooth="yes"/>
+      <point x="316" y="477"/>
+      <point x="279" y="405"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="238" type="curve" smooth="yes"/>
-      <point x="455" y="238"/>
-      <point x="478" y="258"/>
-      <point x="478" y="287" type="curve" smooth="yes"/>
-      <point x="478" y="316"/>
+      <point x="417" y="238" type="curve" smooth="yes"/>
+      <point x="453" y="238"/>
+      <point x="476" y="259"/>
+      <point x="476" y="293" type="curve" smooth="yes"/>
+      <point x="476" y="318"/>
       <point x="455" y="336"/>
-      <point x="426" y="336" type="curve" smooth="yes"/>
-      <point x="397" y="336"/>
-      <point x="374" y="316"/>
-      <point x="374" y="287" type="curve" smooth="yes"/>
-      <point x="374" y="258"/>
-      <point x="397" y="238"/>
+      <point x="429" y="336" type="curve" smooth="yes"/>
+      <point x="395" y="336"/>
+      <point x="370" y="315"/>
+      <point x="370" y="281" type="curve" smooth="yes"/>
+      <point x="370" y="257"/>
+      <point x="390" y="238"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="351" y="163"/>
-      <point x="286" y="205"/>
-      <point x="286" y="281" type="curve" smooth="yes"/>
-      <point x="286" y="323"/>
-      <point x="308" y="353"/>
-      <point x="338" y="372" type="curve"/>
-      <point x="313" y="388"/>
-      <point x="298" y="418"/>
-      <point x="298" y="446" type="curve" smooth="yes"/>
-      <point x="298" y="514"/>
-      <point x="357" y="557"/>
-      <point x="426" y="557" type="curve" smooth="yes"/>
-      <point x="495" y="557"/>
-      <point x="554" y="514"/>
-      <point x="554" y="446" type="curve" smooth="yes"/>
-      <point x="554" y="418"/>
-      <point x="539" y="388"/>
-      <point x="514" y="372" type="curve"/>
-      <point x="544" y="353"/>
-      <point x="566" y="323"/>
-      <point x="566" y="281" type="curve" smooth="yes"/>
-      <point x="566" y="204"/>
-      <point x="501" y="163"/>
+      <point x="410" y="163" type="curve" smooth="yes"/>
+      <point x="335" y="163"/>
+      <point x="280" y="211"/>
+      <point x="280" y="274" type="curve" smooth="yes"/>
+      <point x="280" y="327"/>
+      <point x="313" y="362"/>
+      <point x="353" y="379" type="curve"/>
+      <point x="337" y="394"/>
+      <point x="322" y="416"/>
+      <point x="322" y="442" type="curve" smooth="yes"/>
+      <point x="322" y="513"/>
+      <point x="380" y="557"/>
+      <point x="464" y="557" type="curve" smooth="yes"/>
+      <point x="532" y="557"/>
+      <point x="581" y="516"/>
+      <point x="581" y="459" type="curve" smooth="yes"/>
+      <point x="581" y="423"/>
+      <point x="558" y="390"/>
+      <point x="526" y="372" type="curve"/>
+      <point x="548" y="358"/>
+      <point x="564" y="331"/>
+      <point x="564" y="296" type="curve" smooth="yes"/>
+      <point x="564" y="212"/>
+      <point x="499" y="163"/>
     </contour>
     <contour>
-      <point x="426" y="404" type="curve" smooth="yes"/>
-      <point x="449" y="404"/>
-      <point x="468" y="420"/>
-      <point x="468" y="443" type="curve" smooth="yes"/>
-      <point x="468" y="465"/>
-      <point x="449" y="482"/>
-      <point x="426" y="482" type="curve" smooth="yes"/>
-      <point x="403" y="482"/>
-      <point x="384" y="467"/>
-      <point x="384" y="443" type="curve" smooth="yes"/>
-      <point x="384" y="419"/>
-      <point x="403" y="404"/>
+      <point x="446" y="404" type="curve" smooth="yes"/>
+      <point x="475" y="404"/>
+      <point x="494" y="420"/>
+      <point x="494" y="447" type="curve" smooth="yes"/>
+      <point x="494" y="468"/>
+      <point x="477" y="482"/>
+      <point x="457" y="482" type="curve" smooth="yes"/>
+      <point x="429" y="482"/>
+      <point x="408" y="468"/>
+      <point x="408" y="439" type="curve" smooth="yes"/>
+      <point x="408" y="420"/>
+      <point x="424" y="404"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -18,37 +18,37 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="163" type="curve" smooth="yes"/>
-      <point x="358" y="163"/>
-      <point x="303" y="197"/>
-      <point x="288" y="268" type="curve"/>
-      <point x="369" y="285" type="line"/>
-      <point x="376" y="257"/>
-      <point x="397" y="240"/>
-      <point x="425" y="240" type="curve" smooth="yes"/>
-      <point x="459" y="240"/>
-      <point x="479" y="262"/>
-      <point x="479" y="296" type="curve" smooth="yes"/>
-      <point x="479" y="331"/>
-      <point x="458" y="352"/>
-      <point x="426" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="352"/>
-      <point x="383" y="339"/>
-      <point x="374" y="323" type="curve"/>
-      <point x="301" y="355" type="line"/>
-      <point x="324" y="548" type="line"/>
-      <point x="547" y="548" type="line"/>
-      <point x="547" y="476" type="line"/>
-      <point x="391" y="476" type="line"/>
-      <point x="380" y="406" type="line"/>
-      <point x="398" y="418"/>
-      <point x="417" y="423"/>
-      <point x="442" y="423" type="curve" smooth="yes"/>
-      <point x="512" y="423"/>
-      <point x="566" y="376"/>
-      <point x="566" y="294" type="curve" smooth="yes"/>
-      <point x="566" y="214"/>
-      <point x="505" y="163"/>
+      <point x="405" y="161" type="curve" smooth="yes"/>
+      <point x="338" y="161"/>
+      <point x="286" y="199"/>
+      <point x="272" y="266" type="curve"/>
+      <point x="358" y="283" type="line"/>
+      <point x="365" y="255"/>
+      <point x="388" y="238"/>
+      <point x="413" y="238" type="curve" smooth="yes"/>
+      <point x="447" y="238"/>
+      <point x="469" y="262"/>
+      <point x="469" y="302" type="curve" smooth="yes"/>
+      <point x="469" y="331"/>
+      <point x="450" y="350"/>
+      <point x="422" y="350" type="curve" smooth="yes"/>
+      <point x="399" y="350"/>
+      <point x="379" y="337"/>
+      <point x="367" y="321" type="curve"/>
+      <point x="300" y="353" type="line"/>
+      <point x="353" y="546" type="line"/>
+      <point x="580" y="546" type="line"/>
+      <point x="567" y="474" type="line"/>
+      <point x="411" y="474" type="line"/>
+      <point x="391" y="404" type="line"/>
+      <point x="406" y="415"/>
+      <point x="428" y="421"/>
+      <point x="453" y="421" type="curve" smooth="yes"/>
+      <point x="514" y="421"/>
+      <point x="557" y="373"/>
+      <point x="557" y="309" type="curve" smooth="yes"/>
+      <point x="557" y="212"/>
+      <point x="489" y="161"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="342" y="310" type="line"/>
-      <point x="427" y="310" type="line"/>
-      <point x="427" y="425" type="line"/>
-      <point x="419" y="425" type="line"/>
+      <point x="353" y="308" type="line"/>
+      <point x="434" y="308" type="line"/>
+      <point x="454" y="423" type="line"/>
+      <point x="446" y="423" type="line"/>
     </contour>
     <contour>
-      <point x="427" y="171" type="line"/>
-      <point x="427" y="236" type="line"/>
-      <point x="252" y="236" type="line"/>
-      <point x="252" y="300" type="line"/>
-      <point x="423" y="549" type="line"/>
-      <point x="513" y="549" type="line"/>
-      <point x="513" y="310" type="line"/>
-      <point x="565" y="310" type="line"/>
-      <point x="565" y="236" type="line"/>
-      <point x="513" y="236" type="line"/>
-      <point x="513" y="171" type="line"/>
+      <point x="410" y="169" type="line"/>
+      <point x="421" y="234" type="line"/>
+      <point x="246" y="234" type="line"/>
+      <point x="257" y="298" type="line"/>
+      <point x="467" y="547" type="line"/>
+      <point x="562" y="547" type="line"/>
+      <point x="520" y="308" type="line"/>
+      <point x="572" y="308" type="line"/>
+      <point x="559" y="234" type="line"/>
+      <point x="507" y="234" type="line"/>
+      <point x="496" y="169" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="171" type="curve"/>
-      <point x="316" y="171" type="line"/>
-      <point x="350" y="214"/>
-      <point x="384" y="257"/>
-      <point x="418" y="300" type="curve"/>
-      <point x="413" y="297"/>
-      <point x="405" y="296"/>
-      <point x="396" y="296" type="curve" smooth="yes"/>
-      <point x="334" y="296"/>
-      <point x="280" y="353"/>
-      <point x="280" y="424" type="curve" smooth="yes"/>
-      <point x="280" y="496"/>
-      <point x="338" y="557"/>
-      <point x="423" y="557" type="curve" smooth="yes"/>
-      <point x="510" y="557"/>
-      <point x="566" y="497"/>
-      <point x="566" y="422" type="curve" smooth="yes"/>
-      <point x="566" y="377"/>
-      <point x="548" y="344"/>
-      <point x="520" y="305" type="curve"/>
-      <point x="487" y="260"/>
-      <point x="454" y="216"/>
+      <point x="367" y="161" type="curve"/>
+      <point x="346" y="229" type="line"/>
+      <point x="403" y="244"/>
+      <point x="466" y="278"/>
+      <point x="493" y="321" type="curve"/>
+      <point x="469" y="301"/>
+      <point x="440" y="292"/>
+      <point x="413" y="292" type="curve" smooth="yes"/>
+      <point x="351" y="292"/>
+      <point x="305" y="342"/>
+      <point x="305" y="401" type="curve" smooth="yes"/>
+      <point x="305" y="486"/>
+      <point x="366" y="553"/>
+      <point x="464" y="553" type="curve" smooth="yes"/>
+      <point x="543" y="553"/>
+      <point x="594" y="505"/>
+      <point x="594" y="417" type="curve" smooth="yes"/>
+      <point x="594" y="355"/>
+      <point x="573" y="298"/>
+      <point x="531" y="252" type="curve" smooth="yes"/>
+      <point x="493" y="211"/>
+      <point x="438" y="179"/>
     </contour>
     <contour>
-      <point x="424" y="367" type="curve" smooth="yes"/>
-      <point x="456" y="367"/>
-      <point x="479" y="390"/>
-      <point x="479" y="424" type="curve" smooth="yes"/>
-      <point x="479" y="458"/>
-      <point x="456" y="481"/>
-      <point x="424" y="481" type="curve" smooth="yes"/>
-      <point x="392" y="481"/>
-      <point x="368" y="458"/>
-      <point x="368" y="424" type="curve" smooth="yes"/>
-      <point x="368" y="390"/>
-      <point x="392" y="367"/>
+      <point x="444" y="363" type="curve" smooth="yes"/>
+      <point x="480" y="363"/>
+      <point x="507" y="387"/>
+      <point x="507" y="428" type="curve" smooth="yes"/>
+      <point x="507" y="457"/>
+      <point x="485" y="477"/>
+      <point x="457" y="477" type="curve" smooth="yes"/>
+      <point x="419" y="477"/>
+      <point x="394" y="452"/>
+      <point x="394" y="413" type="curve" smooth="yes"/>
+      <point x="394" y="382"/>
+      <point x="416" y="363"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="394" y="171" type="line"/>
-      <point x="394" y="430" type="line"/>
-      <point x="302" y="363" type="line"/>
-      <point x="302" y="473" type="line"/>
-      <point x="402" y="549" type="line"/>
-      <point x="483" y="549" type="line"/>
-      <point x="483" y="171" type="line"/>
+      <point x="372" y="169" type="line"/>
+      <point x="416" y="423" type="line"/>
+      <point x="313" y="356" type="line"/>
+      <point x="333" y="471" type="line"/>
+      <point x="446" y="547" type="line"/>
+      <point x="527" y="547" type="line"/>
+      <point x="461" y="169" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="451" y="171" type="curve"/>
-      <point x="356" y="171" type="line"/>
-      <point x="356" y="298"/>
-      <point x="403" y="395"/>
-      <point x="469" y="468" type="curve"/>
-      <point x="304" y="468" type="line"/>
-      <point x="304" y="549" type="line"/>
-      <point x="565" y="549" type="line"/>
-      <point x="565" y="472" type="line"/>
-      <point x="486" y="382"/>
-      <point x="451" y="274"/>
+      <point x="417" y="164" type="curve"/>
+      <point x="322" y="164" type="line"/>
+      <point x="339" y="296"/>
+      <point x="414" y="402"/>
+      <point x="487" y="461" type="curve"/>
+      <point x="322" y="461" type="line"/>
+      <point x="336" y="542" type="line"/>
+      <point x="597" y="542" type="line"/>
+      <point x="584" y="465" type="line"/>
+      <point x="486" y="375"/>
+      <point x="432" y="276"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="239" type="curve" smooth="yes"/>
-      <point x="453" y="239"/>
-      <point x="477" y="262"/>
-      <point x="477" y="296" type="curve" smooth="yes"/>
-      <point x="477" y="330"/>
-      <point x="453" y="353"/>
-      <point x="421" y="353" type="curve" smooth="yes"/>
-      <point x="389" y="353"/>
-      <point x="366" y="330"/>
-      <point x="366" y="296" type="curve" smooth="yes"/>
-      <point x="366" y="262"/>
-      <point x="389" y="239"/>
+      <point x="427" y="242" type="curve" smooth="yes"/>
+      <point x="465" y="242"/>
+      <point x="490" y="267"/>
+      <point x="490" y="306" type="curve" smooth="yes"/>
+      <point x="490" y="337"/>
+      <point x="468" y="356"/>
+      <point x="440" y="356" type="curve" smooth="yes"/>
+      <point x="404" y="356"/>
+      <point x="377" y="332"/>
+      <point x="377" y="291" type="curve" smooth="yes"/>
+      <point x="377" y="262"/>
+      <point x="399" y="242"/>
     </contour>
     <contour>
-      <point x="422" y="163" type="curve" smooth="yes"/>
-      <point x="335" y="163"/>
-      <point x="279" y="223"/>
-      <point x="279" y="298" type="curve" smooth="yes"/>
-      <point x="279" y="343"/>
-      <point x="297" y="376"/>
-      <point x="325" y="415" type="curve"/>
-      <point x="358" y="460"/>
-      <point x="391" y="504"/>
-      <point x="424" y="549" type="curve"/>
-      <point x="529" y="549" type="line"/>
-      <point x="495" y="507"/>
-      <point x="461" y="464"/>
-      <point x="427" y="420" type="curve"/>
-      <point x="432" y="423"/>
-      <point x="440" y="424"/>
-      <point x="449" y="424" type="curve" smooth="yes"/>
-      <point x="511" y="424"/>
-      <point x="565" y="367"/>
-      <point x="565" y="296" type="curve" smooth="yes"/>
-      <point x="565" y="224"/>
-      <point x="507" y="163"/>
+      <point x="420" y="166" type="curve" smooth="yes"/>
+      <point x="341" y="166"/>
+      <point x="290" y="214"/>
+      <point x="290" y="302" type="curve" smooth="yes"/>
+      <point x="290" y="364"/>
+      <point x="311" y="421"/>
+      <point x="353" y="467" type="curve" smooth="yes"/>
+      <point x="391" y="508"/>
+      <point x="446" y="540"/>
+      <point x="517" y="558" type="curve"/>
+      <point x="538" y="490" type="line"/>
+      <point x="481" y="475"/>
+      <point x="418" y="441"/>
+      <point x="391" y="398" type="curve"/>
+      <point x="415" y="418"/>
+      <point x="451" y="427"/>
+      <point x="478" y="427" type="curve" smooth="yes"/>
+      <point x="544" y="427"/>
+      <point x="579" y="377"/>
+      <point x="579" y="318" type="curve" smooth="yes"/>
+      <point x="579" y="233"/>
+      <point x="518" y="166"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,51 +18,51 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="426" y="162" type="curve" smooth="yes"/>
-      <point x="348" y="162"/>
-      <point x="291" y="202"/>
-      <point x="278" y="280" type="curve"/>
-      <point x="365" y="297" type="line"/>
-      <point x="370" y="258"/>
-      <point x="394" y="239"/>
-      <point x="426" y="239" type="curve" smooth="yes"/>
-      <point x="458" y="239"/>
-      <point x="478" y="255"/>
-      <point x="478" y="286" type="curve" smooth="yes"/>
-      <point x="478" y="315"/>
-      <point x="453" y="331"/>
-      <point x="418" y="331" type="curve"/>
-      <point x="407" y="331.0"/>
-      <point x="397" y="331.0"/>
-      <point x="386" y="331" type="curve"/>
-      <point x="386" y="401" type="line"/>
-      <point x="396" y="401.0"/>
-      <point x="407" y="401.0"/>
-      <point x="417" y="401" type="curve" smooth="yes"/>
-      <point x="449" y="401"/>
-      <point x="468" y="415"/>
-      <point x="468" y="440" type="curve" smooth="yes"/>
-      <point x="468" y="465"/>
-      <point x="449" y="479"/>
-      <point x="422" y="479" type="curve" smooth="yes"/>
-      <point x="398" y="479"/>
-      <point x="378" y="465"/>
-      <point x="371" y="442" type="curve"/>
-      <point x="288" y="456" type="line"/>
-      <point x="300" y="514"/>
-      <point x="348" y="556"/>
-      <point x="424" y="556" type="curve" smooth="yes"/>
-      <point x="508" y="556"/>
-      <point x="555" y="511"/>
-      <point x="555" y="451" type="curve" smooth="yes"/>
-      <point x="555" y="414"/>
-      <point x="532" y="385"/>
-      <point x="508" y="371" type="curve"/>
-      <point x="538" y="359"/>
-      <point x="567" y="328"/>
-      <point x="567" y="283" type="curve" smooth="yes"/>
-      <point x="567" y="212"/>
-      <point x="507" y="162"/>
+      <point x="408" y="158" type="curve" smooth="yes"/>
+      <point x="341" y="158"/>
+      <point x="281" y="198"/>
+      <point x="271" y="276" type="curve"/>
+      <point x="355" y="293" type="line"/>
+      <point x="359" y="257"/>
+      <point x="380" y="235"/>
+      <point x="412" y="235" type="curve" smooth="yes"/>
+      <point x="446" y="235"/>
+      <point x="472" y="255"/>
+      <point x="472" y="284" type="curve" smooth="yes"/>
+      <point x="472" y="311"/>
+      <point x="453" y="327"/>
+      <point x="420" y="327" type="curve"/>
+      <point x="409" y="327"/>
+      <point x="399" y="327"/>
+      <point x="388" y="327" type="curve"/>
+      <point x="400" y="397" type="line"/>
+      <point x="410" y="397"/>
+      <point x="421" y="397"/>
+      <point x="431" y="397" type="curve" smooth="yes"/>
+      <point x="467" y="397"/>
+      <point x="488" y="411"/>
+      <point x="488" y="439" type="curve" smooth="yes"/>
+      <point x="488" y="460"/>
+      <point x="471" y="475"/>
+      <point x="445" y="475" type="curve" smooth="yes"/>
+      <point x="418" y="475"/>
+      <point x="398" y="463"/>
+      <point x="390" y="438" type="curve"/>
+      <point x="312" y="452" type="line"/>
+      <point x="327" y="517"/>
+      <point x="380" y="552"/>
+      <point x="458" y="552" type="curve" smooth="yes"/>
+      <point x="538" y="552"/>
+      <point x="578" y="505"/>
+      <point x="578" y="449" type="curve" smooth="yes"/>
+      <point x="578" y="407"/>
+      <point x="552" y="380"/>
+      <point x="517" y="367" type="curve"/>
+      <point x="542" y="356"/>
+      <point x="563" y="327"/>
+      <point x="563" y="293" type="curve" smooth="yes"/>
+      <point x="563" y="214"/>
+      <point x="510" y="158"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -18,35 +18,35 @@
       <point x="220" y="-16"/>
     </contour>
     <contour>
-      <point x="297" y="171" type="line"/>
-      <point x="297" y="234" type="line"/>
-      <point x="361" y="280"/>
-      <point x="402" y="315"/>
-      <point x="428" y="344" type="curve" smooth="yes"/>
-      <point x="457" y="377"/>
-      <point x="466" y="404"/>
-      <point x="466" y="433" type="curve" smooth="yes"/>
-      <point x="466" y="461"/>
-      <point x="449" y="478"/>
-      <point x="423" y="478" type="curve" smooth="yes"/>
-      <point x="397" y="478"/>
-      <point x="380" y="459"/>
-      <point x="376" y="428" type="curve"/>
-      <point x="291" y="443" type="line"/>
-      <point x="300" y="514"/>
-      <point x="350" y="557"/>
-      <point x="423" y="557" type="curve" smooth="yes"/>
-      <point x="506" y="557"/>
-      <point x="556" y="514"/>
-      <point x="556" y="433" type="curve" smooth="yes"/>
-      <point x="556" y="388"/>
-      <point x="537" y="351"/>
-      <point x="511" y="319" type="curve" smooth="yes"/>
-      <point x="489" y="292"/>
-      <point x="460" y="269"/>
-      <point x="433" y="250" type="curve"/>
-      <point x="558" y="250" type="line"/>
-      <point x="558" y="171" type="line"/>
+      <point x="279" y="170" type="line"/>
+      <point x="290" y="233" type="line"/>
+      <point x="376" y="292"/>
+      <point x="431" y="335"/>
+      <point x="462" y="370" type="curve" smooth="yes"/>
+      <point x="485" y="395"/>
+      <point x="495" y="417"/>
+      <point x="495" y="438" type="curve" smooth="yes"/>
+      <point x="495" y="462"/>
+      <point x="482" y="477"/>
+      <point x="456" y="477" type="curve" smooth="yes"/>
+      <point x="430" y="477"/>
+      <point x="408" y="461"/>
+      <point x="400" y="427" type="curve"/>
+      <point x="318" y="442" type="line"/>
+      <point x="334" y="518"/>
+      <point x="387" y="556"/>
+      <point x="466" y="556" type="curve" smooth="yes"/>
+      <point x="543" y="556"/>
+      <point x="585" y="511"/>
+      <point x="585" y="446" type="curve" smooth="yes"/>
+      <point x="585" y="400"/>
+      <point x="564" y="363"/>
+      <point x="531" y="328" type="curve" smooth="yes"/>
+      <point x="505" y="301"/>
+      <point x="472" y="275"/>
+      <point x="437" y="249" type="curve"/>
+      <point x="554" y="249" type="line"/>
+      <point x="540" y="170" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="38" y="120" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -17,18 +17,18 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="437" y="28" type="curve" smooth="yes"/>
-      <point x="257" y="28"/>
-      <point x="107" y="178"/>
-      <point x="107" y="358" type="curve" smooth="yes"/>
-      <point x="107" y="541"/>
-      <point x="257" y="688"/>
-      <point x="437" y="688" type="curve" smooth="yes"/>
-      <point x="621" y="688"/>
-      <point x="767" y="541"/>
-      <point x="767" y="358" type="curve" smooth="yes"/>
-      <point x="767" y="178"/>
-      <point x="621" y="28"/>
+      <point x="437" y="34" type="curve" smooth="yes"/>
+      <point x="261" y="34"/>
+      <point x="113" y="182"/>
+      <point x="113" y="358" type="curve" smooth="yes"/>
+      <point x="113" y="537"/>
+      <point x="261" y="682"/>
+      <point x="437" y="682" type="curve" smooth="yes"/>
+      <point x="617" y="682"/>
+      <point x="761" y="537"/>
+      <point x="761" y="358" type="curve" smooth="yes"/>
+      <point x="761" y="182"/>
+      <point x="617" y="34"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.numerator.glif
@@ -4,57 +4,57 @@
   <outline>
     <contour>
       <point x="178" y="342" type="curve" smooth="yes"/>
-      <point x="260" y="342"/>
+      <point x="257" y="342"/>
       <point x="324" y="390"/>
       <point x="324" y="467" type="curve" smooth="yes"/>
       <point x="324" y="499"/>
-      <point x="301" y="529"/>
-      <point x="268" y="543" type="curve"/>
-      <point x="303" y="554"/>
-      <point x="344" y="594"/>
-      <point x="344" y="633" type="curve" smooth="yes"/>
-      <point x="344" y="689"/>
-      <point x="293" y="724"/>
+      <point x="299" y="531"/>
+      <point x="273" y="543" type="curve"/>
+      <point x="311" y="559"/>
+      <point x="341" y="594"/>
+      <point x="341" y="633" type="curve" smooth="yes"/>
+      <point x="341" y="689"/>
+      <point x="290" y="724"/>
       <point x="236" y="724" type="curve" smooth="yes"/>
-      <point x="156" y="724"/>
-      <point x="100" y="671"/>
-      <point x="100" y="608" type="curve" smooth="yes"/>
-      <point x="100" y="578"/>
-      <point x="128" y="554"/>
-      <point x="151" y="545" type="curve"/>
-      <point x="106" y="532"/>
+      <point x="159" y="724"/>
+      <point x="103" y="671"/>
+      <point x="103" y="608" type="curve" smooth="yes"/>
+      <point x="103" y="578"/>
+      <point x="127" y="556"/>
+      <point x="148" y="545" type="curve"/>
+      <point x="104" y="530"/>
       <point x="62" y="492"/>
       <point x="62" y="447" type="curve" smooth="yes"/>
       <point x="62" y="387"/>
-      <point x="107" y="342"/>
+      <point x="110" y="342"/>
     </contour>
     <contour>
-      <point x="189" y="389" type="curve" smooth="yes"/>
-      <point x="143" y="389"/>
-      <point x="114" y="410"/>
-      <point x="114" y="451" type="curve" smooth="yes"/>
-      <point x="114" y="498"/>
-      <point x="150" y="520"/>
-      <point x="198" y="520" type="curve" smooth="yes"/>
-      <point x="247" y="520"/>
-      <point x="273" y="501"/>
-      <point x="273" y="462" type="curve" smooth="yes"/>
-      <point x="273" y="412"/>
-      <point x="238" y="389"/>
+      <point x="188" y="390" type="curve" smooth="yes"/>
+      <point x="147" y="390"/>
+      <point x="116" y="412"/>
+      <point x="116" y="446" type="curve" smooth="yes"/>
+      <point x="116" y="489"/>
+      <point x="155" y="517"/>
+      <point x="198" y="517" type="curve" smooth="yes"/>
+      <point x="243" y="517"/>
+      <point x="271" y="492"/>
+      <point x="271" y="459" type="curve" smooth="yes"/>
+      <point x="271" y="414"/>
+      <point x="233" y="390"/>
     </contour>
     <contour>
-      <point x="214" y="564" type="curve" smooth="yes"/>
-      <point x="178" y="564"/>
-      <point x="157" y="581"/>
-      <point x="157" y="614" type="curve" smooth="yes"/>
-      <point x="157" y="656"/>
-      <point x="185" y="675"/>
-      <point x="227" y="675" type="curve" smooth="yes"/>
-      <point x="262" y="675"/>
-      <point x="287" y="658"/>
+      <point x="213" y="561" type="curve" smooth="yes"/>
+      <point x="182" y="561"/>
+      <point x="157" y="580"/>
+      <point x="157" y="611" type="curve" smooth="yes"/>
+      <point x="157" y="649"/>
+      <point x="190" y="676"/>
+      <point x="228" y="676" type="curve" smooth="yes"/>
+      <point x="262" y="676"/>
+      <point x="287" y="655"/>
       <point x="287" y="626" type="curve" smooth="yes"/>
-      <point x="287" y="586"/>
-      <point x="257" y="564"/>
+      <point x="287" y="583"/>
+      <point x="252" y="561"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="413" y="228" type="curve" smooth="yes"/>
-      <point x="452" y="228"/>
-      <point x="485" y="249"/>
-      <point x="485" y="289" type="curve" smooth="yes"/>
-      <point x="485" y="319"/>
-      <point x="461" y="341"/>
-      <point x="422" y="341" type="curve" smooth="yes"/>
-      <point x="384" y="341"/>
-      <point x="350" y="316"/>
-      <point x="350" y="278" type="curve" smooth="yes"/>
-      <point x="350" y="247"/>
-      <point x="377" y="228"/>
+      <point x="414" y="233" type="curve" smooth="yes"/>
+      <point x="449" y="233"/>
+      <point x="479" y="253"/>
+      <point x="479" y="290" type="curve" smooth="yes"/>
+      <point x="479" y="318"/>
+      <point x="457" y="338"/>
+      <point x="422" y="338" type="curve" smooth="yes"/>
+      <point x="387" y="338"/>
+      <point x="356" y="315"/>
+      <point x="356" y="280" type="curve" smooth="yes"/>
+      <point x="356" y="251"/>
+      <point x="381" y="233"/>
     </contour>
     <contour>
       <point x="402" y="169" type="curve" smooth="yes"/>
-      <point x="331" y="169"/>
-      <point x="283" y="214"/>
-      <point x="283" y="274" type="curve" smooth="yes"/>
-      <point x="283" y="319"/>
+      <point x="327" y="169"/>
+      <point x="279" y="214"/>
+      <point x="279" y="274" type="curve" smooth="yes"/>
+      <point x="279" y="319"/>
       <point x="316" y="355"/>
       <point x="357" y="372" type="curve"/>
       <point x="343" y="382"/>
-      <point x="324" y="405"/>
-      <point x="324" y="435" type="curve" smooth="yes"/>
-      <point x="324" y="498"/>
-      <point x="380" y="551"/>
+      <point x="320" y="405"/>
+      <point x="320" y="435" type="curve" smooth="yes"/>
+      <point x="320" y="498"/>
+      <point x="376" y="551"/>
       <point x="460" y="551" type="curve" smooth="yes"/>
-      <point x="517" y="551"/>
-      <point x="568" y="516"/>
-      <point x="568" y="460" type="curve" smooth="yes"/>
-      <point x="568" y="421"/>
+      <point x="522" y="551"/>
+      <point x="573" y="516"/>
+      <point x="573" y="460" type="curve" smooth="yes"/>
+      <point x="573" y="421"/>
       <point x="544" y="388"/>
       <point x="512" y="370" type="curve"/>
       <point x="537" y="353"/>
-      <point x="551" y="326"/>
-      <point x="551" y="294" type="curve" smooth="yes"/>
-      <point x="551" y="217"/>
-      <point x="484" y="169"/>
+      <point x="556" y="326"/>
+      <point x="556" y="294" type="curve" smooth="yes"/>
+      <point x="556" y="217"/>
+      <point x="489" y="169"/>
     </contour>
     <contour>
-      <point x="438" y="395" type="curve" smooth="yes"/>
-      <point x="471" y="395"/>
-      <point x="501" y="414"/>
-      <point x="501" y="450" type="curve" smooth="yes"/>
-      <point x="501" y="474"/>
-      <point x="480" y="492"/>
-      <point x="451" y="492" type="curve" smooth="yes"/>
-      <point x="419" y="492"/>
-      <point x="391" y="469"/>
-      <point x="391" y="437" type="curve" smooth="yes"/>
-      <point x="391" y="411"/>
-      <point x="412" y="395"/>
+      <point x="438" y="396" type="curve" smooth="yes"/>
+      <point x="470" y="396"/>
+      <point x="499" y="414"/>
+      <point x="499" y="448" type="curve" smooth="yes"/>
+      <point x="499" y="471"/>
+      <point x="479" y="488"/>
+      <point x="450" y="488" type="curve" smooth="yes"/>
+      <point x="420" y="488"/>
+      <point x="393" y="467"/>
+      <point x="393" y="435" type="curve" smooth="yes"/>
+      <point x="393" y="411"/>
+      <point x="414" y="396"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="414" y="233" type="curve" smooth="yes"/>
-      <point x="449" y="233"/>
-      <point x="479" y="253"/>
-      <point x="479" y="290" type="curve" smooth="yes"/>
-      <point x="479" y="318"/>
-      <point x="457" y="338"/>
-      <point x="422" y="338" type="curve" smooth="yes"/>
-      <point x="387" y="338"/>
-      <point x="356" y="315"/>
-      <point x="356" y="280" type="curve" smooth="yes"/>
-      <point x="356" y="251"/>
-      <point x="381" y="233"/>
+      <point x="412.0" y="209" type="curve" smooth="yes"/>
+      <point x="459" y="209"/>
+      <point x="499.0" y="235"/>
+      <point x="499.0" y="281" type="curve" smooth="yes"/>
+      <point x="499.0" y="321"/>
+      <point x="466.0" y="348"/>
+      <point x="422.0" y="348" type="curve" smooth="yes"/>
+      <point x="379.0" y="348"/>
+      <point x="336.0" y="317"/>
+      <point x="336.0" y="273" type="curve"/>
+      <point x="336.0" y="233"/>
+      <point x="369" y="209"/>
     </contour>
     <contour>
-      <point x="402" y="169" type="curve" smooth="yes"/>
-      <point x="327" y="169"/>
-      <point x="279" y="214"/>
-      <point x="279" y="274" type="curve" smooth="yes"/>
-      <point x="279" y="319"/>
-      <point x="316" y="355"/>
-      <point x="357" y="372" type="curve"/>
-      <point x="343" y="382"/>
-      <point x="320" y="405"/>
-      <point x="320" y="435" type="curve" smooth="yes"/>
-      <point x="320" y="498"/>
-      <point x="376" y="551"/>
-      <point x="460" y="551" type="curve" smooth="yes"/>
-      <point x="522" y="551"/>
-      <point x="573" y="516"/>
-      <point x="573" y="460" type="curve" smooth="yes"/>
-      <point x="573" y="421"/>
-      <point x="544" y="388"/>
-      <point x="512" y="370" type="curve"/>
-      <point x="537" y="353"/>
-      <point x="556" y="326"/>
-      <point x="556" y="294" type="curve" smooth="yes"/>
-      <point x="556" y="217"/>
-      <point x="489" y="169"/>
+      <point x="403" y="169.0" type="curve" smooth="yes"/>
+      <point x="334" y="169.0"/>
+      <point x="288" y="214.0"/>
+      <point x="288" y="274.0" type="curve" smooth="yes"/>
+      <point x="288" y="319.0"/>
+      <point x="325" y="353.0"/>
+      <point x="375" y="369.0" type="curve"/>
+      <point x="349" y="380.0"/>
+      <point x="327" y="405.0"/>
+      <point x="327" y="435.0" type="curve" smooth="yes"/>
+      <point x="327" y="498.0"/>
+      <point x="382" y="551.0"/>
+      <point x="460" y="551.0" type="curve" smooth="yes"/>
+      <point x="515" y="551.0"/>
+      <point x="564" y="516.0"/>
+      <point x="564" y="460.0" type="curve" smooth="yes"/>
+      <point x="564" y="421.0"/>
+      <point x="536" y="387.0"/>
+      <point x="494" y="369.0" type="curve"/>
+      <point x="526" y="352.0"/>
+      <point x="548" y="326.0"/>
+      <point x="548" y="294.0" type="curve" smooth="yes"/>
+      <point x="548" y="217.0"/>
+      <point x="482" y="169.0"/>
     </contour>
     <contour>
-      <point x="438" y="396" type="curve" smooth="yes"/>
-      <point x="470" y="396"/>
-      <point x="499" y="414"/>
-      <point x="499" y="448" type="curve" smooth="yes"/>
-      <point x="499" y="471"/>
-      <point x="479" y="488"/>
-      <point x="450" y="488" type="curve" smooth="yes"/>
-      <point x="420" y="488"/>
-      <point x="393" y="467"/>
-      <point x="393" y="435" type="curve" smooth="yes"/>
-      <point x="393" y="411"/>
-      <point x="414" y="396"/>
+      <point x="436.0" y="386.0" type="curve" smooth="yes"/>
+      <point x="480.0" y="386.0"/>
+      <point x="521.0" y="410"/>
+      <point x="521.0" y="456" type="curve" smooth="yes"/>
+      <point x="521.0" y="487"/>
+      <point x="492.0" y="510"/>
+      <point x="454.0" y="510" type="curve" smooth="yes"/>
+      <point x="411.0" y="510"/>
+      <point x="374.0" y="481"/>
+      <point x="374.0" y="440" type="curve" smooth="yes"/>
+      <point x="374.0" y="407"/>
+      <point x="402.0" y="386.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.numerator.glif
@@ -5,31 +5,31 @@
     <contour>
       <point x="177" y="343" type="curve" smooth="yes"/>
       <point x="261" y="343"/>
-      <point x="324" y="400"/>
-      <point x="324" y="485" type="curve" smooth="yes"/>
-      <point x="324" y="555"/>
-      <point x="280" y="595"/>
-      <point x="224" y="595" type="curve" smooth="yes"/>
-      <point x="192" y="595"/>
-      <point x="161" y="580"/>
-      <point x="148" y="567" type="curve"/>
-      <point x="178" y="665" type="line"/>
-      <point x="340" y="665" type="line"/>
+      <point x="327" y="400"/>
+      <point x="327" y="485" type="curve" smooth="yes"/>
+      <point x="327" y="555"/>
+      <point x="285" y="595"/>
+      <point x="229" y="595.0" type="curve" smooth="yes"/>
+      <point x="200" y="595"/>
+      <point x="163" y="583"/>
+      <point x="147" y="570" type="curve"/>
+      <point x="175" y="667" type="line"/>
+      <point x="339" y="667" type="line"/>
       <point x="348" y="716" type="line"/>
-      <point x="146" y="716" type="line"/>
-      <point x="88" y="527" type="line"/>
-      <point x="132" y="505" type="line"/>
-      <point x="146" y="530.0"/>
-      <point x="171" y="549"/>
-      <point x="208" y="549" type="curve" smooth="yes"/>
-      <point x="245" y="549"/>
-      <point x="271" y="527"/>
-      <point x="271.0" y="474" type="curve" smooth="yes"/>
-      <point x="271" y="422"/>
-      <point x="234" y="390"/>
+      <point x="144" y="716" type="line"/>
+      <point x="86" y="527" type="line"/>
+      <point x="128" y="509" type="line"/>
+      <point x="144" y="532"/>
+      <point x="177" y="551.0"/>
+      <point x="210" y="551.0" type="curve" smooth="yes"/>
+      <point x="246" y="551"/>
+      <point x="273" y="522"/>
+      <point x="273" y="480" type="curve" smooth="yes"/>
+      <point x="273.0" y="424.0"/>
+      <point x="233" y="390"/>
       <point x="183" y="390" type="curve" smooth="yes"/>
-      <point x="147" y="390"/>
-      <point x="113" y="405"/>
+      <point x="144.0" y="390"/>
+      <point x="111.0" y="414.0"/>
       <point x="104" y="451" type="curve"/>
       <point x="56" y="434" type="line"/>
       <point x="66" y="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -19,35 +19,35 @@
     </contour>
     <contour>
       <point x="396" y="168" type="curve" smooth="yes"/>
-      <point x="343" y="168"/>
-      <point x="285" y="194"/>
-      <point x="275" y="259" type="curve"/>
-      <point x="337" y="281" type="line"/>
-      <point x="344" y="248"/>
-      <point x="366" y="227"/>
-      <point x="402" y="227" type="curve" smooth="yes"/>
-      <point x="443" y="227"/>
-      <point x="480" y="262"/>
-      <point x="480" y="305" type="curve" smooth="yes"/>
-      <point x="480" y="342"/>
-      <point x="455" y="364"/>
-      <point x="422" y="364" type="curve" smooth="yes"/>
-      <point x="394" y="364"/>
-      <point x="373" y="353"/>
-      <point x="355" y="329" type="curve"/>
-      <point x="302" y="352" type="line"/>
-      <point x="360" y="541" type="line"/>
-      <point x="567" y="541" type="line"/>
-      <point x="558" y="485" type="line"/>
-      <point x="406" y="485" type="line"/>
-      <point x="378" y="399" type="line"/>
-      <point x="394" y="412"/>
-      <point x="419" y="420"/>
-      <point x="443" y="420" type="curve" smooth="yes"/>
-      <point x="504" y="420"/>
-      <point x="548" y="380"/>
-      <point x="548" y="310" type="curve" smooth="yes"/>
-      <point x="548" y="225"/>
+      <point x="339" y="168"/>
+      <point x="282" y="194"/>
+      <point x="270" y="261" type="curve"/>
+      <point x="341" y="285" type="line"/>
+      <point x="348" y="252"/>
+      <point x="370" y="234"/>
+      <point x="402" y="234" type="curve" smooth="yes"/>
+      <point x="441" y="234"/>
+      <point x="474" y="262"/>
+      <point x="474" y="305" type="curve" smooth="yes"/>
+      <point x="474" y="339"/>
+      <point x="450" y="360"/>
+      <point x="422" y="360" type="curve" smooth="yes"/>
+      <point x="394" y="360"/>
+      <point x="373" y="343"/>
+      <point x="359" y="324" type="curve"/>
+      <point x="299" y="352" type="line"/>
+      <point x="357" y="541" type="line"/>
+      <point x="572" y="541" type="line"/>
+      <point x="561" y="477" type="line"/>
+      <point x="410" y="477" type="line"/>
+      <point x="388" y="406" type="line"/>
+      <point x="400" y="416"/>
+      <point x="419" y="424"/>
+      <point x="443" y="424" type="curve" smooth="yes"/>
+      <point x="504" y="424"/>
+      <point x="551" y="380"/>
+      <point x="551" y="310" type="curve" smooth="yes"/>
+      <point x="551" y="225"/>
       <point x="480" y="168"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -19,35 +19,35 @@
     </contour>
     <contour>
       <point x="396" y="168" type="curve" smooth="yes"/>
-      <point x="339" y="168"/>
-      <point x="282" y="194"/>
-      <point x="270" y="261" type="curve"/>
-      <point x="341" y="285" type="line"/>
-      <point x="348" y="252"/>
-      <point x="370" y="234"/>
-      <point x="402" y="234" type="curve" smooth="yes"/>
-      <point x="441" y="234"/>
-      <point x="474" y="262"/>
-      <point x="474" y="305" type="curve" smooth="yes"/>
-      <point x="474" y="339"/>
-      <point x="450" y="360"/>
-      <point x="422" y="360" type="curve" smooth="yes"/>
-      <point x="394" y="360"/>
-      <point x="373" y="343"/>
-      <point x="359" y="324" type="curve"/>
-      <point x="299" y="352" type="line"/>
-      <point x="357" y="541" type="line"/>
-      <point x="572" y="541" type="line"/>
-      <point x="561" y="477" type="line"/>
-      <point x="410" y="477" type="line"/>
-      <point x="388" y="406" type="line"/>
-      <point x="400" y="416"/>
-      <point x="419" y="424"/>
-      <point x="443" y="424" type="curve" smooth="yes"/>
-      <point x="504" y="424"/>
-      <point x="551" y="380"/>
-      <point x="551" y="310" type="curve" smooth="yes"/>
-      <point x="551" y="225"/>
+      <point x="343" y="168"/>
+      <point x="285" y="194"/>
+      <point x="275" y="259" type="curve"/>
+      <point x="316" y="274.0" type="line"/>
+      <point x="326" y="232.0"/>
+      <point x="355" y="209"/>
+      <point x="400" y="209.0" type="curve" smooth="yes"/>
+      <point x="453" y="209.0"/>
+      <point x="498.0" y="246.0"/>
+      <point x="498" y="305.0" type="curve" smooth="yes"/>
+      <point x="498" y="350"/>
+      <point x="467" y="379"/>
+      <point x="435" y="379.0" type="curve" smooth="yes"/>
+      <point x="400" y="379.0"/>
+      <point x="361" y="362.0"/>
+      <point x="342" y="335.0" type="curve"/>
+      <point x="306" y="352" type="line"/>
+      <point x="364" y="541" type="line"/>
+      <point x="567" y="541" type="line"/>
+      <point x="560" y="500" type="line"/>
+      <point x="392" y="500" type="line"/>
+      <point x="358" y="385" type="line"/>
+      <point x="378" y="406"/>
+      <point x="411" y="420"/>
+      <point x="443" y="420" type="curve" smooth="yes"/>
+      <point x="504" y="420"/>
+      <point x="548" y="380"/>
+      <point x="548" y="310" type="curve" smooth="yes"/>
+      <point x="548" y="225"/>
       <point x="480" y="168"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="342"/>
   <outline>
     <contour>
-      <point x="60" y="434" type="line"/>
-      <point x="345" y="434" type="line"/>
-      <point x="352" y="476" type="line"/>
-      <point x="128" y="476" type="line"/>
-      <point x="263" y="629" type="line"/>
-      <point x="269" y="629" type="line"/>
-      <point x="218" y="350" type="line"/>
+      <point x="60" y="430" type="line"/>
+      <point x="345" y="430" type="line"/>
+      <point x="353" y="480" type="line"/>
+      <point x="131" y="480" type="line"/>
+      <point x="260" y="631" type="line"/>
+      <point x="268" y="631" type="line"/>
+      <point x="220" y="350" type="line"/>
       <point x="271" y="350" type="line"/>
       <point x="336" y="716" type="line"/>
       <point x="285" y="716" type="line"/>
-      <point x="65" y="468" type="line"/>
+      <point x="69" y="474" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="336" y="305" type="line"/>
-      <point x="434" y="305" type="line"/>
-      <point x="457" y="437" type="line"/>
-      <point x="453" y="437" type="line"/>
+      <point x="345" y="309" type="line"/>
+      <point x="430" y="309" type="line"/>
+      <point x="450" y="424" type="line"/>
+      <point x="447" y="424" type="line"/>
     </contour>
     <contour>
-      <point x="411" y="175" type="line"/>
-      <point x="424" y="249" type="line"/>
-      <point x="253" y="249" type="line"/>
-      <point x="260" y="293" type="line"/>
-      <point x="480" y="541" type="line"/>
-      <point x="541" y="541" type="line"/>
-      <point x="499" y="305" type="line"/>
-      <point x="548" y="305" type="line"/>
-      <point x="538" y="249" type="line"/>
-      <point x="489" y="249" type="line"/>
-      <point x="476" y="175" type="line"/>
+      <point x="406" y="175" type="line"/>
+      <point x="418" y="246" type="line"/>
+      <point x="249" y="246" type="line"/>
+      <point x="260" y="303" type="line"/>
+      <point x="475" y="541" type="line"/>
+      <point x="547" y="541" type="line"/>
+      <point x="506" y="309" type="line"/>
+      <point x="555" y="309" type="line"/>
+      <point x="543" y="246" type="line"/>
+      <point x="494" y="246" type="line"/>
+      <point x="482" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="345" y="309" type="line"/>
-      <point x="430" y="309" type="line"/>
-      <point x="450" y="424" type="line"/>
-      <point x="447" y="424" type="line"/>
+      <point x="321" y="300" type="line"/>
+      <point x="438" y="300" type="line"/>
+      <point x="467" y="458" type="line"/>
+      <point x="460" y="458" type="line"/>
     </contour>
     <contour>
-      <point x="406" y="175" type="line"/>
-      <point x="418" y="246" type="line"/>
-      <point x="249" y="246" type="line"/>
-      <point x="260" y="303" type="line"/>
-      <point x="475" y="541" type="line"/>
-      <point x="547" y="541" type="line"/>
-      <point x="506" y="309" type="line"/>
-      <point x="555" y="309" type="line"/>
-      <point x="543" y="246" type="line"/>
-      <point x="494" y="246" type="line"/>
-      <point x="482" y="175" type="line"/>
+      <point x="417" y="175" type="line"/>
+      <point x="430" y="256" type="line"/>
+      <point x="255" y="256" type="line"/>
+      <point x="262" y="293" type="line"/>
+      <point x="486" y="541" type="line"/>
+      <point x="531" y="541" type="line"/>
+      <point x="487" y="300" type="line"/>
+      <point x="546" y="300" type="line"/>
+      <point x="538" y="256" type="line"/>
+      <point x="479" y="256" type="line"/>
+      <point x="466" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="315"/>
   <outline>
     <contour>
-      <point x="151" y="334" type="line"/>
-      <point x="196" y="383"/>
-      <point x="243" y="432"/>
-      <point x="287" y="482" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="346" y="564"/>
-      <point x="346" y="614" type="curve" smooth="yes"/>
-      <point x="346" y="673"/>
-      <point x="302" y="724"/>
-      <point x="235" y="724" type="curve" smooth="yes"/>
-      <point x="152" y="724"/>
-      <point x="88" y="664"/>
-      <point x="88" y="579" type="curve" smooth="yes"/>
-      <point x="88" y="525"/>
-      <point x="130" y="479"/>
-      <point x="193" y="479" type="curve" smooth="yes"/>
-      <point x="201" y="479"/>
-      <point x="228" y="483"/>
-      <point x="234" y="487" type="curve"/>
-      <point x="199" y="450"/>
-      <point x="150" y="401"/>
-      <point x="115" y="364" type="curve"/>
+      <point x="152.0" y="334.0" type="line"/>
+      <point x="197.0" y="383.0"/>
+      <point x="242.0" y="433.0"/>
+      <point x="285.0" y="482.0" type="curve" smooth="yes"/>
+      <point x="331.0" y="533.0"/>
+      <point x="347.0" y="564.0"/>
+      <point x="347.0" y="614.0" type="curve" smooth="yes"/>
+      <point x="347.0" y="673.0"/>
+      <point x="300.0" y="724.0"/>
+      <point x="235.0" y="724.0" type="curve" smooth="yes"/>
+      <point x="156.0" y="724.0"/>
+      <point x="89.0" y="664.0"/>
+      <point x="89.0" y="579.0" type="curve" smooth="yes"/>
+      <point x="89.0" y="525.0"/>
+      <point x="124.0" y="474.0"/>
+      <point x="179.0" y="474.0" type="curve" smooth="yes"/>
+      <point x="195.0" y="474.0"/>
+      <point x="219.0" y="479.0"/>
+      <point x="227.0" y="482.0" type="curve"/>
+      <point x="196.0" y="449.0"/>
+      <point x="150.0" y="404.0"/>
+      <point x="115.0" y="367.0" type="curve"/>
     </contour>
     <contour>
-      <point x="208" y="520" type="curve" smooth="yes"/>
-      <point x="161" y="520"/>
-      <point x="141" y="546"/>
-      <point x="141" y="591" type="curve" smooth="yes"/>
-      <point x="141" y="641"/>
-      <point x="178" y="675"/>
-      <point x="226" y="675" type="curve" smooth="yes"/>
-      <point x="273" y="675"/>
-      <point x="295" y="650"/>
-      <point x="295" y="607" type="curve" smooth="yes"/>
-      <point x="295" y="556"/>
-      <point x="263" y="520"/>
+      <point x="208.0" y="520.0" type="curve" smooth="yes"/>
+      <point x="166.0" y="520.0"/>
+      <point x="143.0" y="551.0"/>
+      <point x="143.0" y="590.0" type="curve" smooth="yes"/>
+      <point x="143.0" y="635.0"/>
+      <point x="185.0" y="675.0"/>
+      <point x="228.0" y="675.0" type="curve" smooth="yes"/>
+      <point x="270.0" y="675.0"/>
+      <point x="295.0" y="645.0"/>
+      <point x="295.0" y="608.0" type="curve" smooth="yes"/>
+      <point x="295.0" y="562.0"/>
+      <point x="258.0" y="520.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="379.0" y="155.0" type="curve"/>
-      <point x="325.0" y="201.0" type="line"/>
-      <point x="356.0" y="237.0"/>
-      <point x="405.0" y="285.0"/>
-      <point x="430.0" y="303.0" type="curve"/>
-      <point x="424.0" y="299.0"/>
-      <point x="415.0" y="298.0"/>
-      <point x="407.0" y="298.0" type="curve" smooth="yes"/>
-      <point x="346.0" y="298.0"/>
-      <point x="305.0" y="351.0"/>
-      <point x="305.0" y="405.0" type="curve" smooth="yes"/>
-      <point x="305.0" y="490.0"/>
-      <point x="376.0" y="550.0"/>
-      <point x="461.0" y="550.0" type="curve" smooth="yes"/>
-      <point x="530.0" y="550.0"/>
-      <point x="582.0" y="498.0"/>
-      <point x="582.0" y="439.0" type="curve" smooth="yes"/>
-      <point x="582.0" y="389.0"/>
-      <point x="568.0" y="355.0"/>
-      <point x="519.0" y="304.0" type="curve" smooth="yes"/>
-      <point x="472.0" y="255.0"/>
-      <point x="424.0" y="204.0"/>
+      <point x="377" y="159" type="curve"/>
+      <point x="343" y="188" type="line"/>
+      <point x="378" y="225"/>
+      <point x="435" y="281"/>
+      <point x="471" y="315" type="curve"/>
+      <point x="456" y="305"/>
+      <point x="431" y="301"/>
+      <point x="412" y="301" type="curve" smooth="yes"/>
+      <point x="347.0" y="301.0"/>
+      <point x="309.0" y="351.0"/>
+      <point x="309" y="404" type="curve" smooth="yes"/>
+      <point x="309" y="489"/>
+      <point x="378" y="549"/>
+      <point x="461" y="549" type="curve" smooth="yes"/>
+      <point x="528" y="549"/>
+      <point x="577" y="498"/>
+      <point x="577" y="439" type="curve" smooth="yes"/>
+      <point x="577" y="389"/>
+      <point x="560" y="358"/>
+      <point x="513" y="307" type="curve" smooth="yes"/>
+      <point x="468" y="258"/>
+      <point x="422" y="208"/>
     </contour>
     <contour>
-      <point x="435.0" y="361.0" type="curve" smooth="yes"/>
-      <point x="477.0" y="361.0"/>
-      <point x="505.0" y="394.0"/>
-      <point x="505.0" y="432.0" type="curve" smooth="yes"/>
-      <point x="505.0" y="463.0"/>
-      <point x="486.0" y="486.0"/>
-      <point x="452.0" y="486.0" type="curve" smooth="yes"/>
-      <point x="416.0" y="486.0"/>
-      <point x="383.0" y="454.0"/>
-      <point x="383.0" y="417.0" type="curve" smooth="yes"/>
-      <point x="383.0" y="385.0"/>
-      <point x="400.0" y="361.0"/>
+      <point x="431" y="338" type="curve" smooth="yes"/>
+      <point x="489" y="338"/>
+      <point x="530" y="383"/>
+      <point x="530" y="434" type="curve" smooth="yes"/>
+      <point x="530" y="476"/>
+      <point x="502" y="507"/>
+      <point x="454" y="507" type="curve" smooth="yes"/>
+      <point x="405" y="507"/>
+      <point x="358" y="465"/>
+      <point x="358" y="414" type="curve" smooth="yes"/>
+      <point x="358" y="370"/>
+      <point x="384" y="338"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="377" y="161" type="curve"/>
-      <point x="333" y="197" type="line"/>
-      <point x="368" y="234"/>
-      <point x="403" y="270"/>
-      <point x="438" y="307" type="curve"/>
-      <point x="431" y="303"/>
-      <point x="420" y="301"/>
-      <point x="412" y="301" type="curve" smooth="yes"/>
-      <point x="349" y="301"/>
-      <point x="309" y="352"/>
-      <point x="309" y="406" type="curve" smooth="yes"/>
-      <point x="309" y="491"/>
-      <point x="378" y="551"/>
-      <point x="461" y="551" type="curve" smooth="yes"/>
-      <point x="528" y="551"/>
-      <point x="577" y="500"/>
-      <point x="577" y="441" type="curve" smooth="yes"/>
-      <point x="577" y="391"/>
-      <point x="561" y="361"/>
-      <point x="512" y="308" type="curve" smooth="yes"/>
-      <point x="467" y="259"/>
-      <point x="422" y="210"/>
+      <point x="379.0" y="155.0" type="curve"/>
+      <point x="325.0" y="201.0" type="line"/>
+      <point x="356.0" y="237.0"/>
+      <point x="405.0" y="285.0"/>
+      <point x="430.0" y="303.0" type="curve"/>
+      <point x="424.0" y="299.0"/>
+      <point x="415.0" y="298.0"/>
+      <point x="407.0" y="298.0" type="curve" smooth="yes"/>
+      <point x="346.0" y="298.0"/>
+      <point x="305.0" y="351.0"/>
+      <point x="305.0" y="405.0" type="curve" smooth="yes"/>
+      <point x="305.0" y="490.0"/>
+      <point x="376.0" y="550.0"/>
+      <point x="461.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="530.0" y="550.0"/>
+      <point x="582.0" y="498.0"/>
+      <point x="582.0" y="439.0" type="curve" smooth="yes"/>
+      <point x="582.0" y="389.0"/>
+      <point x="568.0" y="355.0"/>
+      <point x="519.0" y="304.0" type="curve" smooth="yes"/>
+      <point x="472.0" y="255.0"/>
+      <point x="424.0" y="204.0"/>
     </contour>
     <contour>
-      <point x="434" y="357" type="curve" smooth="yes"/>
-      <point x="479" y="357"/>
-      <point x="511" y="393"/>
-      <point x="511" y="434" type="curve" smooth="yes"/>
-      <point x="511" y="467"/>
-      <point x="489" y="492"/>
-      <point x="452" y="492" type="curve" smooth="yes"/>
-      <point x="414" y="492"/>
-      <point x="377" y="458"/>
-      <point x="377" y="418" type="curve" smooth="yes"/>
-      <point x="377" y="383"/>
-      <point x="397" y="357"/>
+      <point x="435.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="477.0" y="361.0"/>
+      <point x="505.0" y="394.0"/>
+      <point x="505.0" y="432.0" type="curve" smooth="yes"/>
+      <point x="505.0" y="463.0"/>
+      <point x="486.0" y="486.0"/>
+      <point x="452.0" y="486.0" type="curve" smooth="yes"/>
+      <point x="416.0" y="486.0"/>
+      <point x="383.0" y="454.0"/>
+      <point x="383.0" y="417.0" type="curve" smooth="yes"/>
+      <point x="383.0" y="385.0"/>
+      <point x="400.0" y="361.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.numerator.glif
@@ -4,12 +4,12 @@
   <outline>
     <contour>
       <point x="135" y="350" type="line"/>
-      <point x="192" y="350" type="line"/>
-      <point x="257" y="716" type="line"/>
+      <point x="187" y="350" type="line"/>
+      <point x="252" y="716" type="line"/>
       <point x="209" y="716" type="line"/>
       <point x="97" y="637" type="line"/>
-      <point x="123" y="596" type="line"/>
-      <point x="187" y="640" type="line"/>
+      <point x="123" y="597" type="line"/>
+      <point x="187" y="643" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="359" y="176" type="line"/>
-      <point x="405" y="436" type="line"/>
-      <point x="358" y="401" type="line"/>
-      <point x="318" y="463" type="line"/>
-      <point x="430" y="542" type="line"/>
-      <point x="509" y="542" type="line"/>
-      <point x="444" y="176" type="line"/>
+      <point x="382" y="176" type="line"/>
+      <point x="438" y="488" type="line"/>
+      <point x="354" y="427" type="line"/>
+      <point x="331" y="463" type="line"/>
+      <point x="444" y="542" type="line"/>
+      <point x="493" y="542" type="line"/>
+      <point x="428" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="369" y="176" type="line"/>
-      <point x="418" y="455" type="line"/>
-      <point x="362" y="414" type="line"/>
-      <point x="331" y="463" type="line"/>
-      <point x="443" y="542" type="line"/>
-      <point x="499" y="542" type="line"/>
-      <point x="434" y="176" type="line"/>
+      <point x="359" y="176" type="line"/>
+      <point x="405" y="436" type="line"/>
+      <point x="358" y="401" type="line"/>
+      <point x="318" y="463" type="line"/>
+      <point x="430" y="542" type="line"/>
+      <point x="509" y="542" type="line"/>
+      <point x="444" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.numerator.glif
@@ -5,15 +5,15 @@
     <contour>
       <point x="110" y="335" type="line"/>
       <point x="188" y="444"/>
-      <point x="265" y="552"/>
-      <point x="343" y="661" type="curve"/>
+      <point x="268" y="563"/>
+      <point x="346" y="672" type="curve"/>
       <point x="353" y="716" type="line"/>
       <point x="105" y="716" type="line"/>
-      <point x="97" y="667" type="line"/>
-      <point x="288" y="667" type="line"/>
-      <point x="219" y="571"/>
-      <point x="140" y="460"/>
-      <point x="70" y="364" type="curve"/>
+      <point x="105" y="664" type="line"/>
+      <point x="283" y="664" type="line"/>
+      <point x="214" y="568"/>
+      <point x="136" y="462"/>
+      <point x="67" y="366" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="345" y="161" type="curve"/>
-      <point x="297" y="195" type="line"/>
-      <point x="366" y="291"/>
-      <point x="436" y="387"/>
-      <point x="505" y="483" type="curve"/>
-      <point x="330" y="483" type="line"/>
+      <point x="347" y="161" type="curve"/>
+      <point x="293" y="199" type="line"/>
+      <point x="362" y="295"/>
+      <point x="424" y="378"/>
+      <point x="493" y="474" type="curve"/>
+      <point x="327" y="474" type="line"/>
       <point x="340" y="542" type="line"/>
       <point x="588" y="542" type="line"/>
-      <point x="578" y="487" type="line"/>
-      <point x="500" y="378"/>
-      <point x="423" y="270"/>
+      <point x="577" y="481" type="line"/>
+      <point x="499" y="372"/>
+      <point x="424" y="268"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="347" y="161" type="curve"/>
-      <point x="293" y="199" type="line"/>
-      <point x="362" y="295"/>
-      <point x="424" y="378"/>
-      <point x="493" y="474" type="curve"/>
-      <point x="327" y="474" type="line"/>
+      <point x="345" y="161" type="curve"/>
+      <point x="308" y="189" type="line"/>
+      <point x="377" y="285"/>
+      <point x="463" y="406"/>
+      <point x="526" y="499" type="curve"/>
+      <point x="333" y="499" type="line"/>
       <point x="340" y="542" type="line"/>
       <point x="588" y="542" type="line"/>
-      <point x="577" y="481" type="line"/>
-      <point x="499" y="372"/>
-      <point x="424" y="268"/>
+      <point x="581" y="504" type="line"/>
+      <point x="503" y="395"/>
+      <point x="423" y="270"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="314"/>
   <outline>
     <contour>
-      <point x="177" y="342" type="curve" smooth="yes"/>
-      <point x="260" y="342"/>
-      <point x="324" y="402"/>
-      <point x="324" y="487" type="curve" smooth="yes"/>
-      <point x="324" y="541"/>
-      <point x="282" y="587"/>
-      <point x="219" y="587" type="curve" smooth="yes"/>
-      <point x="211" y="587"/>
-      <point x="184" y="583"/>
-      <point x="178" y="579" type="curve"/>
-      <point x="213" y="616"/>
-      <point x="262" y="665"/>
-      <point x="297" y="702" type="curve"/>
+      <point x="178" y="342.0" type="curve" smooth="yes"/>
+      <point x="257" y="342.0"/>
+      <point x="324" y="402.0"/>
+      <point x="324" y="487.0" type="curve" smooth="yes"/>
+      <point x="324" y="541.0"/>
+      <point x="289" y="592"/>
+      <point x="234" y="592.0" type="curve" smooth="yes"/>
+      <point x="218" y="592"/>
+      <point x="194" y="587"/>
+      <point x="186" y="583" type="curve"/>
+      <point x="217" y="617"/>
+      <point x="263" y="662"/>
+      <point x="298" y="699" type="curve"/>
       <point x="261" y="732" type="line"/>
       <point x="216" y="683"/>
-      <point x="169" y="634"/>
-      <point x="125" y="584" type="curve" smooth="yes"/>
-      <point x="79" y="532"/>
-      <point x="66" y="502"/>
-      <point x="66" y="452" type="curve" smooth="yes"/>
-      <point x="66" y="393"/>
-      <point x="110" y="342"/>
+      <point x="171" y="633.0"/>
+      <point x="128" y="584.0" type="curve" smooth="yes"/>
+      <point x="82" y="533.0"/>
+      <point x="66" y="502.0"/>
+      <point x="66" y="452.0" type="curve" smooth="yes"/>
+      <point x="66" y="393.0"/>
+      <point x="113" y="342.0"/>
     </contour>
     <contour>
-      <point x="186" y="391" type="curve" smooth="yes"/>
-      <point x="139" y="391"/>
-      <point x="117" y="416"/>
-      <point x="117" y="459" type="curve" smooth="yes"/>
-      <point x="117" y="510"/>
-      <point x="149" y="546"/>
-      <point x="204" y="546" type="curve" smooth="yes"/>
-      <point x="251" y="546"/>
-      <point x="271" y="520"/>
-      <point x="271" y="475" type="curve" smooth="yes"/>
-      <point x="271" y="425"/>
-      <point x="234" y="391"/>
+      <point x="185" y="391" type="curve" smooth="yes"/>
+      <point x="143" y="391"/>
+      <point x="118" y="421"/>
+      <point x="118" y="458" type="curve" smooth="yes"/>
+      <point x="118" y="504"/>
+      <point x="155" y="546"/>
+      <point x="205" y="546" type="curve" smooth="yes"/>
+      <point x="247" y="546"/>
+      <point x="270" y="515"/>
+      <point x="270" y="476" type="curve" smooth="yes"/>
+      <point x="270" y="431"/>
+      <point x="228" y="391"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="235" type="curve" smooth="yes"/>
-      <point x="457" y="235"/>
-      <point x="490" y="267"/>
-      <point x="490" y="304" type="curve" smooth="yes"/>
-      <point x="490" y="336"/>
-      <point x="473" y="360"/>
-      <point x="438" y="360" type="curve" smooth="yes"/>
-      <point x="396" y="360"/>
-      <point x="368" y="327"/>
-      <point x="368" y="289" type="curve" smooth="yes"/>
-      <point x="368" y="258"/>
-      <point x="387" y="235"/>
+      <point x="419" y="213" type="curve" smooth="yes"/>
+      <point x="468" y="213"/>
+      <point x="515" y="255"/>
+      <point x="515" y="306" type="curve" smooth="yes"/>
+      <point x="515" y="350"/>
+      <point x="489" y="382"/>
+      <point x="442" y="382" type="curve" smooth="yes"/>
+      <point x="384" y="382"/>
+      <point x="343" y="337"/>
+      <point x="343" y="286" type="curve" smooth="yes"/>
+      <point x="343" y="244"/>
+      <point x="371" y="213"/>
     </contour>
     <contour>
-      <point x="412" y="171.0" type="curve" smooth="yes"/>
-      <point x="343" y="171.0"/>
-      <point x="291" y="223.0"/>
-      <point x="291" y="282.0" type="curve" smooth="yes"/>
-      <point x="291" y="332.0"/>
-      <point x="305" y="366.0"/>
-      <point x="354" y="417.0" type="curve" smooth="yes"/>
-      <point x="401" y="466.0"/>
-      <point x="449" y="517"/>
-      <point x="494" y="566" type="curve"/>
-      <point x="548" y="520" type="line"/>
-      <point x="517" y="484"/>
-      <point x="468" y="436"/>
-      <point x="443" y="418" type="curve"/>
-      <point x="449" y="422"/>
-      <point x="458" y="423"/>
-      <point x="466" y="423" type="curve" smooth="yes"/>
-      <point x="527" y="423"/>
-      <point x="568" y="370.0"/>
-      <point x="568" y="316.0" type="curve" smooth="yes"/>
-      <point x="568" y="231.0"/>
-      <point x="497" y="171.0"/>
+      <point x="412" y="171" type="curve" smooth="yes"/>
+      <point x="345" y="171"/>
+      <point x="296" y="222"/>
+      <point x="296" y="281" type="curve" smooth="yes"/>
+      <point x="296" y="331"/>
+      <point x="313" y="362"/>
+      <point x="360" y="413" type="curve" smooth="yes"/>
+      <point x="405" y="462"/>
+      <point x="451" y="512"/>
+      <point x="496" y="561" type="curve"/>
+      <point x="530" y="532" type="line"/>
+      <point x="495" y="495"/>
+      <point x="438" y="439"/>
+      <point x="402" y="405" type="curve"/>
+      <point x="417" y="415"/>
+      <point x="442" y="419"/>
+      <point x="461" y="419" type="curve" smooth="yes"/>
+      <point x="526.0" y="419.0"/>
+      <point x="564.0" y="369.0"/>
+      <point x="564" y="316" type="curve" smooth="yes"/>
+      <point x="564" y="231"/>
+      <point x="495" y="171"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="421" y="230" type="curve" smooth="yes"/>
-      <point x="459" y="230"/>
-      <point x="496" y="264"/>
-      <point x="496" y="304" type="curve" smooth="yes"/>
-      <point x="496" y="339"/>
-      <point x="476" y="365"/>
-      <point x="439" y="365" type="curve" smooth="yes"/>
-      <point x="394" y="365"/>
-      <point x="362" y="329"/>
-      <point x="362" y="288" type="curve" smooth="yes"/>
-      <point x="362" y="255"/>
-      <point x="384" y="230"/>
+      <point x="421" y="235" type="curve" smooth="yes"/>
+      <point x="457" y="235"/>
+      <point x="490" y="267"/>
+      <point x="490" y="304" type="curve" smooth="yes"/>
+      <point x="490" y="336"/>
+      <point x="473" y="360"/>
+      <point x="438" y="360" type="curve" smooth="yes"/>
+      <point x="396" y="360"/>
+      <point x="368" y="327"/>
+      <point x="368" y="289" type="curve" smooth="yes"/>
+      <point x="368" y="258"/>
+      <point x="387" y="235"/>
     </contour>
     <contour>
-      <point x="412" y="171" type="curve" smooth="yes"/>
-      <point x="345" y="171"/>
-      <point x="296" y="222"/>
-      <point x="296" y="281" type="curve" smooth="yes"/>
-      <point x="296" y="331"/>
-      <point x="313" y="362"/>
-      <point x="360" y="413" type="curve" smooth="yes"/>
-      <point x="405" y="462"/>
-      <point x="451" y="512"/>
-      <point x="496" y="561" type="curve"/>
-      <point x="540" y="525" type="line"/>
-      <point x="505" y="488"/>
-      <point x="471" y="452"/>
-      <point x="436" y="415" type="curve"/>
-      <point x="442" y="419"/>
-      <point x="453" y="421"/>
-      <point x="461" y="421" type="curve" smooth="yes"/>
-      <point x="524" y="421"/>
-      <point x="564" y="370"/>
-      <point x="564" y="316" type="curve" smooth="yes"/>
-      <point x="564" y="231"/>
-      <point x="495" y="171"/>
+      <point x="412" y="171.0" type="curve" smooth="yes"/>
+      <point x="343" y="171.0"/>
+      <point x="291" y="223.0"/>
+      <point x="291" y="282.0" type="curve" smooth="yes"/>
+      <point x="291" y="332.0"/>
+      <point x="305" y="366.0"/>
+      <point x="354" y="417.0" type="curve" smooth="yes"/>
+      <point x="401" y="466.0"/>
+      <point x="449" y="517"/>
+      <point x="494" y="566" type="curve"/>
+      <point x="548" y="520" type="line"/>
+      <point x="517" y="484"/>
+      <point x="468" y="436"/>
+      <point x="443" y="418" type="curve"/>
+      <point x="449" y="422"/>
+      <point x="458" y="423"/>
+      <point x="466" y="423" type="curve" smooth="yes"/>
+      <point x="527" y="423"/>
+      <point x="568" y="370.0"/>
+      <point x="568" y="316.0" type="curve" smooth="yes"/>
+      <point x="568" y="231.0"/>
+      <point x="497" y="171.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="321"/>
   <outline>
     <contour>
-      <point x="189" y="342.0" type="curve" smooth="yes"/>
-      <point x="260" y="342"/>
-      <point x="321" y="394"/>
-      <point x="321" y="464" type="curve" smooth="yes"/>
-      <point x="321" y="501"/>
-      <point x="297" y="528"/>
-      <point x="268" y="542" type="curve"/>
-      <point x="305" y="555"/>
-      <point x="339" y="592"/>
-      <point x="339" y="633" type="curve" smooth="yes"/>
-      <point x="339" y="685"/>
+      <point x="180" y="342" type="curve" smooth="yes"/>
+      <point x="263" y="342"/>
+      <point x="320" y="394"/>
+      <point x="320.0" y="454" type="curve" smooth="yes"/>
+      <point x="320" y="501"/>
+      <point x="291" y="527"/>
+      <point x="257" y="540" type="curve"/>
+      <point x="304" y="550"/>
+      <point x="337" y="592"/>
+      <point x="337.0" y="631" type="curve" smooth="yes"/>
+      <point x="337" y="685"/>
       <point x="298" y="724"/>
       <point x="234" y="724" type="curve" smooth="yes"/>
       <point x="172" y="724"/>
       <point x="123" y="691"/>
       <point x="105" y="643" type="curve"/>
       <point x="151" y="624" type="line"/>
-      <point x="162" y="644"/>
-      <point x="185" y="676"/>
-      <point x="226" y="676" type="curve" smooth="yes"/>
-      <point x="264" y="676"/>
-      <point x="285" y="657"/>
-      <point x="285" y="623" type="curve" smooth="yes"/>
-      <point x="285" y="591"/>
-      <point x="252" y="564"/>
-      <point x="208" y="564" type="curve" smooth="yes"/>
-      <point x="196" y="564"/>
-      <point x="184" y="564.0"/>
-      <point x="172" y="564" type="curve"/>
-      <point x="164" y="518" type="line"/>
-      <point x="175" y="518.0"/>
-      <point x="185" y="518"/>
-      <point x="196" y="518" type="curve" smooth="yes"/>
-      <point x="243" y="518"/>
-      <point x="268" y="495"/>
-      <point x="268" y="462" type="curve" smooth="yes"/>
-      <point x="268" y="417"/>
-      <point x="236" y="391"/>
-      <point x="187" y="391" type="curve" smooth="yes"/>
-      <point x="153" y="391"/>
-      <point x="119" y="406"/>
-      <point x="108" y="459" type="curve"/>
+      <point x="167" y="650"/>
+      <point x="189" y="675"/>
+      <point x="227" y="675" type="curve" smooth="yes"/>
+      <point x="260" y="675"/>
+      <point x="283" y="654"/>
+      <point x="283" y="623" type="curve" smooth="yes"/>
+      <point x="283" y="589"/>
+      <point x="249" y="563"/>
+      <point x="208" y="563" type="curve" smooth="yes"/>
+      <point x="196" y="563"/>
+      <point x="184" y="563.0"/>
+      <point x="172" y="563" type="curve"/>
+      <point x="163" y="517" type="line"/>
+      <point x="174" y="517.0"/>
+      <point x="184" y="517.0"/>
+      <point x="195" y="517" type="curve" smooth="yes"/>
+      <point x="234" y="517"/>
+      <point x="265" y="495"/>
+      <point x="265" y="462" type="curve" smooth="yes"/>
+      <point x="265.0" y="420.0"/>
+      <point x="237" y="393"/>
+      <point x="187" y="393" type="curve" smooth="yes"/>
+      <point x="144.0" y="393"/>
+      <point x="113.0" y="419.0"/>
+      <point x="103" y="460" type="curve"/>
       <point x="58" y="441" type="line"/>
-      <point x="69" y="373"/>
-      <point x="124" y="342"/>
+      <point x="67.0" y="383.0"/>
+      <point x="117.0" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -20,48 +20,48 @@
     <contour>
       <point x="400" y="166" type="curve" smooth="yes"/>
       <point x="344" y="166"/>
-      <point x="289" y="197"/>
-      <point x="278" y="265" type="curve"/>
-      <point x="338" y="287" type="line"/>
-      <point x="349" y="244"/>
-      <point x="373" y="225"/>
-      <point x="407" y="225" type="curve" smooth="yes"/>
-      <point x="446" y="225"/>
-      <point x="478" y="251"/>
-      <point x="478" y="286" type="curve" smooth="yes"/>
-      <point x="478" y="319"/>
-      <point x="454" y="336"/>
-      <point x="415" y="336" type="curve" smooth="yes"/>
-      <point x="404" y="336.0"/>
-      <point x="394" y="336.0"/>
-      <point x="383" y="336" type="curve"/>
-      <point x="393" y="392" type="line"/>
-      <point x="405" y="392.0"/>
-      <point x="417" y="392.0"/>
-      <point x="429" y="392" type="curve"/>
-      <point x="465" y="392"/>
-      <point x="494" y="415"/>
-      <point x="494" y="447" type="curve" smooth="yes"/>
-      <point x="494" y="474"/>
-      <point x="473" y="489"/>
-      <point x="447" y="489" type="curve" smooth="yes"/>
-      <point x="409" y="489"/>
-      <point x="390" y="464"/>
-      <point x="379" y="444" type="curve"/>
-      <point x="325" y="467" type="line"/>
-      <point x="343" y="515"/>
-      <point x="392" y="548"/>
+      <point x="285" y="199"/>
+      <point x="274" y="267" type="curve"/>
+      <point x="345" y="292" type="line"/>
+      <point x="353" y="255"/>
+      <point x="373" y="232"/>
+      <point x="409" y="232.0" type="curve" smooth="yes"/>
+      <point x="446" y="232"/>
+      <point x="471" y="251"/>
+      <point x="471" y="286" type="curve" smooth="yes"/>
+      <point x="471" y="319"/>
+      <point x="448" y="333"/>
+      <point x="414" y="333" type="curve" smooth="yes"/>
+      <point x="403" y="333"/>
+      <point x="393" y="333.0"/>
+      <point x="382" y="333" type="curve"/>
+      <point x="394" y="395" type="line"/>
+      <point x="405" y="395"/>
+      <point x="416" y="395"/>
+      <point x="427" y="395" type="curve" smooth="yes"/>
+      <point x="460.0" y="395.0"/>
+      <point x="486.0" y="413.0"/>
+      <point x="486.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="486.0" y="467.0"/>
+      <point x="467" y="481.0"/>
+      <point x="445" y="481.0" type="curve" smooth="yes"/>
+      <point x="412" y="481.0"/>
+      <point x="395" y="458.0"/>
+      <point x="386" y="440.0" type="curve"/>
+      <point x="323" y="468" type="line"/>
+      <point x="341" y="516"/>
+      <point x="389" y="548"/>
       <point x="454" y="548" type="curve" smooth="yes"/>
-      <point x="518" y="548"/>
-      <point x="562" y="509"/>
-      <point x="562" y="457" type="curve" smooth="yes"/>
-      <point x="562" y="416"/>
-      <point x="529" y="379"/>
-      <point x="495" y="366" type="curve"/>
-      <point x="524" y="352"/>
-      <point x="545" y="325"/>
-      <point x="545" y="288" type="curve" smooth="yes"/>
-      <point x="545" y="218"/>
+      <point x="524" y="548"/>
+      <point x="566" y="509"/>
+      <point x="566" y="457" type="curve" smooth="yes"/>
+      <point x="566" y="416"/>
+      <point x="534" y="379"/>
+      <point x="501" y="366" type="curve"/>
+      <point x="527" y="354"/>
+      <point x="550" y="325"/>
+      <point x="550" y="288" type="curve" smooth="yes"/>
+      <point x="550" y="218"/>
       <point x="483" y="166"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="400" y="166" type="curve" smooth="yes"/>
+      <point x="408" y="166" type="curve" smooth="yes"/>
       <point x="344" y="166"/>
-      <point x="285" y="199"/>
-      <point x="274" y="267" type="curve"/>
-      <point x="345" y="292" type="line"/>
-      <point x="353" y="255"/>
-      <point x="373" y="232"/>
-      <point x="409" y="232.0" type="curve" smooth="yes"/>
-      <point x="446" y="232"/>
-      <point x="471" y="251"/>
-      <point x="471" y="286" type="curve" smooth="yes"/>
-      <point x="471" y="319"/>
-      <point x="448" y="333"/>
-      <point x="414" y="333" type="curve" smooth="yes"/>
-      <point x="403" y="333"/>
-      <point x="393" y="333.0"/>
-      <point x="382" y="333" type="curve"/>
-      <point x="394" y="395" type="line"/>
-      <point x="405" y="395"/>
-      <point x="416" y="395"/>
-      <point x="427" y="395" type="curve" smooth="yes"/>
-      <point x="460.0" y="395.0"/>
-      <point x="486.0" y="413.0"/>
-      <point x="486.0" y="443.0" type="curve" smooth="yes"/>
-      <point x="486.0" y="467.0"/>
-      <point x="467" y="481.0"/>
-      <point x="445" y="481.0" type="curve" smooth="yes"/>
-      <point x="412" y="481.0"/>
-      <point x="395" y="458.0"/>
-      <point x="386" y="440.0" type="curve"/>
-      <point x="323" y="468" type="line"/>
-      <point x="341" y="516"/>
-      <point x="389" y="548"/>
-      <point x="454" y="548" type="curve" smooth="yes"/>
-      <point x="524" y="548"/>
-      <point x="566" y="509"/>
-      <point x="566" y="457" type="curve" smooth="yes"/>
-      <point x="566" y="416"/>
-      <point x="534" y="379"/>
-      <point x="501" y="366" type="curve"/>
-      <point x="527" y="354"/>
-      <point x="550" y="325"/>
-      <point x="550" y="288" type="curve" smooth="yes"/>
-      <point x="550" y="218"/>
+      <point x="289" y="197"/>
+      <point x="278" y="265" type="curve"/>
+      <point x="322" y="279.0" type="line"/>
+      <point x="335" y="229.0"/>
+      <point x="365" y="206.0"/>
+      <point x="407" y="206.0" type="curve" smooth="yes"/>
+      <point x="454" y="206.0"/>
+      <point x="493" y="237.0"/>
+      <point x="493" y="277.0" type="curve" smooth="yes"/>
+      <point x="493" y="316.0"/>
+      <point x="464" y="339.0"/>
+      <point x="416" y="339.0" type="curve" smooth="yes"/>
+      <point x="402" y="339.0"/>
+      <point x="390" y="339.0"/>
+      <point x="377" y="339.0" type="curve"/>
+      <point x="382.0" y="378" type="line"/>
+      <point x="397.0" y="378"/>
+      <point x="410" y="378"/>
+      <point x="424.0" y="378" type="curve" smooth="yes"/>
+      <point x="472" y="378.0"/>
+      <point x="505" y="414"/>
+      <point x="505.0" y="450" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="487.0" y="509.0"/>
+      <point x="447.0" y="509" type="curve" smooth="yes"/>
+      <point x="404" y="509"/>
+      <point x="377.0" y="473"/>
+      <point x="365.0" y="446" type="curve"/>
+      <point x="325" y="467" type="line"/>
+      <point x="343" y="515"/>
+      <point x="392" y="548"/>
+      <point x="451" y="548.0" type="curve" smooth="yes"/>
+      <point x="518" y="548"/>
+      <point x="552" y="509"/>
+      <point x="552.0" y="461" type="curve" smooth="yes"/>
+      <point x="552" y="416"/>
+      <point x="522" y="381"/>
+      <point x="480" y="364" type="curve"/>
+      <point x="516" y="351"/>
+      <point x="541" y="325"/>
+      <point x="541" y="288" type="curve" smooth="yes"/>
+      <point x="541" y="218"/>
       <point x="483" y="166"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.numerator.glif
@@ -5,12 +5,12 @@
     <contour>
       <point x="43" y="350" type="line"/>
       <point x="289" y="350" type="line"/>
-      <point x="298" y="399" type="line"/>
-      <point x="116" y="399" type="line"/>
-      <point x="116" y="399"/>
-      <point x="227" y="488"/>
-      <point x="253" y="510" type="curve" smooth="yes"/>
-      <point x="296" y="546"/>
+      <point x="295" y="399" type="line"/>
+      <point x="114" y="399" type="line"/>
+      <point x="114" y="399"/>
+      <point x="228" y="488"/>
+      <point x="254" y="510" type="curve" smooth="yes"/>
+      <point x="297" y="546"/>
       <point x="330" y="573"/>
       <point x="330" y="627" type="curve" smooth="yes"/>
       <point x="330" y="683"/>
@@ -19,17 +19,17 @@
       <point x="162" y="724"/>
       <point x="108" y="690"/>
       <point x="90" y="629" type="curve"/>
-      <point x="135" y="608" type="line"/>
-      <point x="149.0" y="646.0"/>
-      <point x="180" y="673"/>
-      <point x="215" y="673.0" type="curve" smooth="yes"/>
-      <point x="251.0" y="673.0"/>
-      <point x="272.0" y="656.0"/>
-      <point x="272" y="620" type="curve" smooth="yes"/>
-      <point x="272" y="589"/>
-      <point x="237" y="562"/>
-      <point x="215" y="542" type="curve" smooth="yes"/>
-      <point x="204" y="532"/>
+      <point x="133" y="608" type="line"/>
+      <point x="149" y="650"/>
+      <point x="188" y="678"/>
+      <point x="224" y="678.0" type="curve" smooth="yes"/>
+      <point x="261.0" y="678.0"/>
+      <point x="276.0" y="656.0"/>
+      <point x="276" y="626" type="curve" smooth="yes"/>
+      <point x="276" y="595"/>
+      <point x="241" y="557"/>
+      <point x="218" y="539" type="curve" smooth="yes"/>
+      <point x="207" y="530"/>
       <point x="51" y="398"/>
       <point x="51" y="398" type="curve"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="282" y="178" type="line"/>
-      <point x="294" y="244" type="line"/>
-      <point x="294" y="244"/>
-      <point x="437" y="364"/>
-      <point x="452.0" y="376" type="curve" smooth="yes"/>
-      <point x="471" y="392"/>
-      <point x="500.0" y="414"/>
-      <point x="500.0" y="442" type="curve" smooth="yes"/>
-      <point x="500.0" y="468"/>
-      <point x="481.0" y="483"/>
-      <point x="456.0" y="483" type="curve" smooth="yes"/>
-      <point x="429.0" y="483"/>
-      <point x="407.0" y="466"/>
-      <point x="393.0" y="427" type="curve"/>
-      <point x="324" y="459" type="line"/>
-      <point x="342" y="520"/>
-      <point x="401" y="552"/>
+      <point x="292" y="218" type="line"/>
+      <point x="292" y="218"/>
+      <point x="441" y="343"/>
+      <point x="457" y="358" type="curve" smooth="yes"/>
+      <point x="505" y="404"/>
+      <point x="519.0" y="433.0"/>
+      <point x="519.0" y="461" type="curve" smooth="yes"/>
+      <point x="519" y="489"/>
+      <point x="500" y="513"/>
+      <point x="459" y="513.0" type="curve" smooth="yes"/>
+      <point x="412.0" y="513.0"/>
+      <point x="380" y="479"/>
+      <point x="367" y="440" type="curve"/>
+      <point x="329" y="457" type="line"/>
+      <point x="345" y="511"/>
+      <point x="396" y="552.0"/>
       <point x="462" y="552" type="curve" smooth="yes"/>
       <point x="528" y="552"/>
-      <point x="579" y="511"/>
-      <point x="579" y="455" type="curve" smooth="yes"/>
-      <point x="579" y="401"/>
-      <point x="538" y="361"/>
-      <point x="495" y="325" type="curve" smooth="yes"/>
-      <point x="469" y="303"/>
-      <point x="402" y="249"/>
-      <point x="402" y="249" type="curve"/>
-      <point x="543" y="249" type="line"/>
+      <point x="564" y="511"/>
+      <point x="564.0" y="466" type="curve" smooth="yes"/>
+      <point x="564" y="411"/>
+      <point x="528" y="373"/>
+      <point x="486" y="335" type="curve" smooth="yes"/>
+      <point x="461" y="312"/>
+      <point x="348" y="217"/>
+      <point x="348" y="217" type="curve"/>
+      <point x="534" y="217" type="line"/>
       <point x="528" y="178" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="282" y="178" type="line"/>
-      <point x="292" y="233" type="line"/>
-      <point x="292" y="233"/>
-      <point x="443" y="361"/>
-      <point x="454" y="370" type="curve" smooth="yes"/>
-      <point x="477" y="388"/>
-      <point x="506" y="417"/>
-      <point x="506" y="448" type="curve" smooth="yes"/>
-      <point x="506" y="477"/>
-      <point x="484" y="493"/>
-      <point x="456" y="493" type="curve" smooth="yes"/>
-      <point x="425" y="493"/>
-      <point x="400" y="474"/>
-      <point x="384" y="432" type="curve"/>
-      <point x="329" y="457" type="line"/>
-      <point x="347" y="518"/>
+      <point x="294" y="244" type="line"/>
+      <point x="294" y="244"/>
+      <point x="437" y="364"/>
+      <point x="452.0" y="376" type="curve" smooth="yes"/>
+      <point x="471" y="392"/>
+      <point x="500.0" y="414"/>
+      <point x="500.0" y="442" type="curve" smooth="yes"/>
+      <point x="500.0" y="468"/>
+      <point x="481.0" y="483"/>
+      <point x="456.0" y="483" type="curve" smooth="yes"/>
+      <point x="429.0" y="483"/>
+      <point x="407.0" y="466"/>
+      <point x="393.0" y="427" type="curve"/>
+      <point x="324" y="459" type="line"/>
+      <point x="342" y="520"/>
       <point x="401" y="552"/>
       <point x="462" y="552" type="curve" smooth="yes"/>
       <point x="528" y="552"/>
-      <point x="574" y="511"/>
-      <point x="574" y="455" type="curve" smooth="yes"/>
-      <point x="574" y="401"/>
-      <point x="536" y="369"/>
-      <point x="493" y="333" type="curve" smooth="yes"/>
-      <point x="467" y="311"/>
-      <point x="378" y="237"/>
-      <point x="378" y="237" type="curve"/>
-      <point x="539" y="237" type="line"/>
+      <point x="579" y="511"/>
+      <point x="579" y="455" type="curve" smooth="yes"/>
+      <point x="579" y="401"/>
+      <point x="538" y="361"/>
+      <point x="495" y="325" type="curve" smooth="yes"/>
+      <point x="469" y="303"/>
+      <point x="402" y="249"/>
+      <point x="402" y="249" type="curve"/>
+      <point x="543" y="249" type="line"/>
       <point x="528" y="178" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="44" y="68" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/zero.numerator.glif
@@ -5,30 +5,30 @@
     <contour>
       <point x="209" y="342" type="curve" smooth="yes"/>
       <point x="320" y="342"/>
-      <point x="386" y="454"/>
-      <point x="386" y="565" type="curve" smooth="yes"/>
-      <point x="386" y="653"/>
+      <point x="393" y="454"/>
+      <point x="393" y="565" type="curve" smooth="yes"/>
+      <point x="393" y="653"/>
       <point x="351" y="724"/>
       <point x="263" y="724" type="curve" smooth="yes"/>
       <point x="143" y="724"/>
-      <point x="85" y="608"/>
-      <point x="85" y="501" type="curve" smooth="yes"/>
-      <point x="85" y="413"/>
+      <point x="78" y="608"/>
+      <point x="78" y="501" type="curve" smooth="yes"/>
+      <point x="78" y="413"/>
       <point x="122" y="342"/>
     </contour>
     <contour>
-      <point x="216" y="393" type="curve" smooth="yes"/>
-      <point x="154" y="393"/>
-      <point x="142" y="443"/>
-      <point x="142" y="504" type="curve" smooth="yes"/>
-      <point x="142" y="583"/>
-      <point x="174" y="675"/>
-      <point x="258" y="675" type="curve" smooth="yes"/>
-      <point x="317" y="675"/>
-      <point x="329" y="624"/>
-      <point x="329" y="562" type="curve" smooth="yes"/>
-      <point x="329" y="481"/>
-      <point x="296" y="393"/>
+      <point x="211" y="393.0" type="curve" smooth="yes"/>
+      <point x="154" y="393.0"/>
+      <point x="134" y="449.0"/>
+      <point x="134" y="502.0" type="curve" smooth="yes"/>
+      <point x="134" y="574.0"/>
+      <point x="176" y="673.0"/>
+      <point x="258" y="673.0" type="curve" smooth="yes"/>
+      <point x="313" y="673.0"/>
+      <point x="333" y="617.0"/>
+      <point x="333" y="564.0" type="curve" smooth="yes"/>
+      <point x="333" y="489.0"/>
+      <point x="289" y="393.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="43" y="88" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/S_ansS_erifC_ircle.glif
@@ -3,32 +3,32 @@
   <advance width="837"/>
   <outline>
     <contour>
-      <point x="437" y="-16" type="curve" smooth="yes"/>
-      <point x="643" y="-16"/>
-      <point x="811" y="152"/>
-      <point x="811" y="358" type="curve" smooth="yes"/>
-      <point x="811" y="564"/>
-      <point x="643" y="732"/>
-      <point x="437" y="732" type="curve" smooth="yes"/>
-      <point x="231" y="732"/>
-      <point x="63" y="564"/>
-      <point x="63" y="358" type="curve" smooth="yes"/>
-      <point x="63" y="152"/>
-      <point x="231" y="-16"/>
+      <point x="437.0" y="-20" type="curve" smooth="yes"/>
+      <point x="645" y="-20"/>
+      <point x="815" y="150"/>
+      <point x="815" y="358.0" type="curve" smooth="yes"/>
+      <point x="815" y="566"/>
+      <point x="645" y="736"/>
+      <point x="437.0" y="736" type="curve" smooth="yes"/>
+      <point x="229" y="736"/>
+      <point x="59" y="566"/>
+      <point x="59" y="358.0" type="curve" smooth="yes"/>
+      <point x="59" y="150"/>
+      <point x="229" y="-20"/>
     </contour>
     <contour>
-      <point x="437.0" y="69" type="curve" smooth="yes"/>
-      <point x="280" y="69"/>
-      <point x="148" y="201"/>
-      <point x="148" y="358.0" type="curve" smooth="yes"/>
-      <point x="148" y="518"/>
-      <point x="280" y="647"/>
-      <point x="437.0" y="647" type="curve" smooth="yes"/>
-      <point x="598.0" y="647"/>
-      <point x="726" y="518"/>
-      <point x="726" y="358.0" type="curve" smooth="yes"/>
-      <point x="726" y="201"/>
-      <point x="598.0" y="69"/>
+      <point x="437.0" y="67" type="curve" smooth="yes"/>
+      <point x="278" y="67"/>
+      <point x="147" y="199"/>
+      <point x="147" y="358.0" type="curve" smooth="yes"/>
+      <point x="147" y="520"/>
+      <point x="278" y="649"/>
+      <point x="437.0" y="649" type="curve" smooth="yes"/>
+      <point x="599" y="649"/>
+      <point x="727" y="520"/>
+      <point x="727" y="358.0" type="curve" smooth="yes"/>
+      <point x="727" y="199"/>
+      <point x="599" y="67"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.numerator.glif
@@ -3,58 +3,58 @@
   <advance width="315"/>
   <outline>
     <contour>
-      <point x="178" y="342" type="curve" smooth="yes"/>
-      <point x="273" y="342"/>
-      <point x="332.0" y="393.0"/>
-      <point x="332.0" y="462" type="curve" smooth="yes"/>
-      <point x="332" y="499"/>
-      <point x="312" y="529"/>
-      <point x="288" y="543" type="curve"/>
-      <point x="326" y="561"/>
-      <point x="349" y="594"/>
-      <point x="349" y="633" type="curve" smooth="yes"/>
-      <point x="349.0" y="691.0"/>
-      <point x="301.0" y="724.0"/>
-      <point x="236" y="724" type="curve" smooth="yes"/>
-      <point x="146" y="724"/>
-      <point x="95" y="671"/>
-      <point x="95.0" y="614" type="curve" smooth="yes"/>
-      <point x="95" y="578"/>
-      <point x="115" y="556"/>
+      <point x="177" y="342.0" type="curve" smooth="yes"/>
+      <point x="262" y="342"/>
+      <point x="331" y="387.0"/>
+      <point x="331" y="467.0" type="curve" smooth="yes"/>
+      <point x="331" y="499"/>
+      <point x="312" y="527"/>
+      <point x="283" y="543" type="curve"/>
+      <point x="327" y="567"/>
+      <point x="348" y="594.0"/>
+      <point x="348" y="633.0" type="curve" smooth="yes"/>
+      <point x="348" y="689.0"/>
+      <point x="300" y="724.0"/>
+      <point x="238" y="724.0" type="curve" smooth="yes"/>
+      <point x="154" y="724"/>
+      <point x="96" y="674.0"/>
+      <point x="96" y="608.0" type="curve" smooth="yes"/>
+      <point x="96" y="578"/>
+      <point x="114" y="557"/>
       <point x="133" y="545" type="curve"/>
-      <point x="92" y="528"/>
-      <point x="54" y="492"/>
-      <point x="54" y="440" type="curve" smooth="yes"/>
-      <point x="54" y="387"/>
-      <point x="97" y="342"/>
+      <point x="93" y="529"/>
+      <point x="56.0" y="492.0"/>
+      <point x="56.0" y="447.0" type="curve" smooth="yes"/>
+      <point x="56.0" y="387.0"/>
+      <point x="100" y="342.0"/>
     </contour>
     <contour>
-      <point x="189" y="411" type="curve" smooth="yes"/>
-      <point x="153" y="411"/>
+      <point x="191" y="410" type="curve" smooth="yes"/>
+      <point x="162" y="410"/>
       <point x="138" y="427"/>
-      <point x="138.0" y="453" type="curve" smooth="yes"/>
-      <point x="138" y="482"/>
-      <point x="160" y="504"/>
-      <point x="198" y="504" type="curve" smooth="yes"/>
-      <point x="236" y="504"/>
-      <point x="252" y="487"/>
-      <point x="252.0" y="462" type="curve" smooth="yes"/>
-      <point x="252" y="431"/>
-      <point x="228" y="411"/>
+      <point x="138" y="453" type="curve" smooth="yes"/>
+      <point x="138" y="485"/>
+      <point x="167" y="505"/>
+      <point x="198" y="505" type="curve" smooth="yes"/>
+      <point x="230" y="505"/>
+      <point x="249" y="488"/>
+      <point x="249" y="462" type="curve" smooth="yes"/>
+      <point x="249" y="429"/>
+      <point x="222" y="410"/>
     </contour>
     <contour>
-      <point x="213" y="572" type="curve" smooth="yes"/>
-      <point x="187" y="572"/>
-      <point x="167" y="582"/>
-      <point x="167" y="608" type="curve" smooth="yes"/>
-      <point x="167" y="640"/>
-      <point x="195" y="655"/>
-      <point x="227" y="655" type="curve" smooth="yes"/>
-      <point x="256" y="655"/>
-      <point x="277" y="643"/>
-      <point x="277" y="619" type="curve" smooth="yes"/>
-      <point x="277" y="583"/>
-      <point x="246" y="572"/>
+      <point x="216" y="572" type="curve" smooth="yes"/>
+      <point x="195" y="572"/>
+      <point x="178" y="588"/>
+      <point x="178.0" y="614" type="curve" smooth="yes"/>
+      <point x="178" y="641"/>
+      <point x="201" y="660"/>
+      <point x="226" y="660" type="curve" smooth="yes"/>
+      <point x="249" y="660"/>
+      <point x="267" y="645"/>
+      <point x="267" y="622" type="curve" smooth="yes"/>
+      <point x="267" y="591"/>
+      <point x="242" y="572"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="412.0" y="209" type="curve" smooth="yes"/>
-      <point x="459" y="209"/>
-      <point x="499.0" y="235"/>
-      <point x="499.0" y="281" type="curve" smooth="yes"/>
-      <point x="499.0" y="321"/>
-      <point x="466.0" y="348"/>
-      <point x="422.0" y="348" type="curve" smooth="yes"/>
-      <point x="379.0" y="348"/>
-      <point x="336.0" y="317"/>
-      <point x="336.0" y="273" type="curve"/>
-      <point x="336.0" y="233"/>
-      <point x="369" y="209"/>
+      <point x="414" y="233" type="curve" smooth="yes"/>
+      <point x="449" y="233"/>
+      <point x="479" y="253"/>
+      <point x="479" y="290" type="curve" smooth="yes"/>
+      <point x="479" y="318"/>
+      <point x="457" y="338"/>
+      <point x="422" y="338" type="curve" smooth="yes"/>
+      <point x="387" y="338"/>
+      <point x="356" y="315"/>
+      <point x="356" y="280" type="curve" smooth="yes"/>
+      <point x="356" y="251"/>
+      <point x="381" y="233"/>
     </contour>
     <contour>
-      <point x="403" y="169.0" type="curve" smooth="yes"/>
-      <point x="334" y="169.0"/>
-      <point x="288" y="214.0"/>
-      <point x="288" y="274.0" type="curve" smooth="yes"/>
-      <point x="288" y="319.0"/>
-      <point x="325" y="353.0"/>
-      <point x="375" y="369.0" type="curve"/>
-      <point x="349" y="380.0"/>
-      <point x="327" y="405.0"/>
-      <point x="327" y="435.0" type="curve" smooth="yes"/>
-      <point x="327" y="498.0"/>
-      <point x="382" y="551.0"/>
-      <point x="460" y="551.0" type="curve" smooth="yes"/>
-      <point x="515" y="551.0"/>
-      <point x="564" y="516.0"/>
-      <point x="564" y="460.0" type="curve" smooth="yes"/>
-      <point x="564" y="421.0"/>
-      <point x="536" y="387.0"/>
-      <point x="494" y="369.0" type="curve"/>
-      <point x="526" y="352.0"/>
-      <point x="548" y="326.0"/>
-      <point x="548" y="294.0" type="curve" smooth="yes"/>
-      <point x="548" y="217.0"/>
-      <point x="482" y="169.0"/>
+      <point x="402" y="169" type="curve" smooth="yes"/>
+      <point x="327" y="169"/>
+      <point x="279" y="214"/>
+      <point x="279" y="274" type="curve" smooth="yes"/>
+      <point x="279" y="319"/>
+      <point x="316" y="355"/>
+      <point x="357" y="372" type="curve"/>
+      <point x="343" y="382"/>
+      <point x="320" y="405"/>
+      <point x="320" y="435" type="curve" smooth="yes"/>
+      <point x="320" y="498"/>
+      <point x="376" y="551"/>
+      <point x="460" y="551" type="curve" smooth="yes"/>
+      <point x="522" y="551"/>
+      <point x="573" y="516"/>
+      <point x="573" y="460" type="curve" smooth="yes"/>
+      <point x="573" y="421"/>
+      <point x="544" y="388"/>
+      <point x="512" y="370" type="curve"/>
+      <point x="537" y="353"/>
+      <point x="556" y="326"/>
+      <point x="556" y="294" type="curve" smooth="yes"/>
+      <point x="556" y="217"/>
+      <point x="489" y="169"/>
     </contour>
     <contour>
-      <point x="436.0" y="386.0" type="curve" smooth="yes"/>
-      <point x="480.0" y="386.0"/>
-      <point x="521.0" y="410"/>
-      <point x="521.0" y="456" type="curve" smooth="yes"/>
-      <point x="521.0" y="487"/>
-      <point x="492.0" y="510"/>
-      <point x="454.0" y="510" type="curve" smooth="yes"/>
-      <point x="411.0" y="510"/>
-      <point x="374.0" y="481"/>
-      <point x="374.0" y="440" type="curve" smooth="yes"/>
-      <point x="374.0" y="407"/>
-      <point x="402.0" y="386.0"/>
+      <point x="438" y="396" type="curve" smooth="yes"/>
+      <point x="470" y="396"/>
+      <point x="499" y="414"/>
+      <point x="499" y="448" type="curve" smooth="yes"/>
+      <point x="499" y="471"/>
+      <point x="479" y="488"/>
+      <point x="450" y="488" type="curve" smooth="yes"/>
+      <point x="420" y="488"/>
+      <point x="393" y="467"/>
+      <point x="393" y="435" type="curve" smooth="yes"/>
+      <point x="393" y="411"/>
+      <point x="414" y="396"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="414" y="237" type="curve" smooth="yes"/>
-      <point x="450" y="237"/>
-      <point x="480" y="257"/>
-      <point x="480" y="293" type="curve" smooth="yes"/>
-      <point x="480" y="321"/>
-      <point x="458" y="341"/>
-      <point x="422" y="341" type="curve" smooth="yes"/>
-      <point x="387" y="341"/>
-      <point x="356" y="318"/>
-      <point x="356" y="283" type="curve" smooth="yes"/>
-      <point x="356" y="255"/>
-      <point x="381" y="237"/>
+      <point x="412.0" y="209" type="curve" smooth="yes"/>
+      <point x="459" y="209"/>
+      <point x="499.0" y="235"/>
+      <point x="499.0" y="281" type="curve" smooth="yes"/>
+      <point x="499.0" y="321"/>
+      <point x="466.0" y="348"/>
+      <point x="422.0" y="348" type="curve" smooth="yes"/>
+      <point x="379.0" y="348"/>
+      <point x="336.0" y="317"/>
+      <point x="336.0" y="273" type="curve"/>
+      <point x="336.0" y="233"/>
+      <point x="369" y="209"/>
     </contour>
     <contour>
-      <point x="402" y="169" type="curve" smooth="yes"/>
-      <point x="331" y="169"/>
-      <point x="283" y="214"/>
-      <point x="283" y="274" type="curve" smooth="yes"/>
-      <point x="283" y="319"/>
-      <point x="316" y="355"/>
-      <point x="357" y="372" type="curve"/>
-      <point x="343" y="382"/>
-      <point x="324" y="405"/>
-      <point x="324" y="435" type="curve" smooth="yes"/>
-      <point x="324" y="498"/>
-      <point x="380" y="551"/>
-      <point x="460" y="551" type="curve" smooth="yes"/>
-      <point x="517" y="551"/>
-      <point x="568" y="516"/>
-      <point x="568" y="460" type="curve" smooth="yes"/>
-      <point x="568" y="421"/>
-      <point x="544" y="388"/>
-      <point x="512" y="370" type="curve"/>
-      <point x="537" y="353"/>
-      <point x="551" y="326"/>
-      <point x="551" y="294" type="curve" smooth="yes"/>
-      <point x="551" y="217"/>
-      <point x="484" y="169"/>
+      <point x="403" y="169.0" type="curve" smooth="yes"/>
+      <point x="334" y="169.0"/>
+      <point x="288" y="214.0"/>
+      <point x="288" y="274.0" type="curve" smooth="yes"/>
+      <point x="288" y="319.0"/>
+      <point x="325" y="353.0"/>
+      <point x="375" y="369.0" type="curve"/>
+      <point x="349" y="380.0"/>
+      <point x="327" y="405.0"/>
+      <point x="327" y="435.0" type="curve" smooth="yes"/>
+      <point x="327" y="498.0"/>
+      <point x="382" y="551.0"/>
+      <point x="460" y="551.0" type="curve" smooth="yes"/>
+      <point x="515" y="551.0"/>
+      <point x="564" y="516.0"/>
+      <point x="564" y="460.0" type="curve" smooth="yes"/>
+      <point x="564" y="421.0"/>
+      <point x="536" y="387.0"/>
+      <point x="494" y="369.0" type="curve"/>
+      <point x="526" y="352.0"/>
+      <point x="548" y="326.0"/>
+      <point x="548" y="294.0" type="curve" smooth="yes"/>
+      <point x="548" y="217.0"/>
+      <point x="482" y="169.0"/>
     </contour>
     <contour>
-      <point x="438" y="395" type="curve" smooth="yes"/>
-      <point x="467" y="395"/>
-      <point x="494" y="412"/>
-      <point x="494" y="445" type="curve" smooth="yes"/>
-      <point x="494" y="467"/>
-      <point x="475" y="483"/>
-      <point x="450" y="483" type="curve" smooth="yes"/>
-      <point x="421" y="483"/>
-      <point x="396" y="462"/>
-      <point x="396" y="433" type="curve" smooth="yes"/>
-      <point x="396" y="409"/>
-      <point x="415" y="395"/>
+      <point x="436.0" y="386.0" type="curve" smooth="yes"/>
+      <point x="480.0" y="386.0"/>
+      <point x="521.0" y="410"/>
+      <point x="521.0" y="456" type="curve" smooth="yes"/>
+      <point x="521.0" y="487"/>
+      <point x="492.0" y="510"/>
+      <point x="454.0" y="510" type="curve" smooth="yes"/>
+      <point x="411.0" y="510"/>
+      <point x="374.0" y="481"/>
+      <point x="374.0" y="440" type="curve" smooth="yes"/>
+      <point x="374.0" y="407"/>
+      <point x="402.0" y="386.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.numerator.glif
@@ -3,37 +3,37 @@
   <advance width="314"/>
   <outline>
     <contour>
-      <point x="177" y="343" type="curve" smooth="yes"/>
-      <point x="272" y="343"/>
-      <point x="335" y="400"/>
-      <point x="335" y="485" type="curve" smooth="yes"/>
-      <point x="335" y="555"/>
-      <point x="285" y="595"/>
-      <point x="229" y="595.0" type="curve" smooth="yes"/>
-      <point x="200" y="595"/>
-      <point x="174" y="586"/>
-      <point x="166" y="580" type="curve"/>
-      <point x="189" y="646" type="line"/>
-      <point x="339" y="646" type="line"/>
-      <point x="348" y="716" type="line"/>
-      <point x="131" y="716" type="line"/>
-      <point x="73" y="527" type="line"/>
-      <point x="138" y="494" type="line"/>
-      <point x="152" y="513"/>
-      <point x="175" y="529"/>
-      <point x="204" y="529.0" type="curve" smooth="yes"/>
-      <point x="233" y="529"/>
-      <point x="248" y="506"/>
-      <point x="248.0" y="474" type="curve" smooth="yes"/>
-      <point x="248.0" y="440"/>
-      <point x="224" y="414"/>
-      <point x="183" y="414" type="curve" smooth="yes"/>
-      <point x="147" y="414"/>
-      <point x="131" y="435"/>
-      <point x="125" y="462" type="curve"/>
-      <point x="52" y="440" type="line"/>
-      <point x="60.0" y="379"/>
-      <point x="112.0" y="343"/>
+      <point x="184" y="343.0" type="curve" smooth="yes"/>
+      <point x="270" y="343.0"/>
+      <point x="336" y="403"/>
+      <point x="336" y="488" type="curve" smooth="yes"/>
+      <point x="336" y="558"/>
+      <point x="295" y="603"/>
+      <point x="231" y="603.0" type="curve" smooth="yes"/>
+      <point x="203" y="603"/>
+      <point x="181" y="594"/>
+      <point x="165" y="581" type="curve"/>
+      <point x="186" y="647" type="line"/>
+      <point x="340" y="647" type="line"/>
+      <point x="351" y="716" type="line"/>
+      <point x="137" y="716" type="line"/>
+      <point x="79" y="526" type="line"/>
+      <point x="137.0" y="500" type="line"/>
+      <point x="154.0" y="521"/>
+      <point x="172.0" y="533.0"/>
+      <point x="199.0" y="533.0" type="curve" smooth="yes"/>
+      <point x="230.0" y="533.0"/>
+      <point x="251.0" y="513"/>
+      <point x="251.0" y="480" type="curve" smooth="yes"/>
+      <point x="251.0" y="440"/>
+      <point x="218.0" y="409"/>
+      <point x="180.0" y="409" type="curve" smooth="yes"/>
+      <point x="146.0" y="409"/>
+      <point x="131" y="431"/>
+      <point x="124" y="462" type="curve"/>
+      <point x="50" y="435" type="line"/>
+      <point x="60" y="372"/>
+      <point x="124" y="343"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -19,35 +19,35 @@
     </contour>
     <contour>
       <point x="396" y="168" type="curve" smooth="yes"/>
-      <point x="343" y="168"/>
-      <point x="285" y="194"/>
-      <point x="275" y="259" type="curve"/>
-      <point x="316" y="274.0" type="line"/>
-      <point x="326" y="232.0"/>
-      <point x="355" y="209"/>
-      <point x="400" y="209.0" type="curve" smooth="yes"/>
-      <point x="453" y="209.0"/>
-      <point x="498.0" y="246.0"/>
-      <point x="498" y="305.0" type="curve" smooth="yes"/>
-      <point x="498" y="350"/>
-      <point x="467" y="379"/>
-      <point x="435" y="379.0" type="curve" smooth="yes"/>
-      <point x="400" y="379.0"/>
-      <point x="361" y="362.0"/>
-      <point x="342" y="335.0" type="curve"/>
-      <point x="306" y="352" type="line"/>
-      <point x="364" y="541" type="line"/>
-      <point x="567" y="541" type="line"/>
-      <point x="560" y="500" type="line"/>
-      <point x="392" y="500" type="line"/>
-      <point x="358" y="385" type="line"/>
-      <point x="378" y="406"/>
-      <point x="411" y="420"/>
-      <point x="443" y="420" type="curve" smooth="yes"/>
-      <point x="504" y="420"/>
-      <point x="548" y="380"/>
-      <point x="548" y="310" type="curve" smooth="yes"/>
-      <point x="548" y="225"/>
+      <point x="339" y="168"/>
+      <point x="282" y="194"/>
+      <point x="270" y="261" type="curve"/>
+      <point x="341" y="285" type="line"/>
+      <point x="348" y="252"/>
+      <point x="370" y="234"/>
+      <point x="402" y="234" type="curve" smooth="yes"/>
+      <point x="441" y="234"/>
+      <point x="474" y="262"/>
+      <point x="474" y="305" type="curve" smooth="yes"/>
+      <point x="474" y="339"/>
+      <point x="450" y="360"/>
+      <point x="422" y="360" type="curve" smooth="yes"/>
+      <point x="394" y="360"/>
+      <point x="373" y="343"/>
+      <point x="359" y="324" type="curve"/>
+      <point x="299" y="352" type="line"/>
+      <point x="357" y="541" type="line"/>
+      <point x="572" y="541" type="line"/>
+      <point x="561" y="477" type="line"/>
+      <point x="410" y="477" type="line"/>
+      <point x="388" y="406" type="line"/>
+      <point x="400" y="416"/>
+      <point x="419" y="424"/>
+      <point x="443" y="424" type="curve" smooth="yes"/>
+      <point x="504" y="424"/>
+      <point x="551" y="380"/>
+      <point x="551" y="310" type="curve" smooth="yes"/>
+      <point x="551" y="225"/>
       <point x="480" y="168"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -22,27 +22,27 @@
       <point x="343" y="168"/>
       <point x="285" y="194"/>
       <point x="275" y="259" type="curve"/>
-      <point x="344" y="283" type="line"/>
-      <point x="351" y="253"/>
-      <point x="370" y="234"/>
-      <point x="403" y="234" type="curve" smooth="yes"/>
-      <point x="439" y="234"/>
-      <point x="473" y="266"/>
-      <point x="473" y="304" type="curve" smooth="yes"/>
-      <point x="473" y="337"/>
-      <point x="450" y="357"/>
-      <point x="421" y="357" type="curve" smooth="yes"/>
-      <point x="395" y="357"/>
-      <point x="377" y="347"/>
-      <point x="360" y="325" type="curve"/>
-      <point x="302" y="352" type="line"/>
-      <point x="360" y="541" type="line"/>
+      <point x="316" y="274.0" type="line"/>
+      <point x="326" y="232.0"/>
+      <point x="355" y="209"/>
+      <point x="400" y="209.0" type="curve" smooth="yes"/>
+      <point x="453" y="209.0"/>
+      <point x="498.0" y="246.0"/>
+      <point x="498" y="305.0" type="curve" smooth="yes"/>
+      <point x="498" y="350"/>
+      <point x="467" y="379"/>
+      <point x="435" y="379.0" type="curve" smooth="yes"/>
+      <point x="400" y="379.0"/>
+      <point x="361" y="362.0"/>
+      <point x="342" y="335.0" type="curve"/>
+      <point x="306" y="352" type="line"/>
+      <point x="364" y="541" type="line"/>
       <point x="567" y="541" type="line"/>
-      <point x="555" y="473" type="line"/>
-      <point x="403" y="473" type="line"/>
-      <point x="378" y="399" type="line"/>
-      <point x="394" y="412"/>
-      <point x="419" y="420"/>
+      <point x="560" y="500" type="line"/>
+      <point x="392" y="500" type="line"/>
+      <point x="358" y="385" type="line"/>
+      <point x="378" y="406"/>
+      <point x="411" y="420"/>
       <point x="443" y="420" type="curve" smooth="yes"/>
       <point x="504" y="420"/>
       <point x="548" y="380"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="342"/>
   <outline>
     <contour>
-      <point x="55" y="414" type="line"/>
-      <point x="340" y="414" type="line"/>
-      <point x="356" y="490" type="line"/>
-      <point x="159" y="490" type="line"/>
-      <point x="246" y="588" type="line"/>
-      <point x="249" y="588" type="line"/>
-      <point x="206" y="350" type="line"/>
-      <point x="292" y="350" type="line"/>
-      <point x="357" y="716" type="line"/>
-      <point x="276" y="716" type="line"/>
-      <point x="69" y="482" type="line"/>
+      <point x="51" y="419" type="line"/>
+      <point x="342" y="419" type="line"/>
+      <point x="354" y="488" type="line"/>
+      <point x="152" y="488" type="line"/>
+      <point x="240" y="587" type="line"/>
+      <point x="245" y="587" type="line"/>
+      <point x="203" y="350" type="line"/>
+      <point x="286" y="350" type="line"/>
+      <point x="351" y="716" type="line"/>
+      <point x="270" y="716" type="line"/>
+      <point x="59" y="476" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="321" y="300" type="line"/>
-      <point x="438" y="300" type="line"/>
-      <point x="467" y="458" type="line"/>
-      <point x="460" y="458" type="line"/>
+      <point x="345" y="309" type="line"/>
+      <point x="430" y="309" type="line"/>
+      <point x="450" y="424" type="line"/>
+      <point x="447" y="424" type="line"/>
     </contour>
     <contour>
-      <point x="417" y="175" type="line"/>
-      <point x="430" y="256" type="line"/>
-      <point x="255" y="256" type="line"/>
-      <point x="262" y="293" type="line"/>
-      <point x="486" y="541" type="line"/>
-      <point x="531" y="541" type="line"/>
-      <point x="487" y="300" type="line"/>
-      <point x="546" y="300" type="line"/>
-      <point x="538" y="256" type="line"/>
-      <point x="479" y="256" type="line"/>
-      <point x="466" y="175" type="line"/>
+      <point x="406" y="175" type="line"/>
+      <point x="418" y="246" type="line"/>
+      <point x="249" y="246" type="line"/>
+      <point x="260" y="303" type="line"/>
+      <point x="475" y="541" type="line"/>
+      <point x="547" y="541" type="line"/>
+      <point x="506" y="309" type="line"/>
+      <point x="555" y="309" type="line"/>
+      <point x="543" y="246" type="line"/>
+      <point x="494" y="246" type="line"/>
+      <point x="482" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="343" y="308" type="line"/>
-      <point x="424" y="308" type="line"/>
-      <point x="444" y="417" type="line"/>
-      <point x="444" y="417" type="line"/>
+      <point x="321" y="300" type="line"/>
+      <point x="438" y="300" type="line"/>
+      <point x="467" y="458" type="line"/>
+      <point x="460" y="458" type="line"/>
     </contour>
     <contour>
-      <point x="401" y="175" type="line"/>
-      <point x="412" y="243" type="line"/>
-      <point x="251" y="243" type="line"/>
-      <point x="260" y="296" type="line"/>
-      <point x="476" y="541" type="line"/>
-      <point x="546" y="541" type="line"/>
-      <point x="504" y="308" type="line"/>
-      <point x="548" y="308" type="line"/>
-      <point x="536" y="243" type="line"/>
-      <point x="492" y="243" type="line"/>
-      <point x="481" y="175" type="line"/>
+      <point x="417" y="175" type="line"/>
+      <point x="430" y="256" type="line"/>
+      <point x="255" y="256" type="line"/>
+      <point x="262" y="293" type="line"/>
+      <point x="486" y="541" type="line"/>
+      <point x="531" y="541" type="line"/>
+      <point x="487" y="300" type="line"/>
+      <point x="546" y="300" type="line"/>
+      <point x="538" y="256" type="line"/>
+      <point x="479" y="256" type="line"/>
+      <point x="466" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="315"/>
   <outline>
     <contour>
-      <point x="156" y="332" type="line"/>
-      <point x="201" y="381"/>
-      <point x="249" y="433"/>
-      <point x="294" y="482" type="curve" smooth="yes"/>
-      <point x="341" y="533"/>
-      <point x="354" y="570"/>
-      <point x="354" y="614" type="curve" smooth="yes"/>
-      <point x="354" y="673"/>
-      <point x="299" y="724"/>
-      <point x="232" y="724" type="curve" smooth="yes"/>
-      <point x="141.0" y="724.0"/>
-      <point x="78.0" y="662.0"/>
-      <point x="78" y="579" type="curve" smooth="yes"/>
-      <point x="78" y="514"/>
-      <point x="125.0" y="473.0"/>
-      <point x="180.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="188" y="473"/>
-      <point x="195" y="474"/>
-      <point x="198" y="475" type="curve"/>
-      <point x="169" y="444"/>
-      <point x="136" y="414"/>
-      <point x="101" y="377" type="curve"/>
+      <point x="154.0" y="330.0" type="line"/>
+      <point x="200.0" y="377.0"/>
+      <point x="242" y="427"/>
+      <point x="291.0" y="476.0" type="curve" smooth="yes"/>
+      <point x="338" y="523"/>
+      <point x="358" y="556"/>
+      <point x="358.0" y="613.0" type="curve" smooth="yes"/>
+      <point x="358" y="675"/>
+      <point x="307" y="725"/>
+      <point x="232" y="725.0" type="curve" smooth="yes"/>
+      <point x="146" y="725"/>
+      <point x="77.0" y="666.0"/>
+      <point x="77.0" y="583" type="curve" smooth="yes"/>
+      <point x="77" y="523"/>
+      <point x="119.0" y="475.0"/>
+      <point x="185.0" y="475.0" type="curve" smooth="yes"/>
+      <point x="188.0" y="475.0"/>
+      <point x="196.0" y="476.0"/>
+      <point x="198.0" y="477.0" type="curve"/>
+      <point x="165.0" y="455.0"/>
+      <point x="129.0" y="418.0"/>
+      <point x="95.0" y="381.0" type="curve"/>
     </contour>
     <contour>
-      <point x="209" y="539" type="curve" smooth="yes"/>
-      <point x="174" y="539"/>
-      <point x="156" y="556"/>
-      <point x="156" y="591" type="curve" smooth="yes"/>
-      <point x="156" y="631"/>
-      <point x="185" y="656"/>
-      <point x="223" y="656" type="curve" smooth="yes"/>
-      <point x="258" y="656"/>
-      <point x="274" y="637"/>
-      <point x="274" y="607" type="curve" smooth="yes"/>
-      <point x="274" y="566"/>
-      <point x="247" y="539"/>
+      <point x="208.0" y="537.0" type="curve" smooth="yes"/>
+      <point x="176.0" y="537.0"/>
+      <point x="159.0" y="561.0"/>
+      <point x="159.0" y="593.0" type="curve" smooth="yes"/>
+      <point x="159.0" y="629.0"/>
+      <point x="191.0" y="660.0"/>
+      <point x="224.0" y="660.0" type="curve" smooth="yes"/>
+      <point x="256.0" y="660.0"/>
+      <point x="273.0" y="637.0"/>
+      <point x="273.0" y="607.0" type="curve" smooth="yes"/>
+      <point x="273.0" y="570.0"/>
+      <point x="247.0" y="537.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="381" y="158" type="curve"/>
-      <point x="328" y="202" type="line"/>
-      <point x="363" y="239"/>
-      <point x="398" y="275"/>
-      <point x="428" y="303" type="curve"/>
-      <point x="425" y="302"/>
-      <point x="420" y="301"/>
+      <point x="377" y="159" type="curve"/>
+      <point x="343" y="188" type="line"/>
+      <point x="378" y="225"/>
+      <point x="435" y="281"/>
+      <point x="471" y="315" type="curve"/>
+      <point x="456" y="305"/>
+      <point x="431" y="301"/>
       <point x="412" y="301" type="curve" smooth="yes"/>
-      <point x="349" y="301"/>
-      <point x="309" y="352"/>
-      <point x="309" y="406" type="curve" smooth="yes"/>
-      <point x="309" y="491"/>
-      <point x="378" y="551"/>
-      <point x="461" y="551" type="curve" smooth="yes"/>
-      <point x="528" y="551"/>
-      <point x="581" y="500"/>
-      <point x="581" y="441" type="curve" smooth="yes"/>
-      <point x="581" y="391"/>
-      <point x="565" y="358"/>
-      <point x="516" y="305" type="curve" smooth="yes"/>
-      <point x="471" y="256"/>
-      <point x="426" y="207"/>
+      <point x="347.0" y="301.0"/>
+      <point x="309.0" y="351.0"/>
+      <point x="309" y="404" type="curve" smooth="yes"/>
+      <point x="309" y="489"/>
+      <point x="378" y="549"/>
+      <point x="461" y="549" type="curve" smooth="yes"/>
+      <point x="528" y="549"/>
+      <point x="577" y="498"/>
+      <point x="577" y="439" type="curve" smooth="yes"/>
+      <point x="577" y="389"/>
+      <point x="560" y="358"/>
+      <point x="513" y="307" type="curve" smooth="yes"/>
+      <point x="468" y="258"/>
+      <point x="422" y="208"/>
     </contour>
     <contour>
-      <point x="435" y="363" type="curve" smooth="yes"/>
-      <point x="477" y="363"/>
-      <point x="507" y="396"/>
-      <point x="507" y="433" type="curve" smooth="yes"/>
-      <point x="507" y="463"/>
-      <point x="487" y="486"/>
-      <point x="452" y="486" type="curve" smooth="yes"/>
-      <point x="416" y="486"/>
-      <point x="381" y="455"/>
-      <point x="381" y="419" type="curve" smooth="yes"/>
-      <point x="381" y="386"/>
-      <point x="399" y="363"/>
+      <point x="431" y="338" type="curve" smooth="yes"/>
+      <point x="489" y="338"/>
+      <point x="530" y="383"/>
+      <point x="530" y="434" type="curve" smooth="yes"/>
+      <point x="530" y="476"/>
+      <point x="502" y="507"/>
+      <point x="454" y="507" type="curve" smooth="yes"/>
+      <point x="405" y="507"/>
+      <point x="358" y="465"/>
+      <point x="358" y="414" type="curve" smooth="yes"/>
+      <point x="358" y="370"/>
+      <point x="384" y="338"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="377" y="159" type="curve"/>
-      <point x="343" y="188" type="line"/>
-      <point x="378" y="225"/>
-      <point x="435" y="281"/>
-      <point x="471" y="315" type="curve"/>
-      <point x="456" y="305"/>
-      <point x="431" y="301"/>
-      <point x="412" y="301" type="curve" smooth="yes"/>
-      <point x="347.0" y="301.0"/>
-      <point x="309.0" y="351.0"/>
-      <point x="309" y="404" type="curve" smooth="yes"/>
-      <point x="309" y="489"/>
-      <point x="378" y="549"/>
-      <point x="461" y="549" type="curve" smooth="yes"/>
-      <point x="528" y="549"/>
-      <point x="577" y="498"/>
-      <point x="577" y="439" type="curve" smooth="yes"/>
-      <point x="577" y="389"/>
-      <point x="560" y="358"/>
-      <point x="513" y="307" type="curve" smooth="yes"/>
-      <point x="468" y="258"/>
-      <point x="422" y="208"/>
+      <point x="379.0" y="155.0" type="curve"/>
+      <point x="325.0" y="201.0" type="line"/>
+      <point x="356.0" y="237.0"/>
+      <point x="405.0" y="285.0"/>
+      <point x="430.0" y="303.0" type="curve"/>
+      <point x="424.0" y="299.0"/>
+      <point x="415.0" y="298.0"/>
+      <point x="407.0" y="298.0" type="curve" smooth="yes"/>
+      <point x="346.0" y="298.0"/>
+      <point x="305.0" y="351.0"/>
+      <point x="305.0" y="405.0" type="curve" smooth="yes"/>
+      <point x="305.0" y="490.0"/>
+      <point x="376.0" y="550.0"/>
+      <point x="461.0" y="550.0" type="curve" smooth="yes"/>
+      <point x="530.0" y="550.0"/>
+      <point x="582.0" y="498.0"/>
+      <point x="582.0" y="439.0" type="curve" smooth="yes"/>
+      <point x="582.0" y="389.0"/>
+      <point x="568.0" y="355.0"/>
+      <point x="519.0" y="304.0" type="curve" smooth="yes"/>
+      <point x="472.0" y="255.0"/>
+      <point x="424.0" y="204.0"/>
     </contour>
     <contour>
-      <point x="431" y="338" type="curve" smooth="yes"/>
-      <point x="489" y="338"/>
-      <point x="530" y="383"/>
-      <point x="530" y="434" type="curve" smooth="yes"/>
-      <point x="530" y="476"/>
-      <point x="502" y="507"/>
-      <point x="454" y="507" type="curve" smooth="yes"/>
-      <point x="405" y="507"/>
-      <point x="358" y="465"/>
-      <point x="358" y="414" type="curve" smooth="yes"/>
-      <point x="358" y="370"/>
-      <point x="384" y="338"/>
+      <point x="435.0" y="361.0" type="curve" smooth="yes"/>
+      <point x="477.0" y="361.0"/>
+      <point x="505.0" y="394.0"/>
+      <point x="505.0" y="432.0" type="curve" smooth="yes"/>
+      <point x="505.0" y="463.0"/>
+      <point x="486.0" y="486.0"/>
+      <point x="452.0" y="486.0" type="curve" smooth="yes"/>
+      <point x="416.0" y="486.0"/>
+      <point x="383.0" y="454.0"/>
+      <point x="383.0" y="417.0" type="curve" smooth="yes"/>
+      <point x="383.0" y="385.0"/>
+      <point x="400.0" y="361.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.numerator.glif
@@ -3,13 +3,13 @@
   <advance width="239"/>
   <outline>
     <contour>
-      <point x="120" y="350" type="line"/>
-      <point x="210" y="350" type="line"/>
-      <point x="275" y="716" type="line"/>
-      <point x="182" y="716" type="line"/>
-      <point x="68" y="638" type="line"/>
-      <point x="110" y="565" type="line"/>
-      <point x="166" y="606" type="line"/>
+      <point x="123" y="350" type="line"/>
+      <point x="207" y="350" type="line"/>
+      <point x="272" y="716" type="line"/>
+      <point x="197" y="716" type="line"/>
+      <point x="74" y="631" type="line"/>
+      <point x="113" y="570" type="line"/>
+      <point x="169" y="611" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="382" y="176" type="line"/>
-      <point x="438" y="488" type="line"/>
-      <point x="354" y="427" type="line"/>
-      <point x="331" y="463" type="line"/>
-      <point x="444" y="542" type="line"/>
-      <point x="493" y="542" type="line"/>
-      <point x="428" y="176" type="line"/>
+      <point x="359" y="176" type="line"/>
+      <point x="405" y="436" type="line"/>
+      <point x="358" y="401" type="line"/>
+      <point x="318" y="463" type="line"/>
+      <point x="430" y="542" type="line"/>
+      <point x="509" y="542" type="line"/>
+      <point x="444" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="359" y="176" type="line"/>
-      <point x="405" y="432" type="line"/>
-      <point x="349" y="391" type="line"/>
-      <point x="310" y="454" type="line"/>
-      <point x="433" y="542" type="line"/>
-      <point x="509" y="542" type="line"/>
-      <point x="444" y="176" type="line"/>
+      <point x="382" y="176" type="line"/>
+      <point x="438" y="488" type="line"/>
+      <point x="354" y="427" type="line"/>
+      <point x="331" y="463" type="line"/>
+      <point x="444" y="542" type="line"/>
+      <point x="493" y="542" type="line"/>
+      <point x="428" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.numerator.glif
@@ -3,17 +3,17 @@
   <advance width="297"/>
   <outline>
     <contour>
-      <point x="127" y="333" type="line"/>
-      <point x="198" y="438"/>
-      <point x="261" y="535"/>
-      <point x="339" y="644" type="curve"/>
-      <point x="353" y="716" type="line"/>
-      <point x="105" y="716" type="line"/>
-      <point x="95" y="637" type="line"/>
-      <point x="246" y="637" type="line"/>
-      <point x="177" y="541"/>
-      <point x="132" y="476"/>
-      <point x="63" y="380" type="curve"/>
+      <point x="114" y="333" type="line"/>
+      <point x="192" y="442"/>
+      <point x="265" y="541"/>
+      <point x="343" y="650" type="curve"/>
+      <point x="355" y="716" type="line"/>
+      <point x="100" y="716" type="line"/>
+      <point x="87" y="642" type="line"/>
+      <point x="243" y="642" type="line"/>
+      <point x="184" y="561"/>
+      <point x="114" y="467"/>
+      <point x="47" y="379" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="345" y="161" type="curve"/>
-      <point x="308" y="189" type="line"/>
-      <point x="377" y="285"/>
-      <point x="463" y="406"/>
-      <point x="526" y="499" type="curve"/>
-      <point x="333" y="499" type="line"/>
+      <point x="347" y="161" type="curve"/>
+      <point x="293" y="199" type="line"/>
+      <point x="362" y="295"/>
+      <point x="424" y="378"/>
+      <point x="493" y="474" type="curve"/>
+      <point x="327" y="474" type="line"/>
       <point x="340" y="542" type="line"/>
       <point x="588" y="542" type="line"/>
-      <point x="581" y="504" type="line"/>
-      <point x="503" y="395"/>
-      <point x="423" y="270"/>
+      <point x="577" y="481" type="line"/>
+      <point x="499" y="372"/>
+      <point x="424" y="268"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -19,15 +19,15 @@
     </contour>
     <contour>
       <point x="345" y="161" type="curve"/>
-      <point x="287" y="202" type="line"/>
-      <point x="356" y="298"/>
-      <point x="416" y="377"/>
-      <point x="485" y="473" type="curve"/>
-      <point x="320" y="473" type="line"/>
-      <point x="333" y="542" type="line"/>
+      <point x="308" y="189" type="line"/>
+      <point x="377" y="285"/>
+      <point x="463" y="406"/>
+      <point x="526" y="499" type="curve"/>
+      <point x="333" y="499" type="line"/>
+      <point x="340" y="542" type="line"/>
       <point x="588" y="542" type="line"/>
-      <point x="578" y="487" type="line"/>
-      <point x="500" y="378"/>
+      <point x="581" y="504" type="line"/>
+      <point x="503" y="395"/>
       <point x="423" y="270"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.numerator.glif
@@ -3,42 +3,42 @@
   <advance width="314"/>
   <outline>
     <contour>
-      <point x="177" y="342" type="curve" smooth="yes"/>
-      <point x="268.0" y="342.0"/>
-      <point x="331.0" y="404.0"/>
-      <point x="331" y="487" type="curve" smooth="yes"/>
-      <point x="331" y="552"/>
-      <point x="284" y="593.0"/>
-      <point x="229" y="593.0" type="curve" smooth="yes"/>
-      <point x="221" y="593"/>
-      <point x="214" y="592"/>
-      <point x="211" y="591" type="curve"/>
-      <point x="240" y="622"/>
-      <point x="273" y="652"/>
-      <point x="308" y="689" type="curve"/>
-      <point x="253" y="734" type="line"/>
-      <point x="208" y="685"/>
-      <point x="160" y="633"/>
-      <point x="115" y="584" type="curve" smooth="yes"/>
-      <point x="68" y="533"/>
-      <point x="55" y="496"/>
-      <point x="55" y="452" type="curve" smooth="yes"/>
-      <point x="55" y="393"/>
-      <point x="110" y="342"/>
+      <point x="176.0" y="342.0" type="curve" smooth="yes"/>
+      <point x="262.0" y="342.0"/>
+      <point x="334.0" y="403"/>
+      <point x="334.0" y="490" type="curve" smooth="yes"/>
+      <point x="334.0" y="544"/>
+      <point x="292" y="592"/>
+      <point x="226" y="592" type="curve" smooth="yes"/>
+      <point x="223" y="592"/>
+      <point x="215" y="591"/>
+      <point x="213" y="590" type="curve"/>
+      <point x="246" y="612"/>
+      <point x="282" y="649"/>
+      <point x="316" y="686" type="curve"/>
+      <point x="257" y="737" type="line"/>
+      <point x="212" y="688"/>
+      <point x="169.0" y="638"/>
+      <point x="122.0" y="588" type="curve" smooth="yes"/>
+      <point x="73.0" y="536"/>
+      <point x="56.0" y="505"/>
+      <point x="56.0" y="454" type="curve" smooth="yes"/>
+      <point x="56.0" y="394"/>
+      <point x="107.0" y="342.0"/>
     </contour>
     <contour>
-      <point x="186" y="410" type="curve" smooth="yes"/>
-      <point x="151" y="410"/>
-      <point x="135" y="429"/>
-      <point x="135" y="459" type="curve" smooth="yes"/>
-      <point x="135" y="500"/>
-      <point x="162" y="527"/>
-      <point x="200" y="527" type="curve" smooth="yes"/>
-      <point x="235" y="527"/>
-      <point x="253" y="510"/>
-      <point x="253" y="475" type="curve" smooth="yes"/>
-      <point x="253" y="435"/>
-      <point x="224" y="410"/>
+      <point x="187" y="407" type="curve" smooth="yes"/>
+      <point x="155" y="407"/>
+      <point x="136" y="430"/>
+      <point x="136" y="460" type="curve" smooth="yes"/>
+      <point x="136" y="497"/>
+      <point x="164" y="530"/>
+      <point x="203" y="530" type="curve" smooth="yes"/>
+      <point x="235" y="530"/>
+      <point x="252" y="506"/>
+      <point x="252" y="474" type="curve" smooth="yes"/>
+      <point x="252" y="438"/>
+      <point x="220" y="407"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="419" y="213" type="curve" smooth="yes"/>
-      <point x="468" y="213"/>
-      <point x="515" y="255"/>
-      <point x="515" y="306" type="curve" smooth="yes"/>
-      <point x="515" y="350"/>
-      <point x="489" y="382"/>
-      <point x="442" y="382" type="curve" smooth="yes"/>
-      <point x="384" y="382"/>
-      <point x="343" y="337"/>
-      <point x="343" y="286" type="curve" smooth="yes"/>
-      <point x="343" y="244"/>
-      <point x="371" y="213"/>
+      <point x="421" y="235" type="curve" smooth="yes"/>
+      <point x="457" y="235"/>
+      <point x="490" y="267"/>
+      <point x="490" y="304" type="curve" smooth="yes"/>
+      <point x="490" y="336"/>
+      <point x="473" y="360"/>
+      <point x="438" y="360" type="curve" smooth="yes"/>
+      <point x="396" y="360"/>
+      <point x="368" y="327"/>
+      <point x="368" y="289" type="curve" smooth="yes"/>
+      <point x="368" y="258"/>
+      <point x="387" y="235"/>
     </contour>
     <contour>
-      <point x="412" y="171" type="curve" smooth="yes"/>
-      <point x="345" y="171"/>
-      <point x="296" y="222"/>
-      <point x="296" y="281" type="curve" smooth="yes"/>
-      <point x="296" y="331"/>
-      <point x="313" y="362"/>
-      <point x="360" y="413" type="curve" smooth="yes"/>
-      <point x="405" y="462"/>
-      <point x="451" y="512"/>
-      <point x="496" y="561" type="curve"/>
-      <point x="530" y="532" type="line"/>
-      <point x="495" y="495"/>
-      <point x="438" y="439"/>
-      <point x="402" y="405" type="curve"/>
-      <point x="417" y="415"/>
-      <point x="442" y="419"/>
-      <point x="461" y="419" type="curve" smooth="yes"/>
-      <point x="526.0" y="419.0"/>
-      <point x="564.0" y="369.0"/>
-      <point x="564" y="316" type="curve" smooth="yes"/>
-      <point x="564" y="231"/>
-      <point x="495" y="171"/>
+      <point x="412" y="171.0" type="curve" smooth="yes"/>
+      <point x="343" y="171.0"/>
+      <point x="291" y="223.0"/>
+      <point x="291" y="282.0" type="curve" smooth="yes"/>
+      <point x="291" y="332.0"/>
+      <point x="305" y="366.0"/>
+      <point x="354" y="417.0" type="curve" smooth="yes"/>
+      <point x="401" y="466.0"/>
+      <point x="449" y="517"/>
+      <point x="494" y="566" type="curve"/>
+      <point x="548" y="520" type="line"/>
+      <point x="517" y="484"/>
+      <point x="468" y="436"/>
+      <point x="443" y="418" type="curve"/>
+      <point x="449" y="422"/>
+      <point x="458" y="423"/>
+      <point x="466" y="423" type="curve" smooth="yes"/>
+      <point x="527" y="423"/>
+      <point x="568" y="370.0"/>
+      <point x="568" y="316.0" type="curve" smooth="yes"/>
+      <point x="568" y="231.0"/>
+      <point x="497" y="171.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,39 +18,39 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="422" y="236" type="curve" smooth="yes"/>
-      <point x="457" y="236"/>
-      <point x="492" y="267"/>
-      <point x="492" y="303" type="curve" smooth="yes"/>
-      <point x="492" y="335"/>
-      <point x="473" y="359"/>
-      <point x="438" y="359" type="curve" smooth="yes"/>
-      <point x="396" y="359"/>
-      <point x="366" y="326"/>
-      <point x="366" y="289" type="curve" smooth="yes"/>
-      <point x="366" y="259"/>
-      <point x="387" y="236"/>
+      <point x="419" y="213" type="curve" smooth="yes"/>
+      <point x="468" y="213"/>
+      <point x="515" y="255"/>
+      <point x="515" y="306" type="curve" smooth="yes"/>
+      <point x="515" y="350"/>
+      <point x="489" y="382"/>
+      <point x="442" y="382" type="curve" smooth="yes"/>
+      <point x="384" y="382"/>
+      <point x="343" y="337"/>
+      <point x="343" y="286" type="curve" smooth="yes"/>
+      <point x="343" y="244"/>
+      <point x="371" y="213"/>
     </contour>
     <contour>
       <point x="412" y="171" type="curve" smooth="yes"/>
       <point x="345" y="171"/>
-      <point x="292" y="222"/>
-      <point x="292" y="281" type="curve" smooth="yes"/>
-      <point x="292" y="331"/>
-      <point x="308" y="366"/>
-      <point x="355" y="417" type="curve" smooth="yes"/>
-      <point x="400" y="466"/>
-      <point x="446" y="516"/>
-      <point x="491" y="565" type="curve"/>
-      <point x="545" y="521" type="line"/>
-      <point x="510" y="484"/>
-      <point x="476" y="448"/>
-      <point x="448" y="420" type="curve"/>
-      <point x="452" y="421"/>
-      <point x="457" y="421"/>
-      <point x="463" y="421" type="curve" smooth="yes"/>
-      <point x="527" y="421"/>
-      <point x="564" y="370"/>
+      <point x="296" y="222"/>
+      <point x="296" y="281" type="curve" smooth="yes"/>
+      <point x="296" y="331"/>
+      <point x="313" y="362"/>
+      <point x="360" y="413" type="curve" smooth="yes"/>
+      <point x="405" y="462"/>
+      <point x="451" y="512"/>
+      <point x="496" y="561" type="curve"/>
+      <point x="530" y="532" type="line"/>
+      <point x="495" y="495"/>
+      <point x="438" y="439"/>
+      <point x="402" y="405" type="curve"/>
+      <point x="417" y="415"/>
+      <point x="442" y="419"/>
+      <point x="461" y="419" type="curve" smooth="yes"/>
+      <point x="526.0" y="419.0"/>
+      <point x="564.0" y="369.0"/>
       <point x="564" y="316" type="curve" smooth="yes"/>
       <point x="564" y="231"/>
       <point x="495" y="171"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.numerator.glif
@@ -3,51 +3,51 @@
   <advance width="321"/>
   <outline>
     <contour>
-      <point x="180" y="342" type="curve" smooth="yes"/>
-      <point x="263" y="342"/>
-      <point x="340" y="394"/>
-      <point x="340" y="464" type="curve" smooth="yes"/>
-      <point x="340" y="501"/>
-      <point x="319" y="528"/>
-      <point x="290" y="542" type="curve"/>
-      <point x="336" y="559"/>
-      <point x="357" y="592"/>
-      <point x="357" y="633" type="curve" smooth="yes"/>
-      <point x="357" y="685"/>
+      <point x="183" y="342.0" type="curve" smooth="yes"/>
+      <point x="267" y="342"/>
+      <point x="332" y="394.0"/>
+      <point x="332" y="464.0" type="curve" smooth="yes"/>
+      <point x="332" y="501.0"/>
+      <point x="309" y="531.0"/>
+      <point x="275.0" y="542.0" type="curve"/>
+      <point x="312" y="554.0"/>
+      <point x="348" y="592.0"/>
+      <point x="348" y="633.0" type="curve" smooth="yes"/>
+      <point x="348" y="685.0"/>
       <point x="308" y="724"/>
-      <point x="245" y="724.0" type="curve" smooth="yes"/>
-      <point x="172" y="724"/>
-      <point x="123" y="691"/>
-      <point x="105" y="643" type="curve"/>
-      <point x="166" y="616" type="line"/>
-      <point x="178" y="637"/>
-      <point x="198" y="649"/>
-      <point x="223" y="649.0" type="curve" smooth="yes"/>
-      <point x="249" y="649"/>
-      <point x="262" y="633"/>
-      <point x="262.0" y="614" type="curve" smooth="yes"/>
-      <point x="262" y="597"/>
-      <point x="245" y="578"/>
-      <point x="209" y="578" type="curve" smooth="yes"/>
-      <point x="197" y="578.0"/>
-      <point x="185" y="578.0"/>
-      <point x="173" y="578" type="curve"/>
-      <point x="163" y="508" type="line"/>
-      <point x="174" y="508.0"/>
-      <point x="184" y="508.0"/>
-      <point x="195" y="508" type="curve" smooth="yes"/>
-      <point x="234" y="508"/>
-      <point x="248" y="485"/>
-      <point x="248" y="462" type="curve" smooth="yes"/>
-      <point x="248" y="438"/>
-      <point x="226" y="421"/>
-      <point x="194" y="421.0" type="curve" smooth="yes"/>
-      <point x="153" y="421"/>
-      <point x="141" y="441"/>
-      <point x="133" y="471" type="curve"/>
-      <point x="58" y="441" type="line"/>
-      <point x="69" y="373"/>
-      <point x="124" y="342"/>
+      <point x="234" y="724.0" type="curve" smooth="yes"/>
+      <point x="168" y="724"/>
+      <point x="117" y="690"/>
+      <point x="98" y="640" type="curve"/>
+      <point x="163" y="610" type="line"/>
+      <point x="171" y="628"/>
+      <point x="198" y="657"/>
+      <point x="224" y="657" type="curve" smooth="yes"/>
+      <point x="251" y="657"/>
+      <point x="266" y="642"/>
+      <point x="266" y="621" type="curve" smooth="yes"/>
+      <point x="266" y="594"/>
+      <point x="242" y="571"/>
+      <point x="207" y="571" type="curve" smooth="yes"/>
+      <point x="196" y="571"/>
+      <point x="182" y="571"/>
+      <point x="170" y="571" type="curve"/>
+      <point x="159" y="509" type="line"/>
+      <point x="170" y="509.0"/>
+      <point x="184" y="509"/>
+      <point x="195" y="509" type="curve" smooth="yes"/>
+      <point x="225" y="509"/>
+      <point x="248" y="495"/>
+      <point x="248" y="464" type="curve" smooth="yes"/>
+      <point x="248" y="431"/>
+      <point x="218" y="407"/>
+      <point x="188" y="407.0" type="curve" smooth="yes"/>
+      <point x="151" y="407"/>
+      <point x="130" y="430"/>
+      <point x="120" y="472" type="curve"/>
+      <point x="51" y="441.0" type="line"/>
+      <point x="63" y="376"/>
+      <point x="116.0" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="408" y="166" type="curve" smooth="yes"/>
+      <point x="400" y="166" type="curve" smooth="yes"/>
       <point x="344" y="166"/>
-      <point x="289" y="197"/>
-      <point x="278" y="265" type="curve"/>
-      <point x="322" y="279.0" type="line"/>
-      <point x="335" y="229.0"/>
-      <point x="365" y="206.0"/>
-      <point x="407" y="206.0" type="curve" smooth="yes"/>
-      <point x="454" y="206.0"/>
-      <point x="493" y="237.0"/>
-      <point x="493" y="277.0" type="curve" smooth="yes"/>
-      <point x="493" y="316.0"/>
-      <point x="464" y="339.0"/>
-      <point x="416" y="339.0" type="curve" smooth="yes"/>
-      <point x="402" y="339.0"/>
-      <point x="390" y="339.0"/>
-      <point x="377" y="339.0" type="curve"/>
-      <point x="382.0" y="378" type="line"/>
-      <point x="397.0" y="378"/>
-      <point x="410" y="378"/>
-      <point x="424.0" y="378" type="curve" smooth="yes"/>
-      <point x="472" y="378.0"/>
-      <point x="505" y="414"/>
-      <point x="505.0" y="450" type="curve" smooth="yes"/>
-      <point x="505" y="485"/>
-      <point x="487.0" y="509.0"/>
-      <point x="447.0" y="509" type="curve" smooth="yes"/>
-      <point x="404" y="509"/>
-      <point x="377.0" y="473"/>
-      <point x="365.0" y="446" type="curve"/>
-      <point x="325" y="467" type="line"/>
-      <point x="343" y="515"/>
-      <point x="392" y="548"/>
-      <point x="451" y="548.0" type="curve" smooth="yes"/>
-      <point x="518" y="548"/>
-      <point x="552" y="509"/>
-      <point x="552.0" y="461" type="curve" smooth="yes"/>
-      <point x="552" y="416"/>
-      <point x="522" y="381"/>
-      <point x="480" y="364" type="curve"/>
-      <point x="516" y="351"/>
-      <point x="541" y="325"/>
-      <point x="541" y="288" type="curve" smooth="yes"/>
-      <point x="541" y="218"/>
+      <point x="285" y="199"/>
+      <point x="274" y="267" type="curve"/>
+      <point x="345" y="292" type="line"/>
+      <point x="353" y="255"/>
+      <point x="373" y="232"/>
+      <point x="409" y="232.0" type="curve" smooth="yes"/>
+      <point x="446" y="232"/>
+      <point x="471" y="251"/>
+      <point x="471" y="286" type="curve" smooth="yes"/>
+      <point x="471" y="319"/>
+      <point x="448" y="333"/>
+      <point x="414" y="333" type="curve" smooth="yes"/>
+      <point x="403" y="333"/>
+      <point x="393" y="333.0"/>
+      <point x="382" y="333" type="curve"/>
+      <point x="394" y="395" type="line"/>
+      <point x="405" y="395"/>
+      <point x="416" y="395"/>
+      <point x="427" y="395" type="curve" smooth="yes"/>
+      <point x="460.0" y="395.0"/>
+      <point x="486.0" y="413.0"/>
+      <point x="486.0" y="443.0" type="curve" smooth="yes"/>
+      <point x="486.0" y="467.0"/>
+      <point x="467" y="481.0"/>
+      <point x="445" y="481.0" type="curve" smooth="yes"/>
+      <point x="412" y="481.0"/>
+      <point x="395" y="458.0"/>
+      <point x="386" y="440.0" type="curve"/>
+      <point x="323" y="468" type="line"/>
+      <point x="341" y="516"/>
+      <point x="389" y="548"/>
+      <point x="454" y="548" type="curve" smooth="yes"/>
+      <point x="524" y="548"/>
+      <point x="566" y="509"/>
+      <point x="566" y="457" type="curve" smooth="yes"/>
+      <point x="566" y="416"/>
+      <point x="534" y="379"/>
+      <point x="501" y="366" type="curve"/>
+      <point x="527" y="354"/>
+      <point x="550" y="325"/>
+      <point x="550" y="288" type="curve" smooth="yes"/>
+      <point x="550" y="218"/>
       <point x="483" y="166"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,50 +18,50 @@
       <point x="231" y="-16"/>
     </contour>
     <contour>
-      <point x="400" y="166" type="curve" smooth="yes"/>
+      <point x="408" y="166" type="curve" smooth="yes"/>
       <point x="344" y="166"/>
       <point x="289" y="197"/>
       <point x="278" y="265" type="curve"/>
-      <point x="342" y="290.0" type="line"/>
-      <point x="352" y="252.0"/>
-      <point x="373" y="235.0"/>
-      <point x="404" y="235.0" type="curve" smooth="yes"/>
-      <point x="439" y="235.0"/>
-      <point x="468" y="258.0"/>
-      <point x="468" y="289.0" type="curve" smooth="yes"/>
-      <point x="468" y="319.0"/>
-      <point x="454" y="332"/>
-      <point x="415" y="332" type="curve" smooth="yes"/>
-      <point x="404" y="332.0"/>
-      <point x="394" y="332.0"/>
-      <point x="383" y="332" type="curve"/>
-      <point x="393" y="396" type="line"/>
-      <point x="404" y="396"/>
-      <point x="417" y="396"/>
-      <point x="428" y="396" type="curve"/>
-      <point x="460" y="396"/>
-      <point x="486" y="413"/>
-      <point x="486" y="441" type="curve" smooth="yes"/>
-      <point x="486" y="465"/>
-      <point x="467" y="479"/>
-      <point x="444" y="479" type="curve" smooth="yes"/>
-      <point x="410" y="479"/>
-      <point x="393" y="456"/>
-      <point x="383" y="438" type="curve"/>
-      <point x="320" y="464" type="line"/>
-      <point x="338" y="512"/>
+      <point x="322" y="279.0" type="line"/>
+      <point x="335" y="229.0"/>
+      <point x="365" y="206.0"/>
+      <point x="407" y="206.0" type="curve" smooth="yes"/>
+      <point x="454" y="206.0"/>
+      <point x="493" y="237.0"/>
+      <point x="493" y="277.0" type="curve" smooth="yes"/>
+      <point x="493" y="316.0"/>
+      <point x="464" y="339.0"/>
+      <point x="416" y="339.0" type="curve" smooth="yes"/>
+      <point x="402" y="339.0"/>
+      <point x="390" y="339.0"/>
+      <point x="377" y="339.0" type="curve"/>
+      <point x="382.0" y="378" type="line"/>
+      <point x="397.0" y="378"/>
+      <point x="410" y="378"/>
+      <point x="424.0" y="378" type="curve" smooth="yes"/>
+      <point x="472" y="378.0"/>
+      <point x="505" y="414"/>
+      <point x="505.0" y="450" type="curve" smooth="yes"/>
+      <point x="505" y="485"/>
+      <point x="487.0" y="509.0"/>
+      <point x="447.0" y="509" type="curve" smooth="yes"/>
+      <point x="404" y="509"/>
+      <point x="377.0" y="473"/>
+      <point x="365.0" y="446" type="curve"/>
+      <point x="325" y="467" type="line"/>
+      <point x="343" y="515"/>
       <point x="392" y="548"/>
-      <point x="454" y="548" type="curve" smooth="yes"/>
+      <point x="451" y="548.0" type="curve" smooth="yes"/>
       <point x="518" y="548"/>
-      <point x="562" y="509"/>
-      <point x="562" y="457" type="curve" smooth="yes"/>
-      <point x="562" y="416"/>
-      <point x="529" y="379"/>
-      <point x="495" y="366" type="curve"/>
-      <point x="524" y="352"/>
-      <point x="545" y="325"/>
-      <point x="545" y="288" type="curve" smooth="yes"/>
-      <point x="545" y="218"/>
+      <point x="552" y="509"/>
+      <point x="552.0" y="461" type="curve" smooth="yes"/>
+      <point x="552" y="416"/>
+      <point x="522" y="381"/>
+      <point x="480" y="364" type="curve"/>
+      <point x="516" y="351"/>
+      <point x="541" y="325"/>
+      <point x="541" y="288" type="curve" smooth="yes"/>
+      <point x="541" y="218"/>
       <point x="483" y="166"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.numerator.glif
@@ -5,33 +5,33 @@
     <contour>
       <point x="43" y="350" type="line"/>
       <point x="289" y="350" type="line"/>
-      <point x="305" y="429" type="line"/>
-      <point x="176" y="429" type="line"/>
-      <point x="176" y="429"/>
-      <point x="243" y="483"/>
-      <point x="269" y="505" type="curve"/>
-      <point x="312" y="541"/>
-      <point x="345" y="573"/>
-      <point x="345" y="627" type="curve" smooth="yes"/>
-      <point x="345" y="683"/>
-      <point x="298" y="724"/>
-      <point x="223" y="724" type="curve" smooth="yes"/>
+      <point x="301" y="424" type="line"/>
+      <point x="163" y="424" type="line"/>
+      <point x="163" y="424"/>
+      <point x="228" y="474"/>
+      <point x="255" y="495" type="curve" smooth="yes"/>
+      <point x="302" y="532"/>
+      <point x="340" y="573"/>
+      <point x="340" y="627" type="curve" smooth="yes"/>
+      <point x="340" y="683"/>
+      <point x="293" y="724"/>
+      <point x="226" y="724.0" type="curve" smooth="yes"/>
       <point x="162" y="724"/>
-      <point x="103" y="694"/>
-      <point x="85" y="633" type="curve"/>
-      <point x="154" y="601" type="line"/>
-      <point x="170" y="634"/>
-      <point x="186" y="645"/>
-      <point x="209" y="645.0" type="curve" smooth="yes"/>
-      <point x="236" y="645"/>
-      <point x="247" y="628"/>
-      <point x="247.0" y="611" type="curve" smooth="yes"/>
-      <point x="247" y="589"/>
-      <point x="228" y="570"/>
-      <point x="205" y="552" type="curve" smooth="yes"/>
-      <point x="194" y="543"/>
-      <point x="57" y="425"/>
-      <point x="57" y="425" type="curve"/>
+      <point x="102" y="695"/>
+      <point x="80" y="629" type="curve"/>
+      <point x="154" y="595" type="line"/>
+      <point x="166" y="624"/>
+      <point x="186" y="655"/>
+      <point x="217" y="655" type="curve" smooth="yes"/>
+      <point x="245" y="655"/>
+      <point x="260" y="639"/>
+      <point x="260" y="620" type="curve" smooth="yes"/>
+      <point x="260" y="589"/>
+      <point x="236" y="570"/>
+      <point x="213" y="552" type="curve" smooth="yes"/>
+      <point x="202" y="543"/>
+      <point x="55" y="420"/>
+      <point x="55" y="420" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,33 +19,33 @@
     </contour>
     <contour>
       <point x="282" y="178" type="line"/>
-      <point x="292" y="218" type="line"/>
-      <point x="292" y="218"/>
-      <point x="441" y="343"/>
-      <point x="457" y="358" type="curve" smooth="yes"/>
-      <point x="505" y="404"/>
-      <point x="519.0" y="433.0"/>
-      <point x="519.0" y="461" type="curve" smooth="yes"/>
-      <point x="519" y="489"/>
-      <point x="500" y="513"/>
-      <point x="459" y="513.0" type="curve" smooth="yes"/>
-      <point x="412.0" y="513.0"/>
-      <point x="380" y="479"/>
-      <point x="367" y="440" type="curve"/>
-      <point x="329" y="457" type="line"/>
-      <point x="345" y="511"/>
-      <point x="396" y="552.0"/>
+      <point x="294" y="244" type="line"/>
+      <point x="294" y="244"/>
+      <point x="437" y="364"/>
+      <point x="452.0" y="376" type="curve" smooth="yes"/>
+      <point x="471" y="392"/>
+      <point x="500.0" y="414"/>
+      <point x="500.0" y="442" type="curve" smooth="yes"/>
+      <point x="500.0" y="468"/>
+      <point x="481.0" y="483"/>
+      <point x="456.0" y="483" type="curve" smooth="yes"/>
+      <point x="429.0" y="483"/>
+      <point x="407.0" y="466"/>
+      <point x="393.0" y="427" type="curve"/>
+      <point x="324" y="459" type="line"/>
+      <point x="342" y="520"/>
+      <point x="401" y="552"/>
       <point x="462" y="552" type="curve" smooth="yes"/>
       <point x="528" y="552"/>
-      <point x="564" y="511"/>
-      <point x="564.0" y="466" type="curve" smooth="yes"/>
-      <point x="564" y="411"/>
-      <point x="528" y="373"/>
-      <point x="486" y="335" type="curve" smooth="yes"/>
-      <point x="461" y="312"/>
-      <point x="348" y="217"/>
-      <point x="348" y="217" type="curve"/>
-      <point x="534" y="217" type="line"/>
+      <point x="579" y="511"/>
+      <point x="579" y="455" type="curve" smooth="yes"/>
+      <point x="579" y="401"/>
+      <point x="538" y="361"/>
+      <point x="495" y="325" type="curve" smooth="yes"/>
+      <point x="469" y="303"/>
+      <point x="402" y="249"/>
+      <point x="402" y="249" type="curve"/>
+      <point x="543" y="249" type="line"/>
       <point x="528" y="178" type="line"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -19,34 +19,34 @@
     </contour>
     <contour>
       <point x="282" y="178" type="line"/>
-      <point x="294" y="248" type="line"/>
-      <point x="294" y="248"/>
-      <point x="444" y="378"/>
-      <point x="452" y="385" type="curve" smooth="yes"/>
-      <point x="470" y="400"/>
-      <point x="495" y="420"/>
-      <point x="495" y="443" type="curve" smooth="yes"/>
-      <point x="495" y="464"/>
-      <point x="477" y="476"/>
-      <point x="454" y="476" type="curve" smooth="yes"/>
-      <point x="429" y="476"/>
-      <point x="408" y="462"/>
-      <point x="395" y="431" type="curve"/>
+      <point x="292" y="218" type="line"/>
+      <point x="292" y="218"/>
+      <point x="441" y="343"/>
+      <point x="457" y="358" type="curve" smooth="yes"/>
+      <point x="505" y="404"/>
+      <point x="519.0" y="433.0"/>
+      <point x="519.0" y="461" type="curve" smooth="yes"/>
+      <point x="519" y="489"/>
+      <point x="500" y="513"/>
+      <point x="459" y="513.0" type="curve" smooth="yes"/>
+      <point x="412.0" y="513.0"/>
+      <point x="380" y="479"/>
+      <point x="367" y="440" type="curve"/>
       <point x="329" y="457" type="line"/>
-      <point x="347" y="518"/>
-      <point x="401" y="552"/>
+      <point x="345" y="511"/>
+      <point x="396" y="552.0"/>
       <point x="462" y="552" type="curve" smooth="yes"/>
       <point x="528" y="552"/>
-      <point x="574" y="511"/>
-      <point x="574" y="455" type="curve" smooth="yes"/>
-      <point x="574" y="401"/>
-      <point x="536" y="369"/>
-      <point x="493" y="333" type="curve" smooth="yes"/>
-      <point x="467" y="311"/>
-      <point x="395" y="250"/>
-      <point x="395" y="250" type="curve"/>
-      <point x="550" y="250" type="line"/>
-      <point x="535" y="178" type="line"/>
+      <point x="564" y="511"/>
+      <point x="564.0" y="466" type="curve" smooth="yes"/>
+      <point x="564" y="411"/>
+      <point x="528" y="373"/>
+      <point x="486" y="335" type="curve" smooth="yes"/>
+      <point x="461" y="312"/>
+      <point x="348" y="217"/>
+      <point x="348" y="217" type="curve"/>
+      <point x="534" y="217" type="line"/>
+      <point x="528" y="178" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="46" y="105" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/zero.numerator.glif
@@ -3,32 +3,32 @@
   <advance width="371"/>
   <outline>
     <contour>
-      <point x="209" y="342" type="curve" smooth="yes"/>
-      <point x="331" y="342"/>
-      <point x="408" y="454"/>
-      <point x="408" y="565" type="curve" smooth="yes"/>
-      <point x="408" y="653"/>
-      <point x="361" y="724"/>
-      <point x="263" y="724" type="curve" smooth="yes"/>
-      <point x="143" y="724"/>
-      <point x="63" y="608"/>
-      <point x="63" y="501" type="curve" smooth="yes"/>
-      <point x="63" y="413"/>
-      <point x="122" y="342"/>
+      <point x="208" y="342.0" type="curve" smooth="yes"/>
+      <point x="323" y="342.0"/>
+      <point x="399" y="454.0"/>
+      <point x="399" y="565.0" type="curve" smooth="yes"/>
+      <point x="399" y="653.0"/>
+      <point x="354" y="724.0"/>
+      <point x="264" y="724.0" type="curve" smooth="yes"/>
+      <point x="140" y="724.0"/>
+      <point x="72" y="608.0"/>
+      <point x="72" y="501.0" type="curve" smooth="yes"/>
+      <point x="72" y="413.0"/>
+      <point x="119" y="342.0"/>
     </contour>
     <contour>
-      <point x="216" y="421" type="curve" smooth="yes"/>
-      <point x="178" y="421"/>
-      <point x="161" y="453"/>
-      <point x="161" y="504" type="curve" smooth="yes"/>
-      <point x="161" y="572"/>
-      <point x="184" y="645"/>
-      <point x="251" y="645.0" type="curve" smooth="yes"/>
-      <point x="298" y="645"/>
-      <point x="310" y="613"/>
-      <point x="310" y="562" type="curve" smooth="yes"/>
-      <point x="310" y="491"/>
-      <point x="286" y="421"/>
+      <point x="217" y="415" type="curve" smooth="yes"/>
+      <point x="167" y="415"/>
+      <point x="155" y="462"/>
+      <point x="155" y="507" type="curve" smooth="yes"/>
+      <point x="155" y="568"/>
+      <point x="186" y="649"/>
+      <point x="257" y="649" type="curve" smooth="yes"/>
+      <point x="304" y="649"/>
+      <point x="316" y="604"/>
+      <point x="316" y="559" type="curve" smooth="yes"/>
+      <point x="316" y="496"/>
+      <point x="284" y="415"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/eight.sansS_erifB_lackC_ircled.glif
@@ -18,58 +18,58 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="436" y="244" type="curve" smooth="yes"/>
-      <point x="461" y="244"/>
-      <point x="486" y="262"/>
-      <point x="486" y="289" type="curve" smooth="yes"/>
-      <point x="486" y="315"/>
-      <point x="461" y="334"/>
-      <point x="436" y="334" type="curve" smooth="yes"/>
-      <point x="410" y="334"/>
-      <point x="386" y="316"/>
-      <point x="386" y="289" type="curve" smooth="yes"/>
-      <point x="386" y="262"/>
-      <point x="409" y="244"/>
+      <point x="411" y="244" type="curve" smooth="yes"/>
+      <point x="440" y="244"/>
+      <point x="468" y="260"/>
+      <point x="468" y="294" type="curve" smooth="yes"/>
+      <point x="468" y="318"/>
+      <point x="449" y="334"/>
+      <point x="423" y="334" type="curve" smooth="yes"/>
+      <point x="392" y="334"/>
+      <point x="366" y="313"/>
+      <point x="366" y="282" type="curve" smooth="yes"/>
+      <point x="366" y="258"/>
+      <point x="386" y="244"/>
     </contour>
     <contour>
-      <point x="436" y="169" type="curve" smooth="yes"/>
-      <point x="366" y="169"/>
-      <point x="298" y="210"/>
-      <point x="298" y="283" type="curve" smooth="yes"/>
-      <point x="298" y="320"/>
-      <point x="320" y="352"/>
-      <point x="353" y="370" type="curve"/>
-      <point x="326" y="386"/>
-      <point x="310" y="415"/>
-      <point x="310" y="442" type="curve" smooth="yes"/>
-      <point x="310" y="509"/>
-      <point x="368" y="551"/>
-      <point x="436" y="551" type="curve" smooth="yes"/>
-      <point x="504" y="551"/>
-      <point x="562" y="509"/>
-      <point x="562" y="442" type="curve" smooth="yes"/>
-      <point x="562" y="415"/>
-      <point x="546" y="386"/>
-      <point x="519" y="370" type="curve"/>
-      <point x="552" y="352"/>
-      <point x="574" y="320"/>
-      <point x="574" y="283" type="curve" smooth="yes"/>
-      <point x="574" y="209"/>
-      <point x="505" y="169"/>
+      <point x="403" y="169" type="curve" smooth="yes"/>
+      <point x="331" y="169"/>
+      <point x="276" y="210"/>
+      <point x="276" y="272" type="curve" smooth="yes"/>
+      <point x="276" y="316"/>
+      <point x="307" y="355"/>
+      <point x="350" y="373" type="curve"/>
+      <point x="333" y="385"/>
+      <point x="317" y="407"/>
+      <point x="317" y="435" type="curve" smooth="yes"/>
+      <point x="317" y="499"/>
+      <point x="376" y="551"/>
+      <point x="459" y="551" type="curve" smooth="yes"/>
+      <point x="520" y="551"/>
+      <point x="572" y="513"/>
+      <point x="572" y="457" type="curve" smooth="yes"/>
+      <point x="572" y="414"/>
+      <point x="547" y="386"/>
+      <point x="515" y="369" type="curve"/>
+      <point x="537" y="354"/>
+      <point x="556" y="328"/>
+      <point x="556" y="293" type="curve" smooth="yes"/>
+      <point x="556" y="220"/>
+      <point x="491" y="169"/>
     </contour>
     <contour>
-      <point x="436" y="402" type="curve" smooth="yes"/>
-      <point x="456" y="402"/>
-      <point x="476" y="417"/>
-      <point x="476" y="439" type="curve" smooth="yes"/>
-      <point x="476" y="460"/>
-      <point x="459" y="476"/>
-      <point x="436" y="476" type="curve" smooth="yes"/>
-      <point x="413" y="476"/>
-      <point x="396" y="462"/>
-      <point x="396" y="439" type="curve" smooth="yes"/>
-      <point x="396" y="416"/>
-      <point x="415" y="402"/>
+      <point x="439" y="402" type="curve" smooth="yes"/>
+      <point x="464" y="402"/>
+      <point x="485" y="418"/>
+      <point x="485" y="444" type="curve" smooth="yes"/>
+      <point x="485" y="463"/>
+      <point x="468" y="476"/>
+      <point x="448" y="476" type="curve" smooth="yes"/>
+      <point x="426" y="476"/>
+      <point x="403" y="461"/>
+      <point x="403" y="435" type="curve" smooth="yes"/>
+      <point x="403" y="415"/>
+      <point x="419" y="402"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/five.sansS_erifB_lackC_ircled.glif
@@ -18,37 +18,37 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="436" y="169" type="curve" smooth="yes"/>
-      <point x="379" y="169"/>
-      <point x="320" y="194"/>
-      <point x="300" y="260" type="curve"/>
-      <point x="379" y="291" type="line"/>
-      <point x="385" y="263"/>
-      <point x="407" y="246"/>
-      <point x="435" y="246" type="curve" smooth="yes"/>
-      <point x="464" y="246"/>
-      <point x="485" y="268"/>
-      <point x="485" y="298" type="curve" smooth="yes"/>
-      <point x="485" y="329"/>
-      <point x="464" y="350"/>
-      <point x="436" y="350" type="curve" smooth="yes"/>
-      <point x="412" y="350"/>
-      <point x="395" y="338"/>
-      <point x="384" y="321" type="curve"/>
-      <point x="311" y="353" type="line"/>
-      <point x="334" y="542" type="line"/>
-      <point x="553" y="542" type="line"/>
-      <point x="553" y="470" type="line"/>
-      <point x="401" y="470" type="line"/>
-      <point x="387" y="392" type="line"/>
-      <point x="401" y="411"/>
-      <point x="428" y="421"/>
-      <point x="453" y="421" type="curve" smooth="yes"/>
-      <point x="516" y="421"/>
-      <point x="573" y="374"/>
-      <point x="573" y="296" type="curve" smooth="yes"/>
-      <point x="573" y="219"/>
-      <point x="508" y="169"/>
+      <point x="400" y="169" type="curve" smooth="yes"/>
+      <point x="337" y="169"/>
+      <point x="289" y="198"/>
+      <point x="272" y="260" type="curve"/>
+      <point x="350" y="289" type="line"/>
+      <point x="356" y="263"/>
+      <point x="376" y="246"/>
+      <point x="406" y="246" type="curve" smooth="yes"/>
+      <point x="437" y="246"/>
+      <point x="465" y="269"/>
+      <point x="465" y="305" type="curve" smooth="yes"/>
+      <point x="465" y="334"/>
+      <point x="445" y="350"/>
+      <point x="421" y="350" type="curve" smooth="yes"/>
+      <point x="396" y="350"/>
+      <point x="379" y="338"/>
+      <point x="366" y="321" type="curve"/>
+      <point x="299" y="353" type="line"/>
+      <point x="355" y="542" type="line"/>
+      <point x="574" y="542" type="line"/>
+      <point x="562" y="470" type="line"/>
+      <point x="408" y="470" type="line"/>
+      <point x="386" y="404" type="line"/>
+      <point x="402" y="415"/>
+      <point x="422" y="421"/>
+      <point x="446" y="421" type="curve" smooth="yes"/>
+      <point x="504" y="421"/>
+      <point x="553" y="385"/>
+      <point x="553" y="313" type="curve" smooth="yes"/>
+      <point x="553" y="229"/>
+      <point x="483" y="169"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/four.sansS_erifB_lackC_ircled.glif
@@ -18,23 +18,23 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="352" y="316" type="line"/>
-      <point x="436" y="316" type="line"/>
-      <point x="436" y="423" type="line"/>
-      <point x="428" y="423" type="line"/>
+      <point x="346" y="314" type="line"/>
+      <point x="426" y="314" type="line"/>
+      <point x="445" y="418" type="line"/>
+      <point x="437" y="418" type="line"/>
     </contour>
     <contour>
-      <point x="436" y="177" type="line"/>
-      <point x="436" y="242" type="line"/>
-      <point x="264" y="242" type="line"/>
-      <point x="264" y="306" type="line"/>
-      <point x="435" y="543" type="line"/>
-      <point x="522" y="543" type="line"/>
-      <point x="522" y="316" type="line"/>
-      <point x="570" y="316" type="line"/>
-      <point x="570" y="242" type="line"/>
-      <point x="522" y="242" type="line"/>
-      <point x="522" y="177" type="line"/>
+      <point x="401" y="175" type="line"/>
+      <point x="413" y="240" type="line"/>
+      <point x="241" y="240" type="line"/>
+      <point x="252" y="304" type="line"/>
+      <point x="465" y="541" type="line"/>
+      <point x="552" y="541" type="line"/>
+      <point x="512" y="314" type="line"/>
+      <point x="559" y="314" type="line"/>
+      <point x="546" y="240" type="line"/>
+      <point x="499" y="240" type="line"/>
+      <point x="487" y="175" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nine.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="419" y="161" type="curve"/>
-      <point x="352" y="210" type="line"/>
-      <point x="377" y="242"/>
-      <point x="402" y="274"/>
-      <point x="429" y="306" type="curve"/>
-      <point x="424" y="303"/>
-      <point x="415" y="302"/>
-      <point x="409" y="302" type="curve" smooth="yes"/>
-      <point x="352" y="302"/>
-      <point x="296" y="354"/>
-      <point x="296" y="424" type="curve" smooth="yes"/>
-      <point x="296" y="493"/>
-      <point x="357" y="551"/>
-      <point x="433" y="551" type="curve" smooth="yes"/>
-      <point x="513" y="551"/>
-      <point x="570" y="491"/>
-      <point x="570" y="422" type="curve" smooth="yes"/>
-      <point x="570" y="379"/>
-      <point x="551" y="344"/>
-      <point x="527" y="311" type="curve"/>
-      <point x="492" y="261"/>
-      <point x="456" y="211"/>
+      <point x="385" y="161" type="curve"/>
+      <point x="326" y="210" type="line"/>
+      <point x="356" y="242"/>
+      <point x="387" y="274"/>
+      <point x="417" y="306" type="curve"/>
+      <point x="411" y="303"/>
+      <point x="401" y="302"/>
+      <point x="396" y="302" type="curve" smooth="yes"/>
+      <point x="349" y="302"/>
+      <point x="306" y="347"/>
+      <point x="306" y="406" type="curve" smooth="yes"/>
+      <point x="306" y="489"/>
+      <point x="374" y="551"/>
+      <point x="461" y="551" type="curve" smooth="yes"/>
+      <point x="538" y="551"/>
+      <point x="584" y="498"/>
+      <point x="584" y="438" type="curve" smooth="yes"/>
+      <point x="584" y="389"/>
+      <point x="565" y="356"/>
+      <point x="521" y="309" type="curve" smooth="yes"/>
+      <point x="476" y="260"/>
+      <point x="430" y="210"/>
     </contour>
     <contour>
-      <point x="434" y="373" type="curve" smooth="yes"/>
-      <point x="463" y="373"/>
-      <point x="484" y="397"/>
-      <point x="484" y="424" type="curve" smooth="yes"/>
-      <point x="484" y="452"/>
-      <point x="464" y="475"/>
-      <point x="434" y="475" type="curve" smooth="yes"/>
-      <point x="404" y="475"/>
-      <point x="384" y="452"/>
-      <point x="384" y="424" type="curve" smooth="yes"/>
-      <point x="384" y="397"/>
-      <point x="404" y="373"/>
+      <point x="439" y="373" type="curve" smooth="yes"/>
+      <point x="472" y="373"/>
+      <point x="496" y="400"/>
+      <point x="496" y="430" type="curve" smooth="yes"/>
+      <point x="496" y="457"/>
+      <point x="479" y="475"/>
+      <point x="452" y="475" type="curve" smooth="yes"/>
+      <point x="420" y="475"/>
+      <point x="395" y="450"/>
+      <point x="395" y="418" type="curve" smooth="yes"/>
+      <point x="395" y="393"/>
+      <point x="412" y="373"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/one.sansS_erifB_lackC_ircled.glif
@@ -18,13 +18,13 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="404" y="177" type="line"/>
-      <point x="404" y="432" type="line"/>
-      <point x="354" y="389" type="line"/>
-      <point x="305" y="455" type="line"/>
-      <point x="412" y="543" type="line"/>
-      <point x="493" y="543" type="line"/>
-      <point x="493" y="177" type="line"/>
+      <point x="368" y="176" type="line"/>
+      <point x="413" y="427" type="line"/>
+      <point x="360" y="389" type="line"/>
+      <point x="319" y="454" type="line"/>
+      <point x="441" y="542" type="line"/>
+      <point x="522" y="542" type="line"/>
+      <point x="457" y="176" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/seven.sansS_erifB_lackC_ircled.glif
@@ -18,17 +18,17 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="404" y="162" type="curve"/>
-      <point x="325" y="202" type="line"/>
-      <point x="374" y="289"/>
-      <point x="423" y="375"/>
-      <point x="472" y="462" type="curve"/>
-      <point x="314" y="462" type="line"/>
-      <point x="314" y="543" type="line"/>
-      <point x="574" y="543" type="line"/>
-      <point x="574" y="466" type="line"/>
-      <point x="517" y="365"/>
-      <point x="461" y="263"/>
+      <point x="354" y="161" type="curve"/>
+      <point x="287" y="209" type="line"/>
+      <point x="349" y="293"/>
+      <point x="411" y="377"/>
+      <point x="473" y="461" type="curve"/>
+      <point x="317" y="461" type="line"/>
+      <point x="331" y="542" type="line"/>
+      <point x="592" y="542" type="line"/>
+      <point x="579" y="465" type="line"/>
+      <point x="504" y="364"/>
+      <point x="429" y="262"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/six.sansS_erifB_lackC_ircled.glif
@@ -18,42 +18,42 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="431" y="245" type="curve" smooth="yes"/>
-      <point x="461" y="245"/>
-      <point x="481" y="268"/>
-      <point x="481" y="296" type="curve" smooth="yes"/>
-      <point x="481" y="323"/>
-      <point x="461" y="347"/>
-      <point x="431" y="347" type="curve" smooth="yes"/>
-      <point x="402" y="347"/>
-      <point x="381" y="323"/>
-      <point x="381" y="296" type="curve" smooth="yes"/>
-      <point x="381" y="268"/>
-      <point x="401" y="245"/>
+      <point x="421" y="248" type="curve" smooth="yes"/>
+      <point x="453" y="248"/>
+      <point x="479" y="273"/>
+      <point x="479" y="305" type="curve" smooth="yes"/>
+      <point x="479" y="330"/>
+      <point x="462" y="350"/>
+      <point x="435" y="350" type="curve" smooth="yes"/>
+      <point x="401" y="350"/>
+      <point x="377" y="323"/>
+      <point x="377" y="293" type="curve" smooth="yes"/>
+      <point x="377" y="266"/>
+      <point x="395" y="248"/>
     </contour>
     <contour>
-      <point x="432" y="169" type="curve" smooth="yes"/>
-      <point x="352" y="169"/>
-      <point x="295" y="229"/>
-      <point x="295" y="298" type="curve" smooth="yes"/>
-      <point x="295" y="341"/>
-      <point x="314" y="376"/>
-      <point x="338" y="409" type="curve"/>
-      <point x="375" y="459"/>
-      <point x="411" y="509"/>
-      <point x="446" y="559" type="curve"/>
-      <point x="513" y="510" type="line"/>
-      <point x="487" y="478"/>
-      <point x="462" y="446"/>
-      <point x="436" y="414" type="curve"/>
-      <point x="441" y="417"/>
-      <point x="450" y="418"/>
-      <point x="456" y="418" type="curve" smooth="yes"/>
-      <point x="513" y="418"/>
-      <point x="569" y="366"/>
-      <point x="569" y="296" type="curve" smooth="yes"/>
-      <point x="569" y="227"/>
-      <point x="508" y="169"/>
+      <point x="412" y="172" type="curve" smooth="yes"/>
+      <point x="336" y="172"/>
+      <point x="290" y="225"/>
+      <point x="290" y="285" type="curve" smooth="yes"/>
+      <point x="290" y="334"/>
+      <point x="309" y="366"/>
+      <point x="353" y="414" type="curve" smooth="yes"/>
+      <point x="398" y="463"/>
+      <point x="443" y="513"/>
+      <point x="488" y="562" type="curve"/>
+      <point x="547" y="513" type="line"/>
+      <point x="517" y="481"/>
+      <point x="487" y="449"/>
+      <point x="457" y="417" type="curve"/>
+      <point x="462" y="420"/>
+      <point x="472" y="421"/>
+      <point x="477" y="421" type="curve" smooth="yes"/>
+      <point x="524" y="421"/>
+      <point x="568" y="376"/>
+      <point x="568" y="317" type="curve" smooth="yes"/>
+      <point x="568" y="234"/>
+      <point x="499" y="172"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/three.sansS_erifB_lackC_ircled.glif
@@ -18,51 +18,51 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="435" y="168" type="curve" smooth="yes"/>
-      <point x="371" y="168"/>
-      <point x="311" y="199"/>
-      <point x="294" y="268" type="curve"/>
-      <point x="377" y="298" type="line"/>
-      <point x="384" y="259"/>
-      <point x="410" y="245"/>
-      <point x="435" y="245" type="curve" smooth="yes"/>
-      <point x="461" y="245"/>
-      <point x="483" y="262"/>
-      <point x="483" y="289" type="curve" smooth="yes"/>
-      <point x="483" y="315"/>
-      <point x="460" y="330"/>
-      <point x="427" y="330" type="curve" smooth="yes"/>
-      <point x="414" y="330.0"/>
-      <point x="401" y="330.0"/>
-      <point x="388" y="330" type="curve"/>
-      <point x="388" y="401" type="line"/>
-      <point x="400" y="401.0"/>
-      <point x="411" y="401.0"/>
-      <point x="423" y="401" type="curve"/>
-      <point x="453" y="401"/>
-      <point x="473" y="414"/>
-      <point x="473" y="439" type="curve" smooth="yes"/>
-      <point x="473" y="460"/>
-      <point x="455" y="474"/>
-      <point x="433" y="474" type="curve" smooth="yes"/>
-      <point x="403" y="474"/>
-      <point x="388" y="454"/>
-      <point x="382" y="435" type="curve"/>
-      <point x="306" y="466" type="line"/>
-      <point x="323" y="514"/>
-      <point x="365" y="550"/>
-      <point x="435" y="550" type="curve" smooth="yes"/>
-      <point x="510" y="550"/>
-      <point x="560" y="505"/>
-      <point x="560" y="448" type="curve" smooth="yes"/>
-      <point x="560" y="411"/>
-      <point x="537" y="382"/>
-      <point x="507" y="369" type="curve"/>
-      <point x="547" y="353"/>
-      <point x="573" y="321"/>
-      <point x="573" y="285" type="curve" smooth="yes"/>
-      <point x="573" y="211"/>
-      <point x="507" y="168"/>
+      <point x="402" y="165" type="curve" smooth="yes"/>
+      <point x="339" y="165"/>
+      <point x="283" y="200"/>
+      <point x="271" y="266" type="curve"/>
+      <point x="349" y="294" type="line"/>
+      <point x="359" y="257"/>
+      <point x="380" y="242"/>
+      <point x="409" y="242" type="curve" smooth="yes"/>
+      <point x="437" y="242"/>
+      <point x="465" y="259"/>
+      <point x="465" y="289" type="curve" smooth="yes"/>
+      <point x="465" y="314"/>
+      <point x="444" y="328"/>
+      <point x="411" y="328" type="curve" smooth="yes"/>
+      <point x="399" y="328.0"/>
+      <point x="388" y="328.0"/>
+      <point x="376" y="328" type="curve"/>
+      <point x="389" y="398" type="line"/>
+      <point x="400" y="398.0"/>
+      <point x="412" y="398.0"/>
+      <point x="423" y="398" type="curve" smooth="yes"/>
+      <point x="454" y="398"/>
+      <point x="480" y="412"/>
+      <point x="480" y="438" type="curve" smooth="yes"/>
+      <point x="480" y="458"/>
+      <point x="461" y="470"/>
+      <point x="442" y="470" type="curve" smooth="yes"/>
+      <point x="412" y="470"/>
+      <point x="395" y="452"/>
+      <point x="387" y="434" type="curve"/>
+      <point x="314" y="466" type="line"/>
+      <point x="337" y="514"/>
+      <point x="385" y="547"/>
+      <point x="455" y="547" type="curve" smooth="yes"/>
+      <point x="522" y="547"/>
+      <point x="570" y="507"/>
+      <point x="570" y="454" type="curve" smooth="yes"/>
+      <point x="570" y="412"/>
+      <point x="544" y="383"/>
+      <point x="509" y="366" type="curve"/>
+      <point x="536" y="352"/>
+      <point x="554" y="325"/>
+      <point x="554" y="293" type="curve" smooth="yes"/>
+      <point x="554" y="218"/>
+      <point x="490" y="165"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.sansS_erifB_lackC_ircled.glif
@@ -18,35 +18,35 @@
       <point x="230" y="-16"/>
     </contour>
     <contour>
-      <point x="304" y="177" type="line"/>
-      <point x="304" y="240" type="line"/>
-      <point x="304" y="240"/>
-      <point x="421" y="357"/>
-      <point x="432" y="369" type="curve" smooth="yes"/>
-      <point x="456" y="392"/>
-      <point x="473" y="410"/>
-      <point x="473" y="436" type="curve" smooth="yes"/>
-      <point x="473" y="455"/>
-      <point x="456" y="472"/>
-      <point x="432" y="472" type="curve" smooth="yes"/>
-      <point x="407" y="472"/>
-      <point x="387" y="456"/>
-      <point x="381" y="422" type="curve"/>
-      <point x="300" y="453" type="line"/>
-      <point x="315" y="513"/>
-      <point x="367" y="551"/>
-      <point x="432" y="551" type="curve" smooth="yes"/>
-      <point x="507" y="551"/>
-      <point x="564" y="507"/>
-      <point x="564" y="443" type="curve" smooth="yes"/>
-      <point x="564" y="395"/>
-      <point x="524" y="353"/>
-      <point x="501" y="330" type="curve" smooth="yes"/>
-      <point x="481" y="310"/>
-      <point x="426" y="256"/>
-      <point x="426" y="256" type="curve"/>
-      <point x="566" y="256" type="line"/>
-      <point x="566" y="177" type="line"/>
+      <point x="275" y="177" type="line"/>
+      <point x="286" y="240" type="line"/>
+      <point x="286" y="240"/>
+      <point x="422" y="356"/>
+      <point x="437" y="369" type="curve" smooth="yes"/>
+      <point x="455" y="384"/>
+      <point x="486" y="409"/>
+      <point x="486" y="436" type="curve" smooth="yes"/>
+      <point x="486" y="458"/>
+      <point x="470" y="472"/>
+      <point x="447" y="472" type="curve" smooth="yes"/>
+      <point x="421" y="472"/>
+      <point x="403" y="456"/>
+      <point x="393" y="424" type="curve"/>
+      <point x="318" y="453" type="line"/>
+      <point x="336" y="514"/>
+      <point x="389" y="551"/>
+      <point x="460" y="551" type="curve" smooth="yes"/>
+      <point x="534" y="551"/>
+      <point x="579" y="508"/>
+      <point x="579" y="450" type="curve" smooth="yes"/>
+      <point x="579" y="400"/>
+      <point x="552" y="371"/>
+      <point x="503" y="330" type="curve" smooth="yes"/>
+      <point x="477" y="308"/>
+      <point x="433" y="270"/>
+      <point x="416" y="256" type="curve"/>
+      <point x="550" y="256" type="line"/>
+      <point x="536" y="177" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/two.tf.glif
@@ -35,10 +35,4 @@
       <point x="41" y="120" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
-      <string>=600</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/gurmukhi.fea
+++ b/source/GoogleSans/gurmukhi.fea
@@ -20,11 +20,11 @@ lookup gur2_dflt_blwf_below_base_consonant_forms {
     sub halant-gurmukhi va-gurmukhi by va-gurmukhi.below;
 } gur2_dflt_blwf_below_base_consonant_forms;
 
-lookup gur2_dflt_ss01_historical_below_base_consonant_forms {
+lookup gur2_dflt_historical_below_base_consonant_forms {
     sub halant-gurmukhi ca-gurmukhi by ca-gurmukhi.below;
     sub halant-gurmukhi tta-gurmukhi by tta-gurmukhi.below;
     sub halant-gurmukhi ta-gurmukhi by ta-gurmukhi.below;
-} gur2_dflt_ss01_historical_below_base_consonant_forms;
+} gur2_dflt_historical_below_base_consonant_forms;
 
 
 feature locl {
@@ -361,7 +361,7 @@ feature hist {
     script gur2;
     lookup gur2_dflt_hist_historical_sunscript_consonants {
         ignore sub [rakar-gurmukhi va-gurmukhi.below ha-gurmukhi.below yakash-gurmukhi ca-gurmukhi.below tta-gurmukhi.below ta-gurmukhi.below] halant-gurmukhi' [ca-gurmukhi tta-gurmukhi ta-gurmukhi]';
-        sub halant-gurmukhi' lookup gur2_dflt_ss01_historical_below_base_consonant_forms [ca-gurmukhi tta-gurmukhi ta-gurmukhi]';
+        sub halant-gurmukhi' lookup gur2_dflt_historical_below_base_consonant_forms [ca-gurmukhi tta-gurmukhi ta-gurmukhi]';
     } gur2_dflt_hist_historical_sunscript_consonants;
 
 } hist;


### PR DESCRIPTION
Closes https://github.com/googlefonts/googlesans/issues/322
Closes #269
Supersedes https://github.com/googlefonts/googlesans/pull/311

---

Test strings:

```
➊➋➌➍➎➏➐➑➒
```

```
➀➁➂➃➄➅➆➇➈
```

### TODO

- [x] remove kerning updates in this PR (per D Berlow, there should be no kerning update in numr/dnom forms)
- [x] grade axis is reversed in negative circled figs (https://github.com/googlefonts/googlesans/pull/326#issuecomment-875871303), requires source update before we merge (fixed in https://github.com/googlefonts/googlesans/pull/326/commits/ca2b1d925af926d829fbcf23ca67ab6d3c95305c)