### PR TITLE
Add Sanskrit glyphs to meet Bureau of Indian Standards Devanagari script requirements

### DIFF
--- a/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
@@ -3553,3 +3553,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
@@ -3557,3 +3557,8 @@ eight.loclTAML.tf
 nine.loclTAML.tf
 hyphentwo
 nonbreakinghyphen
+uni0900
+uni0951
+uni0952
+uni0953
+uni0954

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="85" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="85" y="757" type="line"/>
+      <point x="274" y="976" type="line"/>
+      <point x="205" y="1032" type="line"/>
+      <point x="20" y="812" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-216" type="line"/>
+      <point x="370" y="-216" type="line"/>
+      <point x="370" y="-144" type="line"/>
+      <point x="20" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="254" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="209" y="757" type="line"/>
+      <point x="274" y="812" type="line"/>
+      <point x="89" y="1032" type="line"/>
+      <point x="20" y="976" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="232" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="112" y="840" type="line"/>
+      <point x="128" y="904"/>
+      <point x="169" y="938"/>
+      <point x="232" y="938" type="curve" smooth="yes"/>
+      <point x="295" y="938"/>
+      <point x="336" y="904"/>
+      <point x="352" y="840" type="curve"/>
+      <point x="428" y="862" type="line"/>
+      <point x="405" y="964"/>
+      <point x="336" y="1018"/>
+      <point x="232" y="1018" type="curve" smooth="yes"/>
+      <point x="128" y="1018"/>
+      <point x="59" y="964"/>
+      <point x="36" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="232" y="757" type="curve" smooth="yes"/>
+      <point x="267" y="757"/>
+      <point x="291" y="781"/>
+      <point x="291" y="815" type="curve" smooth="yes"/>
+      <point x="291" y="850"/>
+      <point x="267" y="875"/>
+      <point x="232" y="875" type="curve" smooth="yes"/>
+      <point x="197" y="875"/>
+      <point x="173" y="850"/>
+      <point x="173" y="815" type="curve" smooth="yes"/>
+      <point x="173" y="781"/>
+      <point x="197" y="757"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>464</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="777" type="line"/>
+      <point x="98" y="777" type="line"/>
+      <point x="108" y="1017" type="line"/>
+      <point x="20" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="85" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="85" y="757" type="line"/>
+      <point x="274" y="976" type="line"/>
+      <point x="205" y="1032" type="line"/>
+      <point x="20" y="812" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-216" type="line"/>
+      <point x="370" y="-216" type="line"/>
+      <point x="370" y="-144" type="line"/>
+      <point x="20" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="254" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="209" y="757" type="line"/>
+      <point x="274" y="812" type="line"/>
+      <point x="89" y="1032" type="line"/>
+      <point x="20" y="976" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="232" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="112" y="840" type="line"/>
+      <point x="128" y="904"/>
+      <point x="169" y="938"/>
+      <point x="232" y="938" type="curve" smooth="yes"/>
+      <point x="295" y="938"/>
+      <point x="336" y="904"/>
+      <point x="352" y="840" type="curve"/>
+      <point x="428" y="862" type="line"/>
+      <point x="405" y="964"/>
+      <point x="336" y="1018"/>
+      <point x="232" y="1018" type="curve" smooth="yes"/>
+      <point x="128" y="1018"/>
+      <point x="59" y="964"/>
+      <point x="36" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="232" y="757" type="curve" smooth="yes"/>
+      <point x="267" y="757"/>
+      <point x="291" y="781"/>
+      <point x="291" y="815" type="curve" smooth="yes"/>
+      <point x="291" y="850"/>
+      <point x="267" y="875"/>
+      <point x="232" y="875" type="curve" smooth="yes"/>
+      <point x="197" y="875"/>
+      <point x="173" y="850"/>
+      <point x="173" y="815" type="curve" smooth="yes"/>
+      <point x="173" y="781"/>
+      <point x="197" y="757"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>464</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="777" type="line"/>
+      <point x="98" y="777" type="line"/>
+      <point x="108" y="1017" type="line"/>
+      <point x="20" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="85" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="85" y="757" type="line"/>
+      <point x="274" y="976" type="line"/>
+      <point x="205" y="1032" type="line"/>
+      <point x="20" y="812" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-216" type="line"/>
+      <point x="370" y="-216" type="line"/>
+      <point x="370" y="-144" type="line"/>
+      <point x="20" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="254" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="209" y="757" type="line"/>
+      <point x="274" y="812" type="line"/>
+      <point x="89" y="1032" type="line"/>
+      <point x="20" y="976" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="232" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="112" y="840" type="line"/>
+      <point x="128" y="904"/>
+      <point x="169" y="938"/>
+      <point x="232" y="938" type="curve" smooth="yes"/>
+      <point x="295" y="938"/>
+      <point x="336" y="904"/>
+      <point x="352" y="840" type="curve"/>
+      <point x="428" y="862" type="line"/>
+      <point x="405" y="964"/>
+      <point x="336" y="1018"/>
+      <point x="232" y="1018" type="curve" smooth="yes"/>
+      <point x="128" y="1018"/>
+      <point x="59" y="964"/>
+      <point x="36" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="232" y="757" type="curve" smooth="yes"/>
+      <point x="267" y="757"/>
+      <point x="291" y="781"/>
+      <point x="291" y="815" type="curve" smooth="yes"/>
+      <point x="291" y="850"/>
+      <point x="267" y="875"/>
+      <point x="232" y="875" type="curve" smooth="yes"/>
+      <point x="197" y="875"/>
+      <point x="173" y="850"/>
+      <point x="173" y="815" type="curve" smooth="yes"/>
+      <point x="173" y="781"/>
+      <point x="197" y="757"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>464</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="777" type="line"/>
+      <point x="98" y="777" type="line"/>
+      <point x="108" y="1017" type="line"/>
+      <point x="20" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="101" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="101" y="757" type="line"/>
+      <point x="295" y="980" type="line"/>
+      <point x="210" y="1051" type="line"/>
+      <point x="20" y="827" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>315</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="205" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-216" type="line"/>
+      <point x="390" y="-216" type="line"/>
+      <point x="390" y="-122" type="line"/>
+      <point x="20" y="-122" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>410</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="270" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="214" y="757" type="line"/>
+      <point x="295" y="827" type="line"/>
+      <point x="105" y="1051" type="line"/>
+      <point x="20" y="980" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>315</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="249" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="133" y="859" type="line"/>
+      <point x="149" y="920"/>
+      <point x="187" y="952"/>
+      <point x="249" y="952" type="curve" smooth="yes"/>
+      <point x="311" y="952"/>
+      <point x="350" y="920"/>
+      <point x="365" y="859" type="curve"/>
+      <point x="463" y="887" type="line"/>
+      <point x="438" y="996"/>
+      <point x="365" y="1052"/>
+      <point x="249" y="1052" type="curve" smooth="yes"/>
+      <point x="134" y="1052"/>
+      <point x="60" y="996"/>
+      <point x="35" y="887" type="curve"/>
+    </contour>
+    <contour>
+      <point x="249" y="757" type="curve" smooth="yes"/>
+      <point x="289" y="757"/>
+      <point x="317" y="785"/>
+      <point x="317" y="824" type="curve" smooth="yes"/>
+      <point x="317" y="864"/>
+      <point x="289" y="892"/>
+      <point x="249" y="892" type="curve" smooth="yes"/>
+      <point x="210" y="892"/>
+      <point x="182" y="864"/>
+      <point x="182" y="824" type="curve" smooth="yes"/>
+      <point x="182" y="785"/>
+      <point x="210" y="757"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>498</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="76" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="777" type="line"/>
+      <point x="122" y="777" type="line"/>
+      <point x="132" y="1017" type="line"/>
+      <point x="20" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>152</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="78" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="78" y="738" type="line"/>
+      <point x="271" y="954" type="line"/>
+      <point x="205" y="1010" type="line"/>
+      <point x="20" y="788" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-206" type="line"/>
+      <point x="370" y="-206" type="line"/>
+      <point x="370" y="-134" type="line"/>
+      <point x="20" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="252" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="738" type="line"/>
+      <point x="271" y="788" type="line"/>
+      <point x="86" y="1010" type="line"/>
+      <point x="20" y="954" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="216" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="96" y="819" type="line"/>
+      <point x="113" y="880"/>
+      <point x="153" y="919"/>
+      <point x="216" y="919" type="curve" smooth="yes"/>
+      <point x="279" y="919"/>
+      <point x="319" y="880"/>
+      <point x="336" y="819" type="curve"/>
+      <point x="412" y="843" type="line"/>
+      <point x="389" y="938"/>
+      <point x="318" y="999"/>
+      <point x="216" y="999" type="curve" smooth="yes"/>
+      <point x="114" y="999"/>
+      <point x="43" y="938"/>
+      <point x="20" y="843" type="curve"/>
+    </contour>
+    <contour>
+      <point x="216" y="738" type="curve" smooth="yes"/>
+      <point x="251" y="738"/>
+      <point x="275" y="762"/>
+      <point x="275" y="796" type="curve" smooth="yes"/>
+      <point x="275" y="831"/>
+      <point x="251" y="856"/>
+      <point x="216" y="856" type="curve" smooth="yes"/>
+      <point x="181" y="856"/>
+      <point x="157" y="831"/>
+      <point x="157" y="796" type="curve" smooth="yes"/>
+      <point x="157" y="762"/>
+      <point x="181" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>432</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="758" type="line"/>
+      <point x="98" y="758" type="line"/>
+      <point x="108" y="978" type="line"/>
+      <point x="20" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="78" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="78" y="738" type="line"/>
+      <point x="271" y="954" type="line"/>
+      <point x="205" y="1010" type="line"/>
+      <point x="20" y="788" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-206" type="line"/>
+      <point x="370" y="-206" type="line"/>
+      <point x="370" y="-134" type="line"/>
+      <point x="20" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="252" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="738" type="line"/>
+      <point x="271" y="788" type="line"/>
+      <point x="86" y="1010" type="line"/>
+      <point x="20" y="954" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="216" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="96" y="819" type="line"/>
+      <point x="113" y="880"/>
+      <point x="153" y="919"/>
+      <point x="216" y="919" type="curve" smooth="yes"/>
+      <point x="279" y="919"/>
+      <point x="319" y="880"/>
+      <point x="336" y="819" type="curve"/>
+      <point x="412" y="843" type="line"/>
+      <point x="389" y="938"/>
+      <point x="318" y="999"/>
+      <point x="216" y="999" type="curve" smooth="yes"/>
+      <point x="114" y="999"/>
+      <point x="43" y="938"/>
+      <point x="20" y="843" type="curve"/>
+    </contour>
+    <contour>
+      <point x="216" y="738" type="curve" smooth="yes"/>
+      <point x="251" y="738"/>
+      <point x="275" y="762"/>
+      <point x="275" y="796" type="curve" smooth="yes"/>
+      <point x="275" y="831"/>
+      <point x="251" y="856"/>
+      <point x="216" y="856" type="curve" smooth="yes"/>
+      <point x="181" y="856"/>
+      <point x="157" y="831"/>
+      <point x="157" y="796" type="curve" smooth="yes"/>
+      <point x="157" y="762"/>
+      <point x="181" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>432</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="758" type="line"/>
+      <point x="98" y="758" type="line"/>
+      <point x="108" y="978" type="line"/>
+      <point x="20" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="78" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="78" y="738" type="line"/>
+      <point x="271" y="954" type="line"/>
+      <point x="205" y="1010" type="line"/>
+      <point x="20" y="788" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="195" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-206" type="line"/>
+      <point x="370" y="-206" type="line"/>
+      <point x="370" y="-134" type="line"/>
+      <point x="20" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="252" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="738" type="line"/>
+      <point x="271" y="788" type="line"/>
+      <point x="86" y="1010" type="line"/>
+      <point x="20" y="954" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>291</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="216" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="96" y="819" type="line"/>
+      <point x="113" y="880"/>
+      <point x="153" y="919"/>
+      <point x="216" y="919" type="curve" smooth="yes"/>
+      <point x="279" y="919"/>
+      <point x="319" y="880"/>
+      <point x="336" y="819" type="curve"/>
+      <point x="412" y="843" type="line"/>
+      <point x="389" y="938"/>
+      <point x="318" y="999"/>
+      <point x="216" y="999" type="curve" smooth="yes"/>
+      <point x="114" y="999"/>
+      <point x="43" y="938"/>
+      <point x="20" y="843" type="curve"/>
+    </contour>
+    <contour>
+      <point x="216" y="738" type="curve" smooth="yes"/>
+      <point x="251" y="738"/>
+      <point x="275" y="762"/>
+      <point x="275" y="796" type="curve" smooth="yes"/>
+      <point x="275" y="831"/>
+      <point x="251" y="856"/>
+      <point x="216" y="856" type="curve" smooth="yes"/>
+      <point x="181" y="856"/>
+      <point x="157" y="831"/>
+      <point x="157" y="796" type="curve" smooth="yes"/>
+      <point x="157" y="762"/>
+      <point x="181" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>432</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="64" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="758" type="line"/>
+      <point x="98" y="758" type="line"/>
+      <point x="108" y="978" type="line"/>
+      <point x="20" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="94" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="94" y="738" type="line"/>
+      <point x="292" y="958" type="line"/>
+      <point x="207" y="1029" type="line"/>
+      <point x="20" y="802" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>312</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="205" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="20" y="-206" type="line"/>
+      <point x="390" y="-206" type="line"/>
+      <point x="390" y="-112" type="line"/>
+      <point x="20" y="-112" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>410</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -1416,6 +1416,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1736,6 +1738,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3536,6 +3540,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3918,6 +3924,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6810,6 +6818,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="270" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="218" y="738" type="line"/>
+      <point x="292" y="802" type="line"/>
+      <point x="105" y="1029" type="line"/>
+      <point x="20" y="958" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>312</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="242" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="121" y="835" type="line"/>
+      <point x="139" y="899"/>
+      <point x="180" y="936"/>
+      <point x="242" y="936" type="curve" smooth="yes"/>
+      <point x="304" y="936"/>
+      <point x="345" y="899"/>
+      <point x="363" y="835" type="curve"/>
+      <point x="464" y="867" type="line"/>
+      <point x="437" y="975"/>
+      <point x="355" y="1038"/>
+      <point x="242" y="1038" type="curve" smooth="yes"/>
+      <point x="129" y="1038"/>
+      <point x="47" y="975"/>
+      <point x="20" y="867" type="curve"/>
+    </contour>
+    <contour>
+      <point x="242" y="738" type="curve" smooth="yes"/>
+      <point x="281" y="738"/>
+      <point x="309" y="766"/>
+      <point x="309" y="805" type="curve" smooth="yes"/>
+      <point x="309" y="844"/>
+      <point x="281" y="872"/>
+      <point x="242" y="872" type="curve" smooth="yes"/>
+      <point x="203" y="872"/>
+      <point x="175" y="844"/>
+      <point x="175" y="805" type="curve" smooth="yes"/>
+      <point x="175" y="766"/>
+      <point x="203" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>484</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="76" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="30" y="758" type="line"/>
+      <point x="122" y="758" type="line"/>
+      <point x="132" y="979" type="line"/>
+      <point x="20" y="979" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>152</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -3854,6 +3854,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9588,6 +9593,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9852,6 +9859,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11078,6 +11087,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11368,6 +11379,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13450,6 +13463,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="170" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="176" y="763" type="line"/>
+      <point x="401" y="965" type="line"/>
+      <point x="343" y="1027" type="line"/>
+      <point x="122" y="823" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-61" y="-216" type="line"/>
+      <point x="289" y="-216" type="line"/>
+      <point x="301" y="-144" type="line"/>
+      <point x="-49" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="330" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="299" y="753" type="line"/>
+      <point x="371" y="798" type="line"/>
+      <point x="227" y="1034" type="line"/>
+      <point x="151" y="988" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <guideline x="306" y="756" angle="80"/>
+  <anchor x="304" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="839" type="line"/>
+      <point x="231" y="906"/>
+      <point x="276" y="938"/>
+      <point x="336" y="938" type="curve" smooth="yes"/>
+      <point x="400" y="938"/>
+      <point x="434" y="901"/>
+      <point x="443" y="839" type="curve"/>
+      <point x="514" y="850" type="line"/>
+      <point x="504" y="945"/>
+      <point x="441" y="1018"/>
+      <point x="332" y="1018" type="curve" smooth="yes"/>
+      <point x="226" y="1018"/>
+      <point x="148" y="965"/>
+      <point x="129" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="329" y="756" type="curve" smooth="yes"/>
+      <point x="363" y="756"/>
+      <point x="388" y="781"/>
+      <point x="388" y="816" type="curve" smooth="yes"/>
+      <point x="388" y="850"/>
+      <point x="363" y="875"/>
+      <point x="329" y="875" type="curve" smooth="yes"/>
+      <point x="295" y="875"/>
+      <point x="270" y="850"/>
+      <point x="270" y="816" type="curve" smooth="yes"/>
+      <point x="270" y="781"/>
+      <point x="295" y="756"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>427</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="133" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="114" y="777" type="line"/>
+      <point x="182" y="777" type="line"/>
+      <point x="244" y="1017" type="line"/>
+      <point x="156" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="170" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="176" y="763" type="line"/>
+      <point x="401" y="965" type="line"/>
+      <point x="343" y="1027" type="line"/>
+      <point x="122" y="823" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-61" y="-216" type="line"/>
+      <point x="289" y="-216" type="line"/>
+      <point x="301" y="-144" type="line"/>
+      <point x="-49" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="330" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="299" y="753" type="line"/>
+      <point x="371" y="798" type="line"/>
+      <point x="227" y="1034" type="line"/>
+      <point x="151" y="988" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <guideline x="306" y="756" angle="80"/>
+  <anchor x="304" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="839" type="line"/>
+      <point x="231" y="906"/>
+      <point x="276" y="938"/>
+      <point x="336" y="938" type="curve" smooth="yes"/>
+      <point x="400" y="938"/>
+      <point x="434" y="901"/>
+      <point x="443" y="839" type="curve"/>
+      <point x="514" y="850" type="line"/>
+      <point x="504" y="945"/>
+      <point x="441" y="1018"/>
+      <point x="332" y="1018" type="curve" smooth="yes"/>
+      <point x="226" y="1018"/>
+      <point x="148" y="965"/>
+      <point x="129" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="329" y="756" type="curve" smooth="yes"/>
+      <point x="363" y="756"/>
+      <point x="388" y="781"/>
+      <point x="388" y="816" type="curve" smooth="yes"/>
+      <point x="388" y="850"/>
+      <point x="363" y="875"/>
+      <point x="329" y="875" type="curve" smooth="yes"/>
+      <point x="295" y="875"/>
+      <point x="270" y="850"/>
+      <point x="270" y="816" type="curve" smooth="yes"/>
+      <point x="270" y="781"/>
+      <point x="295" y="756"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>427</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="133" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="114" y="777" type="line"/>
+      <point x="182" y="777" type="line"/>
+      <point x="244" y="1017" type="line"/>
+      <point x="156" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="170" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="176" y="763" type="line"/>
+      <point x="401" y="965" type="line"/>
+      <point x="343" y="1027" type="line"/>
+      <point x="122" y="823" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>294</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-61" y="-216" type="line"/>
+      <point x="289" y="-216" type="line"/>
+      <point x="301" y="-144" type="line"/>
+      <point x="-49" y="-144" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>390</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="330" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="299" y="753" type="line"/>
+      <point x="371" y="798" type="line"/>
+      <point x="227" y="1034" type="line"/>
+      <point x="151" y="988" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <guideline x="306" y="756" angle="80"/>
+  <anchor x="304" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="213" y="839" type="line"/>
+      <point x="231" y="906"/>
+      <point x="276" y="938"/>
+      <point x="336" y="938" type="curve" smooth="yes"/>
+      <point x="400" y="938"/>
+      <point x="434" y="901"/>
+      <point x="443" y="839" type="curve"/>
+      <point x="514" y="850" type="line"/>
+      <point x="504" y="945"/>
+      <point x="441" y="1018"/>
+      <point x="332" y="1018" type="curve" smooth="yes"/>
+      <point x="226" y="1018"/>
+      <point x="148" y="965"/>
+      <point x="129" y="862" type="curve"/>
+    </contour>
+    <contour>
+      <point x="329" y="756" type="curve" smooth="yes"/>
+      <point x="363" y="756"/>
+      <point x="388" y="781"/>
+      <point x="388" y="816" type="curve" smooth="yes"/>
+      <point x="388" y="850"/>
+      <point x="363" y="875"/>
+      <point x="329" y="875" type="curve" smooth="yes"/>
+      <point x="295" y="875"/>
+      <point x="270" y="850"/>
+      <point x="270" y="816" type="curve" smooth="yes"/>
+      <point x="270" y="781"/>
+      <point x="295" y="756"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>427</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="133" y="679" name="_top"/>
+  <outline>
+    <contour>
+      <point x="114" y="777" type="line"/>
+      <point x="182" y="777" type="line"/>
+      <point x="244" y="1017" type="line"/>
+      <point x="156" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="187" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="193" y="762" type="line"/>
+      <point x="424" y="968" type="line"/>
+      <point x="353" y="1047" type="line"/>
+      <point x="125" y="839" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>317</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="158" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-61" y="-216" type="line"/>
+      <point x="309" y="-216" type="line"/>
+      <point x="325" y="-122" type="line"/>
+      <point x="-45" y="-122" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>410</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="342" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="307" y="762" type="line"/>
+      <point x="391" y="814" type="line"/>
+      <point x="248" y="1058" type="line"/>
+      <point x="154" y="1001" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>310</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="341" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="238" y="854" type="line"/>
+      <point x="256" y="916"/>
+      <point x="303" y="950"/>
+      <point x="370" y="950" type="curve" smooth="yes"/>
+      <point x="434" y="950"/>
+      <point x="473" y="917"/>
+      <point x="483" y="855" type="curve"/>
+      <point x="574" y="877" type="line"/>
+      <point x="567" y="982"/>
+      <point x="485" y="1050"/>
+      <point x="365" y="1050" type="curve" smooth="yes"/>
+      <point x="245" y="1050"/>
+      <point x="167" y="996"/>
+      <point x="133" y="888" type="curve"/>
+    </contour>
+    <contour>
+      <point x="364" y="757" type="curve" smooth="yes"/>
+      <point x="403" y="757"/>
+      <point x="431" y="785"/>
+      <point x="431" y="823" type="curve" smooth="yes"/>
+      <point x="431" y="861"/>
+      <point x="402" y="890"/>
+      <point x="364" y="890" type="curve" smooth="yes"/>
+      <point x="326" y="890"/>
+      <point x="298" y="861"/>
+      <point x="298" y="823" type="curve" smooth="yes"/>
+      <point x="298" y="785"/>
+      <point x="326" y="757"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>483</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="153" y="690" name="_top"/>
+  <outline>
+    <contour>
+      <point x="118" y="777" type="line"/>
+      <point x="210" y="777" type="line"/>
+      <point x="268" y="1017" type="line"/>
+      <point x="156" y="1017" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>152</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -3852,6 +3852,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9628,6 +9633,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9892,6 +9899,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11124,6 +11133,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11414,6 +11425,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13498,6 +13511,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="160" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="166" y="744" type="line"/>
+      <point x="395" y="943" type="line"/>
+      <point x="341" y="1005" type="line"/>
+      <point x="118" y="799" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>292</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-59" y="-206" type="line"/>
+      <point x="291" y="-206" type="line"/>
+      <point x="303" y="-134" type="line"/>
+      <point x="-47" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>391</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="343" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="301" y="733" type="line"/>
+      <point x="366" y="774" type="line"/>
+      <point x="221" y="1012" type="line"/>
+      <point x="147" y="965" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="308" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="212" y="815" type="line"/>
+      <point x="240" y="884"/>
+      <point x="285" y="919"/>
+      <point x="342" y="919" type="curve" smooth="yes"/>
+      <point x="401" y="919"/>
+      <point x="436" y="885"/>
+      <point x="444" y="821" type="curve"/>
+      <point x="521" y="836" type="line"/>
+      <point x="506" y="940"/>
+      <point x="441" y="999"/>
+      <point x="341" y="999" type="curve" smooth="yes"/>
+      <point x="241" y="999"/>
+      <point x="167" y="948"/>
+      <point x="127" y="849" type="curve"/>
+    </contour>
+    <contour>
+      <point x="332" y="738" type="curve" smooth="yes"/>
+      <point x="367" y="738"/>
+      <point x="391" y="762"/>
+      <point x="391" y="796" type="curve" smooth="yes"/>
+      <point x="391" y="831"/>
+      <point x="367" y="856"/>
+      <point x="332" y="856" type="curve" smooth="yes"/>
+      <point x="297" y="856"/>
+      <point x="273" y="831"/>
+      <point x="273" y="796" type="curve" smooth="yes"/>
+      <point x="273" y="762"/>
+      <point x="297" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>437</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="136" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="119" y="758" type="line"/>
+      <point x="187" y="758" type="line"/>
+      <point x="237" y="978" type="line"/>
+      <point x="149" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="160" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="166" y="744" type="line"/>
+      <point x="395" y="943" type="line"/>
+      <point x="341" y="1005" type="line"/>
+      <point x="118" y="799" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>292</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-59" y="-206" type="line"/>
+      <point x="291" y="-206" type="line"/>
+      <point x="303" y="-134" type="line"/>
+      <point x="-47" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>391</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="343" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="301" y="733" type="line"/>
+      <point x="366" y="774" type="line"/>
+      <point x="221" y="1012" type="line"/>
+      <point x="147" y="965" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="308" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="212" y="815" type="line"/>
+      <point x="240" y="884"/>
+      <point x="285" y="919"/>
+      <point x="342" y="919" type="curve" smooth="yes"/>
+      <point x="401" y="919"/>
+      <point x="436" y="885"/>
+      <point x="444" y="821" type="curve"/>
+      <point x="521" y="836" type="line"/>
+      <point x="506" y="940"/>
+      <point x="441" y="999"/>
+      <point x="341" y="999" type="curve" smooth="yes"/>
+      <point x="241" y="999"/>
+      <point x="167" y="948"/>
+      <point x="127" y="849" type="curve"/>
+    </contour>
+    <contour>
+      <point x="332" y="738" type="curve" smooth="yes"/>
+      <point x="367" y="738"/>
+      <point x="391" y="762"/>
+      <point x="391" y="796" type="curve" smooth="yes"/>
+      <point x="391" y="831"/>
+      <point x="367" y="856"/>
+      <point x="332" y="856" type="curve" smooth="yes"/>
+      <point x="297" y="856"/>
+      <point x="273" y="831"/>
+      <point x="273" y="796" type="curve" smooth="yes"/>
+      <point x="273" y="762"/>
+      <point x="297" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>437</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="136" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="119" y="758" type="line"/>
+      <point x="187" y="758" type="line"/>
+      <point x="237" y="978" type="line"/>
+      <point x="149" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="160" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="166" y="744" type="line"/>
+      <point x="395" y="943" type="line"/>
+      <point x="341" y="1005" type="line"/>
+      <point x="118" y="799" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>292</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="148" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-59" y="-206" type="line"/>
+      <point x="291" y="-206" type="line"/>
+      <point x="303" y="-134" type="line"/>
+      <point x="-47" y="-134" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>391</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="343" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="301" y="733" type="line"/>
+      <point x="366" y="774" type="line"/>
+      <point x="221" y="1012" type="line"/>
+      <point x="147" y="965" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>293</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="308" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="212" y="815" type="line"/>
+      <point x="240" y="884"/>
+      <point x="285" y="919"/>
+      <point x="342" y="919" type="curve" smooth="yes"/>
+      <point x="401" y="919"/>
+      <point x="436" y="885"/>
+      <point x="444" y="821" type="curve"/>
+      <point x="521" y="836" type="line"/>
+      <point x="506" y="940"/>
+      <point x="441" y="999"/>
+      <point x="341" y="999" type="curve" smooth="yes"/>
+      <point x="241" y="999"/>
+      <point x="167" y="948"/>
+      <point x="127" y="849" type="curve"/>
+    </contour>
+    <contour>
+      <point x="332" y="738" type="curve" smooth="yes"/>
+      <point x="367" y="738"/>
+      <point x="391" y="762"/>
+      <point x="391" y="796" type="curve" smooth="yes"/>
+      <point x="391" y="831"/>
+      <point x="367" y="856"/>
+      <point x="332" y="856" type="curve" smooth="yes"/>
+      <point x="297" y="856"/>
+      <point x="273" y="831"/>
+      <point x="273" y="796" type="curve" smooth="yes"/>
+      <point x="273" y="762"/>
+      <point x="297" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>437</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="136" y="660" name="_top"/>
+  <outline>
+    <contour>
+      <point x="119" y="758" type="line"/>
+      <point x="187" y="758" type="line"/>
+      <point x="237" y="978" type="line"/>
+      <point x="149" y="978" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>128</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -3853,6 +3853,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9629,6 +9634,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9893,6 +9900,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11125,6 +11134,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11415,6 +11426,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13499,6 +13512,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/acute-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/acute-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acute-deva" format="2">
+  <unicode hex="0954"/>
+  <anchor x="179" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="185" y="744" type="line"/>
+      <point x="419" y="946" type="line"/>
+      <point x="349" y="1025" type="line"/>
+      <point x="121" y="816" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>315</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/anudatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="anudatta-deva" format="2">
+  <unicode hex="0952"/>
+  <anchor x="158" y="0" name="_bottom"/>
+  <outline>
+    <contour>
+      <point x="-59" y="-206" type="line"/>
+      <point x="311" y="-206" type="line"/>
+      <point x="327" y="-112" type="line"/>
+      <point x="-43" y="-112" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>411</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -1420,6 +1420,8 @@
     <string>acircumflextilde.sc.glif</string>
     <key>acute</key>
     <string>acute.glif</string>
