### PR TITLE
Fix Hebrew script vav / yod dlig sub order

### DIFF
--- a/qa/shaping/dlig_hebr_IWR.json
+++ b/qa/shaping/dlig_hebr_IWR.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "build_commit": "ca6c2a5b7d8b78f52060c7c81a0a3ca16c2b3a20"
+    "build_commit": "cd849c8decc1788e75e48b69f1fa8c0fa723a812"
   },
   "input": {
     "features": {
@@ -14,6 +14,7 @@
       "אל",
       "וו",
       "יו",
+      "וי",
       "יי"
     ]
   },
@@ -22,36 +23,42 @@
       "opsz=18.0,wght=400.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=18.0,wght=500.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=18.0,wght=700.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=400.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=500.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=700.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ]
@@ -60,36 +67,42 @@
       "opsz=18.0,wght=400.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=18.0,wght=500.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=18.0,wght=700.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=400.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=500.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ],
       "opsz=17.0,wght=700.0,GRAD=0.0": [
         "uniFB4F",
         "uni05F0",
+        "uni05D5|uni05D9",
         "uni05F1",
         "uni05F2"
       ]
@@ -97,72 +110,84 @@
     "GoogleSans-Bold.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSans-BoldItalic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSans-Italic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSans-Medium.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSans-MediumItalic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSans-Regular.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-Bold.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-BoldItalic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-Italic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-Medium.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-MediumItalic.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ],
     "GoogleSansText-Regular.ttf": [
       "uniFB4F",
       "uni05F0",
+      "uni05D5|uni05D9",
       "uni05F1",
       "uni05F2"
     ]

--- a/qa/shaping_input/dlig_hebr_IWR.toml
+++ b/qa/shaping_input/dlig_hebr_IWR.toml
@@ -13,5 +13,6 @@ text = [
     "אל", # Yiddish: alef lamed
     "וו", # Yiddish: vav vav
     "יו", # Yiddish: yod vav
+    "וי", # Yiddish: vav yod
     "יי", # Yiddish: yod yod
 ]

--- a/source/GoogleSans/family.fea
+++ b/source/GoogleSans/family.fea
@@ -1562,7 +1562,7 @@ feature dlig {
         lookupflag IgnoreMarks;
         sub alef-hb lamed-hb by aleflamed-hb;
         sub vav-hb vav-hb by vavvav-hb;
-        sub yod-hb vav-hb by vavyod-hb;
+        sub vav-hb yod-hb by vavyod-hb;
         sub yod-hb yod-hb by yodyod-hb;
     } hb_yiddish;
 


### PR DESCRIPTION
This PR includes a feature file fix to address incorrect order in the vav / yod substitution within the family.fea dlig block

Closes #321