### PR TITLE
Fix `six` and `nine` outline artifacts in Italic

### DIFF
--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nine.glif
@@ -4,46 +4,46 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="189.0" y="-10.0" type="line"/>
-      <point x="304.0" y="36.0"/>
-      <point x="411.0" y="114.0"/>
-      <point x="472.0" y="216.0" type="curve" smooth="yes"/>
-      <point x="516.0" y="295.0"/>
-      <point x="543.0" y="387.0"/>
-      <point x="543.0" y="498.0" type="curve" smooth="yes"/>
-      <point x="543.0" y="556.0"/>
-      <point x="532.0" y="609.0"/>
-      <point x="509.0" y="649.0" type="curve" smooth="yes"/>
-      <point x="478.0" y="699.0"/>
+      <point x="191.0" y="-10.0" type="line"/>
+      <point x="316.0" y="40.0"/>
+      <point x="420.0" y="127.0"/>
+      <point x="476.0" y="218.0" type="curve" smooth="yes"/>
+      <point x="523.0" y="294.0"/>
+      <point x="554.0" y="381.0"/>
+      <point x="554.0" y="486.0" type="curve" smooth="yes"/>
+      <point x="554.0" y="551.0"/>
+      <point x="540.0" y="605.0"/>
+      <point x="513.0" y="650.0" type="curve" smooth="yes"/>
+      <point x="484.0" y="698.0"/>
       <point x="426.0" y="732.0"/>
-      <point x="349.0" y="732.0" type="curve" smooth="yes"/>
-      <point x="177.0" y="732.0"/>
-      <point x="96.0" y="613.0"/>
-      <point x="95.0" y="473.0" type="curve" smooth="yes"/>
-      <point x="94.0" y="347.0"/>
-      <point x="196.0" y="292.0"/>
-      <point x="291.0" y="292.0" type="curve" smooth="yes"/>
-      <point x="387.0" y="292.0"/>
-      <point x="455.0" y="331.0"/>
-      <point x="493.0" y="382.0" type="curve"/>
-      <point x="496.0" y="380.0" type="line"/>
-      <point x="459.0" y="227.0"/>
-      <point x="299.0" y="111.0"/>
-      <point x="163.0" y="47.0" type="curve"/>
+      <point x="351.0" y="732.0" type="curve" smooth="yes"/>
+      <point x="188.0" y="732.0"/>
+      <point x="97.0" y="613.0"/>
+      <point x="96.0" y="466.0" type="curve" smooth="yes"/>
+      <point x="95.0" y="347.0"/>
+      <point x="190.0" y="292.0"/>
+      <point x="286.0" y="292.0" type="curve" smooth="yes"/>
+      <point x="378.0" y="292.0"/>
+      <point x="451.0" y="346.0"/>
+      <point x="480.0" y="391.0" type="curve"/>
+      <point x="483.0" y="389.0" type="line"/>
+      <point x="449.0" y="217.0"/>
+      <point x="296.0" y="93.0"/>
+      <point x="170.0" y="48.0" type="curve"/>
     </contour>
     <contour>
-      <point x="305.0" y="348.0" type="curve" smooth="yes"/>
-      <point x="202.0" y="348.0"/>
-      <point x="159.0" y="391.0"/>
-      <point x="159.0" y="480.0" type="curve" smooth="yes"/>
-      <point x="159.0" y="599.0"/>
-      <point x="223.0" y="673.0"/>
-      <point x="339.0" y="673.0" type="curve" smooth="yes"/>
-      <point x="435.0" y="673.0"/>
-      <point x="491.0" y="619.0"/>
-      <point x="491.0" y="528.0" type="curve" smooth="yes"/>
+      <point x="302.0" y="348.0" type="curve" smooth="yes"/>
+      <point x="207.0" y="348.0"/>
+      <point x="160.0" y="384.0"/>
+      <point x="160.0" y="476.0" type="curve" smooth="yes"/>
+      <point x="160.0" y="595.0"/>
+      <point x="222.0" y="673.0"/>
+      <point x="338.0" y="673.0" type="curve" smooth="yes"/>
+      <point x="432.0" y="673.0"/>
+      <point x="491.0" y="624.0"/>
+      <point x="491.0" y="521.0" type="curve" smooth="yes"/>
       <point x="491.0" y="417.0"/>
-      <point x="409.0" y="348.0"/>
+      <point x="404.0" y="348.0"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/six.glif
@@ -12,23 +12,23 @@
       <point x="409.0" y="424.0"/>
       <point x="313.0" y="424.0" type="curve" smooth="yes"/>
       <point x="221.0" y="424.0"/>
-      <point x="134.0" y="383.0"/>
-      <point x="97.0" y="334.0" type="curve"/>
-      <point x="94.0" y="336.0" type="line"/>
-      <point x="131.0" y="489.0"/>
-      <point x="296.0" y="609.0"/>
+      <point x="148.0" y="370.0"/>
+      <point x="119.0" y="325.0" type="curve"/>
+      <point x="116.0" y="327.0" type="line"/>
+      <point x="150.0" y="499.0"/>
+      <point x="303.0" y="623.0"/>
       <point x="429.0" y="668.0" type="curve"/>
       <point x="408.0" y="726.0" type="line"/>
       <point x="283.0" y="676.0"/>
-      <point x="177.0" y="598.0"/>
-      <point x="118.0" y="499.0" type="curve" smooth="yes"/>
-      <point x="75.0" y="423.0"/>
-      <point x="52.0" y="335.0"/>
-      <point x="52.0" y="230.0" type="curve" smooth="yes"/>
-      <point x="52.0" y="165.0"/>
-      <point x="64.0" y="109.0"/>
-      <point x="89.0" y="67.0" type="curve" smooth="yes"/>
-      <point x="120.0" y="16.0"/>
+      <point x="179.0" y="589.0"/>
+      <point x="123.0" y="498.0" type="curve" smooth="yes"/>
+      <point x="76" y="422"/>
+      <point x="45.0" y="335.0"/>
+      <point x="45.0" y="230.0" type="curve" smooth="yes"/>
+      <point x="45.0" y="165.0"/>
+      <point x="59.0" y="111.0"/>
+      <point x="86" y="66" type="curve" smooth="yes"/>
+      <point x="115.0" y="18.0"/>
       <point x="173.0" y="-16.0"/>
     </contour>
     <contour>


### PR DESCRIPTION
Closes #372

Source updates from https://github.com/googlefonts/googlesans/issues/372#issuecomment-907762721