+    <key>acute-deva</key>
+    <string>acute-deva.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
     <key>acutecomb.cap</key>
@@ -1740,6 +1742,8 @@
     <string>anoteleia.case.glif</string>
     <key>anoteleia.sc</key>
     <string>anoteleia.sc.glif</string>
+    <key>anudatta-deva</key>
+    <string>anudatta-deva.glif</string>
     <key>anusvara-deva</key>
     <string>anusvara-deva.glif</string>
     <key>anusvara-tamil</key>
@@ -3538,6 +3542,8 @@
     <string>graphemejoinercomb.glif</string>
     <key>grave</key>
     <string>grave.glif</string>
+    <key>grave-deva</key>
+    <string>grave-deva.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
     <key>gravecomb.cap</key>
@@ -3920,6 +3926,8 @@
     <string>ini-arm.sc.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
+    <key>invertedCandraBindu-deva</key>
+    <string>invertedC_andraB_indu-deva.glif</string>
     <key>io-cy</key>
     <string>io-cy.glif</string>
     <key>io-cy.sc</key>
@@ -6804,6 +6812,8 @@
     <string>ucircumflex.sc.glif</string>
     <key>udaat-gurmukhi</key>
     <string>udaat-gurmukhi.glif</string>
+    <key>udatta-deva</key>
+    <string>udatta-deva.glif</string>
     <key>udieresis</key>
     <string>udieresis.glif</string>
     <key>udieresis-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/grave-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/grave-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="grave-deva" format="2">
