### PR TITLE
Support colon.ss03 in calt, Roman builds

### DIFF
--- a/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
@@ -2253,7 +2253,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
@@ -2108,7 +2108,6 @@ dieresistonos
 uni1FBF
 uni1FBD
 uni1FFE
-uni1FFE.case
 uni1FCD
 uni1FDD
 uni1FCE

--- a/qa/shaping/ss03.json
+++ b/qa/shaping/ss03.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "build_commit": "e2766096416e641da5edff0ced5c1f8f9dcc0e5b"
+    "build_commit": "32312434b45053f272628d9720eb10fbf03b3a09"
   },
   "input": {
     "features": {
@@ -45,32 +45,32 @@
     "GoogleSans[GRAD,opsz,wght].ttf": {
       "opsz=18.0,wght=400.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ],
       "opsz=18.0,wght=500.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ],
       "opsz=18.0,wght=700.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ],
       "opsz=17.0,wght=400.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ],
       "opsz=17.0,wght=500.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ],
       "opsz=17.0,wght=700.0,GRAD=0.0": [
         "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-        "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+        "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
       ]
     },
     "GoogleSans-Bold.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ],
     "GoogleSans-BoldItalic.ttf": [
       "zero|one|two|three|four|five|six|seven|eight|nine|nine",
@@ -82,7 +82,7 @@
     ],
     "GoogleSans-Medium.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ],
     "GoogleSans-MediumItalic.ttf": [
       "zero|one|two|three|four|five|six|seven|eight|nine|nine",
@@ -90,11 +90,11 @@
     ],
     "GoogleSans-Regular.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ],
     "GoogleSansText-Bold.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ],
     "GoogleSansText-BoldItalic.ttf": [
       "zero|one|two|three|four|five|six|seven|eight|nine|nine",
@@ -106,7 +106,7 @@
     ],
     "GoogleSansText-Medium.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ],
     "GoogleSansText-MediumItalic.ttf": [
       "zero|one|two|three|four|five|six|seven|eight|nine|nine",
@@ -114,7 +114,7 @@
     ],
     "GoogleSansText-Regular.ttf": [
       "zero.ss03|one.ss03|two.ss03|three.ss03|four.ss03|five.ss03|six.ss03|seven.ss03|eight.ss03|nine.ss03|nine.ss03",
-      "zero.ss03|nine.ss03|colon.time|three.ss03|zero.ss03|space|one.ss03|colon.time|two.ss03|zero.ss03|p|m"
+      "zero.ss03|nine.ss03|colon.ss03|three.ss03|zero.ss03|space|one.ss03|colon.ss03|two.ss03|zero.ss03|p|m"
     ]
   }
 }

--- a/source/GoogleSans/family_uprights.fea
+++ b/source/GoogleSans/family_uprights.fea
@@ -55,7 +55,7 @@ feature ss03 {
 } ss03;
 
 feature calt {
-    sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.time;
+    sub [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] colon.time' [zero.ss03 one.ss03 two.ss03 three.ss03 four.ss03 five.ss03 six.ss03 seven.ss03 eight.ss03 nine.ss03] by colon.ss03;
 } calt;
 
 feature kern {


### PR DESCRIPTION
Fixes #178


with calt off, colon -> colon.ss03 is already implemented in ss03 feature

with calt on, this PR adds a new colon.time -> colon.ss03 sub **in Roman only** to address the issue in #178