+  <unicode hex="0953"/>
+  <anchor x="353" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="305" y="733" type="line"/>
+      <point x="389" y="785" type="line"/>
+      <point x="244" y="1028" type="line"/>
+      <point x="148" y="970" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>314</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/invertedC_andraB_indu-deva.glif
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="invertedCandraBindu-deva" format="2">
+  <unicode hex="0900"/>
+  <anchor x="328" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="234" y="833" type="line"/>
+      <point x="259" y="897"/>
+      <point x="305" y="933"/>
+      <point x="361" y="933" type="curve" smooth="yes"/>
+      <point x="418" y="933"/>
+      <point x="454" y="900"/>
+      <point x="467" y="837" type="curve"/>
+      <point x="559" y="859" type="line"/>
+      <point x="545" y="966"/>
+      <point x="470" y="1033"/>
+      <point x="365" y="1033" type="curve" smooth="yes"/>
+      <point x="261" y="1033"/>
+      <point x="174" y="975"/>
+      <point x="131" y="876" type="curve"/>
+    </contour>
+    <contour>
+      <point x="352" y="738" type="curve" smooth="yes"/>
+      <point x="392" y="738"/>
+      <point x="420" y="766"/>
+      <point x="420" y="805" type="curve" smooth="yes"/>
+      <point x="420" y="845"/>
+      <point x="392" y="873"/>
+      <point x="352" y="873" type="curve" smooth="yes"/>
+      <point x="313" y="873"/>
+      <point x="285" y="845"/>
+      <point x="285" y="805" type="curve" smooth="yes"/>
+      <point x="285" y="766"/>
+      <point x="313" y="738"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>471</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/udatta-deva.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="udatta-deva" format="2">
+  <unicode hex="0951"/>
+  <anchor x="150" y="671" name="_top"/>
+  <outline>
+    <contour>
+      <point x="116" y="758" type="line"/>
+      <point x="208" y="758" type="line"/>
+      <point x="261" y="979" type="line"/>
+      <point x="149" y="979" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>152</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -3851,6 +3851,11 @@
       <string>nine.loclTAML.tf</string>
       <string>hyphentwo</string>
       <string>nonbreakinghyphen</string>
+      <string>invertedCandraBindu-deva</string>
+      <string>udatta-deva</string>
+      <string>anudatta-deva</string>
+      <string>grave-deva</string>
+      <string>acute-deva</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -9627,6 +9632,8 @@
       <string>uni1EAB.alt</string>
       <key>acircumflextilde.sc</key>
       <string>uni1EAB.sc</string>
+      <key>acute-deva</key>
+      <string>uni0954</string>
       <key>adakbindi-gurmukhi</key>
       <string>uni0A01</string>
       <key>addak-gurmukhi</key>
@@ -9891,6 +9898,8 @@
       <string>uni10D0</string>
       <key>angkhankhu-thai</key>
       <string>uni0E5A</string>
+      <key>anudatta-deva</key>
+      <string>uni0952</string>
       <key>anusvara-deva</key>
       <string>uni0902</string>
       <key>anusvara-tamil</key>
@@ -11123,6 +11132,8 @@
       <string>uni097D</string>
       <key>graphemejoinercomb</key>
       <string>uni034F</string>
+      <key>grave-deva</key>
+      <string>uni0953</string>
       <key>guillemetleft</key>
       <string>guillemotleft</string>
       <key>guillemetleft.cap</key>
@@ -11413,6 +11424,8 @@
       <string>uni056B</string>
       <key>ini-arm.sc</key>
       <string>uni056B.sc</string>
+      <key>invertedCandraBindu-deva</key>
+      <string>uni0900</string>
       <key>io-cy</key>
       <string>uni0451</string>
       <key>io-cy.sc</key>
@@ -13497,6 +13510,8 @@
       <string>uni0BC1</string>
       <key>udaat-gurmukhi</key>
       <string>uni0A51</string>
+      <key>udatta-deva</key>
+      <string>uni0951</string>
       <key>udieresis-cy</key>
       <string>uni04F1</string>
       <key>udieresis-cy.sc</key>


### PR DESCRIPTION
Closes #359

Imported from sources pushed by @kalapi in https://github.com/googlefonts/googlesans/issues/359#issuecomment-910564251

New glyph names:

```
invertedCandraBindu-deva
udatta-deva
anudatta-deva
grave-deva
acute-deva
```

cc @davelab6 @marekjez86 

### TODO

- [x] rebase after #374 is merged (glyphsetdef conflict)