### PR TITLE
Fix graded width of various Greek polytonic glyphs

### DIFF
--- a/scripts/one-off/fix-greek-poly-widths.py
+++ b/scripts/one-off/fix-greek-poly-widths.py
@@ -1,0 +1,123 @@
+# Copyright 2021 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Match the width of Greek polytonic glyphs in other grades to the width in GRAD0.
+
+See:
+https://github.com/googlefonts/googlesans/issues/421
+https://github.com/googlefonts/googlesans/pull/425
+"""
+from __future__ import annotations
+
+# This script requires Python 3.9+ for graphlib
+from graphlib import TopologicalSorter
+from pathlib import Path
+from textwrap import indent
+from typing import Dict, FrozenSet, List
+
+import ufoLib2
+
+DEPENDENT_UFOS = {
+    "GoogleSans-opsz17-wght380-GRAD0.ufo": [
+        "GoogleSans-opsz17-wght380-GRAD-50.ufo",
+        "GoogleSans-opsz17-wght380-GRAD200.ufo",
+    ],
+    "GoogleSans-opsz18-wght380-GRAD0.ufo": [
+        "GoogleSans-opsz18-wght380-GRAD-50.ufo",
+        "GoogleSans-opsz18-wght380-GRAD200.ufo",
+    ],
+    "GoogleSansItalic-opsz17-wght380-GRAD0.ufo": [
+        "GoogleSansItalic-opsz17-wght380-GRAD-50.ufo",
+        "GoogleSansItalic-opsz17-wght380-GRAD200.ufo",
+    ],
+    "GoogleSansItalic-opsz18-wght380-GRAD0.ufo": [
+        "GoogleSansItalic-opsz18-wght380-GRAD-50.ufo",
+        "GoogleSansItalic-opsz18-wght380-GRAD200.ufo",
+    ],
+}
+
+
+def topo_sort(font: ufoLib2.Font) -> List[str]:
+    # Build a cache of what glyphs are used as components where, to keep them
+    # in place when moving the base.
+    glyph_graph: Dict[str, FrozenSet[str]] = {}
+    for g in font:
+        if g.name is None:
+            continue
+        glyph_graph[g.name] = frozenset(c.baseGlyph for c in g.components)
+
+    # Make sure outline glyphs are first in the list, then those that use these
+    # outlines as components, then those that use these composite glyphs as
+    # components etc. This ensures changing bearings does not change glyphs
+    # we already processed.
+    ts = TopologicalSorter(glyph_graph)
+    return list(ts.static_order())
+
+
+ROOT_DIR = Path(__file__).parent.parent.parent
+SOURCE_DIR = ROOT_DIR / "source" / "GoogleSans"
+
+
+def main():
+    topo = None
+    fixed_glyphs = set()
+    not_fixed = set()
+
+    for grad0, other_grades in DEPENDENT_UFOS.items():
+        source_ufo_path = SOURCE_DIR / grad0
+        source_ufo = ufoLib2.Font.open(source_ufo_path)
+
+        if topo is None:
+            # Same order for all UFOs because they're compatible so have the
+            # same components
+            topo = topo_sort(source_ufo)
+
+        for other_grade in other_grades:
+            target_ufo_path = SOURCE_DIR / other_grade
+            target_ufo = ufoLib2.Font.open(target_ufo_path)
+
+            for glyph_name in topo:
+                try:
+                    source_glyph = source_ufo[glyph_name]  # Width 800
+                    target_glyph = target_ufo[glyph_name]  # Width 700
+                except KeyError:
+                    pass
+                width_diff = source_glyph.width - target_glyph.width  # Diff 100
+                if width_diff:
+                    if any(
+                        part in glyph_name for part in ("loclARM", "-arm", "baht.tf")
+                    ):
+                        not_fixed.add(glyph_name)
+                        continue
+                    # Apply the source width to the LSB of the target glyph
+                    target_lsb = target_glyph.getLeftMargin(target_ufo)  # LSB 50
+                    if target_lsb is not None:
+                        target_glyph.setLeftMargin(
+                            target_lsb + width_diff, target_ufo
+                        )  # New LSB 150
+                    else:
+                        target_glyph.width += width_diff
+                    fixed_glyphs.add(glyph_name)
+                assert source_glyph.width == target_glyph.width
+            target_ufo.save()
+
+        print()
+        print(f"{str(grad0)} - fixed glyphs:")
+        print(indent("\n".join(sorted(fixed_glyphs)), "    "))
+        print(f"{str(grad0)} - NOT fixed glyphs:")
+        print(indent("\n".join(sorted(not_fixed)), "    "))
+
+
+if __name__ == "__main__":
+    main()

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="762"/>
+  <advance width="767.0"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1066"/>
+  <advance width="1071.0"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="762"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="767.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="762"/>
+  <advance width="767.0"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="253"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="258.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="615"/>
+  <advance width="624.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-37"/>
-    <component base="oxia.case" xOffset="-174"/>
+    <component base="Alpha" xOffset="-28.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="762"/>
+  <advance width="767.0"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1066"/>
+  <advance width="1071.0"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="762"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="767.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="762"/>
+  <advance width="767.0"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="110"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="253"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="258.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="615"/>
+  <advance width="624.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-37"/>
-    <component base="tonos.case" xOffset="-174"/>
+    <component base="Alpha" xOffset="-28.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="631"/>
+  <advance width="649.0"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="-21"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Alpha" xOffset="-3.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="690"/>
+  <advance width="705.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="107"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Epsilon" xOffset="122.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="690"/>
+  <advance width="705.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="107"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Epsilon" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="712"/>
+  <advance width="730.0"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="129"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Epsilon" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="954"/>
+  <advance width="959.0"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1258"/>
+  <advance width="1263.0"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="954"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="959.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="954"/>
+  <advance width="959.0"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="424"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="429.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="801"/>
+  <advance width="816.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="107"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Eta" xOffset="122.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="595"/>
+  <advance width="600.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-99"/>
-    <component base="ypogegrammeni" xOffset="65"/>
+    <component base="Eta" xOffset="-94.0"/>
+    <component base="ypogegrammeni" xOffset="70.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="954"/>
+  <advance width="959.0"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1258"/>
+  <advance width="1263.0"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="954"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="959.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="954"/>
+  <advance width="959.0"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="424"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="429.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="805"/>
+  <advance width="820.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="107"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Eta" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="823"/>
+  <advance width="841.0"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="129"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Eta" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="513"/>
+  <advance width="518.0"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
+    <component base="Iota" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="366"/>
+  <advance width="375.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="107"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Iota" xOffset="116.0"/>
+    <component base="oxia.case" xOffset="-171.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="513"/>
+  <advance width="518.0"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
+    <component base="Iota" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="360"/>
+  <advance width="375.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="107"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Iota" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="382"/>
+  <advance width="400.0"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="129"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Iota" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="962"/>
+  <advance width="967.0"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1266"/>
+  <advance width="1271.0"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="962"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="967.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="962"/>
+  <advance width="967.0"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="413"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="418.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="809"/>
+  <advance width="824.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="77"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Omega" xOffset="92.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="962"/>
+  <advance width="967.0"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1266"/>
+  <advance width="1271.0"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="prosgegrammeni" xOffset="962"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="967.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="962"/>
+  <advance width="967.0"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="230"/>
-    <component base="psiliperispomeni.case" xOffset="-82"/>
-    <component base="ypogegrammeni" xOffset="413"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="418.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="809"/>
+  <advance width="824.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="77"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Omega" xOffset="92.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="831"/>
+  <advance width="849.0"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="99"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Omega" xOffset="117.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="836"/>
+  <advance width="851.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="67"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Omicron" xOffset="82.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="836"/>
+  <advance width="851.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="67"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Omicron" xOffset="82.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="858"/>
+  <advance width="876.0"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="89"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Omicron" xOffset="107.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="877"/>
+  <advance width="882.0"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="300"/>
-    <component base="dasiaperispomeni.case" xOffset="-82"/>
+    <component base="Upsilon" xOffset="305.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="724"/>
+  <advance width="739.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="147"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Upsilon" xOffset="162.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="724"/>
+  <advance width="739.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="147"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Upsilon" xOffset="162.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="746"/>
+  <advance width="764.0"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="169"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Upsilon" xOffset="187.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="638"/>
+  <advance width="635.0"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="dasia.case" xOffset="-81.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="772"/>
+  <advance width="767.0"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1076"/>
+  <advance width="1071.0"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="772"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="767.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="772"/>
+  <advance width="767.0"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="263"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="258.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="942"/>
+  <advance width="939.0"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="638"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="dasia.case" xOffset="-81.0"/>
+    <component base="prosgegrammeni" xOffset="635.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="638"/>
+  <advance width="635.0"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="129"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="dasia.case" xOffset="-81.0"/>
+    <component base="ypogegrammeni" xOffset="126.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="638"/>
+  <advance width="624.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="oxia.case" xOffset="-151"/>
+    <component base="Alpha" xOffset="-28.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsili" format="2">
-  <advance width="638"/>
+  <advance width="635.0"/>
   <unicode hex="1F08"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="psili.case" xOffset="-81.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="772"/>
+  <advance width="767.0"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1076"/>
+  <advance width="1071.0"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="772"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="767.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="772"/>
+  <advance width="767.0"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="120"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="263"/>
+    <component base="Alpha" xOffset="115.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="258.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni.ad" format="2">
-  <advance width="942"/>
+  <advance width="939.0"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="638"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="psili.case" xOffset="-81.0"/>
+    <component base="prosgegrammeni" xOffset="635.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni" format="2">
-  <advance width="638"/>
+  <advance width="635.0"/>
   <unicode hex="1F88"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="129"/>
+    <component base="Alpha" xOffset="-17.0"/>
+    <component base="psili.case" xOffset="-81.0"/>
+    <component base="ypogegrammeni" xOffset="126.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="638"/>
+  <advance width="624.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="tonos.case" xOffset="-151"/>
+    <component base="Alpha" xOffset="-28.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="661"/>
+  <advance width="649.0"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="9"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Alpha" xOffset="-3.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="715"/>
+  <advance width="705.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="132"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Epsilon" xOffset="122.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="715"/>
+  <advance width="705.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="132"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Epsilon" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="742"/>
+  <advance width="730.0"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="159"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Epsilon" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="964"/>
+  <advance width="959.0"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1268"/>
+  <advance width="1263.0"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="964"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="959.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="964"/>
+  <advance width="959.0"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="434"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="429.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="826"/>
+  <advance width="816.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="132"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Eta" xOffset="122.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="613"/>
+  <advance width="600.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-81"/>
-    <component base="ypogegrammeni" xOffset="83"/>
+    <component base="Eta" xOffset="-94.0"/>
+    <component base="ypogegrammeni" xOffset="70.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="964"/>
+  <advance width="959.0"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1268"/>
+  <advance width="1263.0"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="964"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="959.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="964"/>
+  <advance width="959.0"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="270"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="434"/>
+    <component base="Eta" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="429.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="830"/>
+  <advance width="820.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="132"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Eta" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="853"/>
+  <advance width="841.0"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="159"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Eta" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="523"/>
+  <advance width="518.0"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="270"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
+    <component base="Iota" xOffset="265.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="385"/>
+  <advance width="375.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="132"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Iota" xOffset="122.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="523"/>
+  <advance width="518.0"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="270"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
+    <component base="Iota" xOffset="265.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="385"/>
+  <advance width="375.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="132"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Iota" xOffset="122.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="412"/>
+  <advance width="400.0"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="159"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Iota" xOffset="147.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="972"/>
+  <advance width="967.0"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1276"/>
+  <advance width="1271.0"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="972"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="967.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="972"/>
+  <advance width="967.0"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="423"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="418.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="834"/>
+  <advance width="824.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="102"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Omega" xOffset="92.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="972"/>
+  <advance width="967.0"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1276"/>
+  <advance width="1271.0"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="972"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="967.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="972"/>
+  <advance width="967.0"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="240"/>
-    <component base="psiliperispomeni.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="423"/>
+    <component base="Omega" xOffset="235.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="418.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="834"/>
+  <advance width="824.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="102"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Omega" xOffset="92.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="861"/>
+  <advance width="849.0"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="129"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Omega" xOffset="117.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="861"/>
+  <advance width="851.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="92"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Omicron" xOffset="82.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="861"/>
+  <advance width="851.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="92"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Omicron" xOffset="82.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="888"/>
+  <advance width="876.0"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="119"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Omicron" xOffset="107.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="887"/>
+  <advance width="882.0"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="310"/>
-    <component base="dasiaperispomeni.case" xOffset="-72"/>
+    <component base="Upsilon" xOffset="305.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="749"/>
+  <advance width="739.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="172"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Upsilon" xOffset="162.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="749"/>
+  <advance width="739.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="172"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Upsilon" xOffset="162.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="776"/>
+  <advance width="764.0"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="199"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Upsilon" xOffset="187.0"/>
+    <component base="varia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="777"/>
+  <advance width="782.0"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1075"/>
+  <advance width="1080.0"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="777"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="782.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="777"/>
+  <advance width="782.0"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="259"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="264.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="637"/>
+  <advance width="645.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-33"/>
-    <component base="oxia.case" xOffset="-166"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="oxia.case" xOffset="-158.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="777"/>
+  <advance width="782.0"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1075"/>
+  <advance width="1080.0"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="777"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="782.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="777"/>
+  <advance width="782.0"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="107"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="259"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="264.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="637"/>
+  <advance width="645.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-33"/>
-    <component base="tonos.case" xOffset="-166"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="tonos.case" xOffset="-158.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="641"/>
+  <advance width="659"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="-29"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Alpha" xOffset="-11"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="654"/>
+  <advance width="669.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="103"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Epsilon" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="654"/>
+  <advance width="669.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="103"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Epsilon" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="672"/>
+  <advance width="690"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="121"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Epsilon" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="955"/>
+  <advance width="960.0"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1253"/>
+  <advance width="1258.0"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="955"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="960.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="955"/>
+  <advance width="960.0"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="423"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="428.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="801"/>
+  <advance width="816.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="103"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Eta" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="603"/>
+  <advance width="608.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-95"/>
-    <component base="ypogegrammeni" xOffset="71"/>
+    <component base="Eta" xOffset="-90.0"/>
+    <component base="ypogegrammeni" xOffset="76.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="955"/>
+  <advance width="960.0"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1253"/>
+  <advance width="1258.0"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="955"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="960.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="955"/>
+  <advance width="960.0"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="257"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="423"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="428.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="834"/>
+  <advance width="849.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="103"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Eta" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="819"/>
+  <advance width="837"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="121"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Eta" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="502"/>
+  <advance width="507.0"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="257"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
+    <component base="Iota" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="348"/>
+  <advance width="363.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="103"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Iota" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="502"/>
+  <advance width="507.0"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="257"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
+    <component base="Iota" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="348"/>
+  <advance width="363.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="103"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Iota" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="366"/>
+  <advance width="384"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="121"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Iota" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="995"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1293"/>
+  <advance width="1298.0"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="995"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="995"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="428"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="433.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="841"/>
+  <advance width="856.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="73"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Omega" xOffset="88.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="995"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1293"/>
+  <advance width="1298.0"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="995"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="995"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="227"/>
-    <component base="psiliperispomeni.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="428"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="433.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="841"/>
+  <advance width="856.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="73"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Omega" xOffset="88.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="859"/>
+  <advance width="877"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="91"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Omega" xOffset="109"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="887"/>
+  <advance width="902.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="63"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Omicron" xOffset="78.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="887"/>
+  <advance width="902.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="63"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Omicron" xOffset="78.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="905"/>
+  <advance width="923"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="81"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Omicron" xOffset="99"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="892"/>
+  <advance width="897.0"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="297"/>
-    <component base="dasiaperispomeni.case" xOffset="-88"/>
+    <component base="Upsilon" xOffset="302.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="738"/>
+  <advance width="753.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="143"/>
-    <component base="oxia.case" xOffset="-180"/>
+    <component base="Upsilon" xOffset="158.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="738"/>
+  <advance width="753.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="143"/>
-    <component base="tonos.case" xOffset="-180"/>
+    <component base="Upsilon" xOffset="158.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="756"/>
+  <advance width="774"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="161"/>
-    <component base="varia.case" xOffset="-183"/>
+    <component base="Upsilon" xOffset="179"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-50"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="dasia.case" xOffset="-65.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="787"/>
+  <advance width="782.0"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1085"/>
+  <advance width="1080.0"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="787"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="782.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="787"/>
+  <advance width="782.0"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="269"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="264.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="958"/>
+  <advance width="943.0"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-50"/>
-    <component base="prosgegrammeni" xOffset="660"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="dasia.case" xOffset="-65.0"/>
+    <component base="prosgegrammeni" xOffset="645.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-50"/>
-    <component base="ypogegrammeni" xOffset="142"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="dasia.case" xOffset="-65.0"/>
+    <component base="ypogegrammeni" xOffset="127.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="oxia.case" xOffset="-158.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsili" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="1F08"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-50"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="psili.case" xOffset="-65.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="787"/>
+  <advance width="782.0"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1085"/>
+  <advance width="1080.0"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="787"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="782.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="787"/>
+  <advance width="782.0"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="117"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="269"/>
+    <component base="Alpha" xOffset="112.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="264.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni.ad" format="2">
-  <advance width="958"/>
+  <advance width="943.0"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-50"/>
-    <component base="prosgegrammeni" xOffset="660"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="psili.case" xOffset="-65.0"/>
+    <component base="prosgegrammeni" xOffset="645.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="1F88"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-50"/>
-    <component base="ypogegrammeni" xOffset="142"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="psili.case" xOffset="-65.0"/>
+    <component base="ypogegrammeni" xOffset="127.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="660"/>
+  <advance width="645.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Alpha" xOffset="-25.0"/>
+    <component base="tonos.case" xOffset="-158.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="671"/>
+  <advance width="659"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="1"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Alpha" xOffset="-11"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="679"/>
+  <advance width="669.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="128"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Epsilon" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="679"/>
+  <advance width="669.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="128"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Epsilon" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="702"/>
+  <advance width="690"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="151"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Epsilon" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="965"/>
+  <advance width="960.0"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1263"/>
+  <advance width="1258.0"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="965"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="960.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="965"/>
+  <advance width="960.0"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="433"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="428.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="826"/>
+  <advance width="816.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="128"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Eta" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="621"/>
+  <advance width="608.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-77"/>
-    <component base="ypogegrammeni" xOffset="89"/>
+    <component base="Eta" xOffset="-90.0"/>
+    <component base="ypogegrammeni" xOffset="76.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="965"/>
+  <advance width="960.0"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1263"/>
+  <advance width="1258.0"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="965"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="960.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="965"/>
+  <advance width="960.0"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="267"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="433"/>
+    <component base="Eta" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="428.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="859"/>
+  <advance width="849.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="128"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Eta" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="849"/>
+  <advance width="837"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="151"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Eta" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="512"/>
+  <advance width="507.0"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="267"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
+    <component base="Iota" xOffset="262.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="373"/>
+  <advance width="363.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="128"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Iota" xOffset="118.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="512"/>
+  <advance width="507.0"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="267"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
+    <component base="Iota" xOffset="262.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="373"/>
+  <advance width="363.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="128"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Iota" xOffset="118.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="396"/>
+  <advance width="384"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="151"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Iota" xOffset="139"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="1005"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1303"/>
+  <advance width="1298.0"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="1005"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="1005"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="438"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="433.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="866"/>
+  <advance width="856.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="98"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Omega" xOffset="88.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="1005"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1303"/>
+  <advance width="1298.0"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="1005"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="1005"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="237"/>
-    <component base="psiliperispomeni.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="438"/>
+    <component base="Omega" xOffset="232.0"/>
+    <component base="psiliperispomeni.case" xOffset="-83.0"/>
+    <component base="ypogegrammeni" xOffset="433.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="866"/>
+  <advance width="856.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="98"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Omega" xOffset="88.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="889"/>
+  <advance width="877"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="121"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Omega" xOffset="109"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="912"/>
+  <advance width="902.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="88"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Omicron" xOffset="78.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="912"/>
+  <advance width="902.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="88"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Omicron" xOffset="78.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="935"/>
+  <advance width="923"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="111"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Omicron" xOffset="99"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="902"/>
+  <advance width="897.0"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="307"/>
-    <component base="dasiaperispomeni.case" xOffset="-78"/>
+    <component base="Upsilon" xOffset="302.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-83.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="763"/>
+  <advance width="753.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="168"/>
-    <component base="oxia.case" xOffset="-155"/>
+    <component base="Upsilon" xOffset="158.0"/>
+    <component base="oxia.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="763"/>
+  <advance width="753.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="168"/>
-    <component base="tonos.case" xOffset="-155"/>
+    <component base="Upsilon" xOffset="158.0"/>
+    <component base="tonos.case" xOffset="-165.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="786"/>
+  <advance width="774"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="191"/>
-    <component base="varia.case" xOffset="-153"/>
+    <component base="Upsilon" xOffset="179"/>
+    <component base="varia.case" xOffset="-165"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="622"/>
+  <advance width="633.0"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-30"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxia" format="2">
-  <advance width="796"/>
+  <advance width="807.0"/>
   <unicode hex="1F0D"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Alpha" xOffset="155.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1099"/>
+  <advance width="1110.0"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="796"/>
+    <component base="Alpha" xOffset="155.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="807.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxiaprosgegrammeni" format="2">
-  <advance width="796"/>
+  <advance width="807.0"/>
   <unicode hex="1F8D"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="307"/>
+    <component base="Alpha" xOffset="155.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="318.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="763"/>
+  <advance width="773.0"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1066"/>
+  <advance width="1076.0"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="763"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="773.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="763"/>
+  <advance width="773.0"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="274"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="284.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="925"/>
+  <advance width="936.0"/>
   <outline>
-    <component base="Alpha" xOffset="-30"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="622"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="633.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="622"/>
+  <advance width="633.0"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-30"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="133"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="144.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavaria" format="2">
-  <advance width="836"/>
+  <advance width="847.0"/>
   <unicode hex="1F0B"/>
   <outline>
-    <component base="Alpha" xOffset="184"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Alpha" xOffset="195.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1139"/>
+  <advance width="1150.0"/>
   <outline>
-    <component base="Alpha" xOffset="184"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="836"/>
+    <component base="Alpha" xOffset="195.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="847.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavariaprosgegrammeni" format="2">
-  <advance width="836"/>
+  <advance width="847.0"/>
   <unicode hex="1F8B"/>
   <outline>
-    <component base="Alpha" xOffset="184"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="347"/>
+    <component base="Alpha" xOffset="195.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="358.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="619"/>
+  <advance width="629.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-33"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Alpha" xOffset="-23.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="763"/>
+  <advance width="773.0"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1066"/>
+  <advance width="1076.0"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="763"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="773.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="763"/>
+  <advance width="773.0"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="111"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="274"/>
+    <component base="Alpha" xOffset="121.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="284.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="619"/>
+  <advance width="629.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-33"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Alpha" xOffset="-23.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="663"/>
+  <advance width="673.0"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="11"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Alpha" xOffset="21.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasia" format="2">
-  <advance width="702"/>
+  <advance width="713.0"/>
   <unicode hex="1F19"/>
   <outline>
-    <component base="Epsilon" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Epsilon" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasiaoxia" format="2">
-  <advance width="876"/>
+  <advance width="887.0"/>
   <unicode hex="1F1D"/>
   <outline>
-    <component base="Epsilon" xOffset="293"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Epsilon" xOffset="304.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilondasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasiavaria" format="2">
-  <advance width="916"/>
+  <advance width="927.0"/>
   <unicode hex="1F1B"/>
   <outline>
-    <component base="Epsilon" xOffset="333"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Epsilon" xOffset="344.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="699"/>
+  <advance width="709.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="116"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Epsilon" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="699"/>
+  <advance width="709.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="116"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Epsilon" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="743"/>
+  <advance width="753.0"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="160"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Epsilon" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasia" format="2">
-  <advance width="813"/>
+  <advance width="824.0"/>
   <unicode hex="1F29"/>
   <outline>
-    <component base="Eta" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Eta" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxia" format="2">
-  <advance width="987"/>
+  <advance width="998.0"/>
   <unicode hex="1F2D"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Eta" xOffset="304.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1290"/>
+  <advance width="1301.0"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="987"/>
+    <component base="Eta" xOffset="304.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="998.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxiaprosgegrammeni" format="2">
-  <advance width="987"/>
+  <advance width="998.0"/>
   <unicode hex="1F9D"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="477"/>
+    <component base="Eta" xOffset="304.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="488.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="954"/>
+  <advance width="964.0"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1257"/>
+  <advance width="1267.0"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="954"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="964.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="954"/>
+  <advance width="964.0"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="444"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="454.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaprosgegrammeni.ad" format="2">
-  <advance width="1116"/>
+  <advance width="1127.0"/>
   <outline>
-    <component base="Eta" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="813"/>
+    <component base="Eta" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="824.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaprosgegrammeni" format="2">
-  <advance width="813"/>
+  <advance width="824.0"/>
   <unicode hex="1F99"/>
   <outline>
-    <component base="Eta" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="303"/>
+    <component base="Eta" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="314.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavaria" format="2">
-  <advance width="1027"/>
+  <advance width="1038.0"/>
   <unicode hex="1F2B"/>
   <outline>
-    <component base="Eta" xOffset="333"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Eta" xOffset="344.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1330"/>
+  <advance width="1341.0"/>
   <outline>
-    <component base="Eta" xOffset="333"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="1027"/>
+    <component base="Eta" xOffset="344.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1038.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavariaprosgegrammeni" format="2">
-  <advance width="1027"/>
+  <advance width="1038.0"/>
   <unicode hex="1F9B"/>
   <outline>
-    <component base="Eta" xOffset="333"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="517"/>
+    <component base="Eta" xOffset="344.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="528.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="810"/>
+  <advance width="820.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="116"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Eta" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="590"/>
+  <advance width="600.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-104"/>
-    <component base="ypogegrammeni" xOffset="80"/>
+    <component base="Eta" xOffset="-94.0"/>
+    <component base="ypogegrammeni" xOffset="90.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="954"/>
+  <advance width="964.0"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1257"/>
+  <advance width="1267.0"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="954"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="964.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="954"/>
+  <advance width="964.0"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="444"/>
+    <component base="Eta" xOffset="270.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="454.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="814"/>
+  <advance width="824.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="116"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Eta" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="854"/>
+  <advance width="864.0"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="160"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Eta" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasia" format="2">
-  <advance width="372"/>
+  <advance width="383.0"/>
   <unicode hex="1F39"/>
   <outline>
-    <component base="Iota" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Iota" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaoxia" format="2">
-  <advance width="546"/>
+  <advance width="557.0"/>
   <unicode hex="1F3D"/>
   <outline>
-    <component base="Iota" xOffset="293"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Iota" xOffset="304.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="513"/>
+  <advance width="523.0"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="260"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
+    <component base="Iota" xOffset="270.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiavaria" format="2">
-  <advance width="586"/>
+  <advance width="597.0"/>
   <unicode hex="1F3B"/>
   <outline>
-    <component base="Iota" xOffset="333"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Iota" xOffset="344.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="369"/>
+  <advance width="379.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="116"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Iota" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="513"/>
+  <advance width="523.0"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="260"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
+    <component base="Iota" xOffset="270.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="369"/>
+  <advance width="379.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="116"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Iota" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="413"/>
+  <advance width="423.0"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="160"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Iota" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasia" format="2">
-  <advance width="849"/>
+  <advance width="860.0"/>
   <unicode hex="1F69"/>
   <outline>
-    <component base="Omega" xOffset="109"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Omega" xOffset="120.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxia" format="2">
-  <advance width="1023"/>
+  <advance width="1034.0"/>
   <unicode hex="1F6D"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Omega" xOffset="294.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1326"/>
+  <advance width="1337.0"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="1023"/>
+    <component base="Omega" xOffset="294.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1034.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxiaprosgegrammeni" format="2">
-  <advance width="1023"/>
+  <advance width="1034.0"/>
   <unicode hex="1FAD"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="500"/>
+    <component base="Omega" xOffset="294.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="511.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="990"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1293"/>
+  <advance width="1303.0"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="990"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="990"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="467"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="477.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaprosgegrammeni.ad" format="2">
-  <advance width="1152"/>
+  <advance width="1163.0"/>
   <outline>
-    <component base="Omega" xOffset="109"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="849"/>
+    <component base="Omega" xOffset="120.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="860.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaprosgegrammeni" format="2">
-  <advance width="849"/>
+  <advance width="860.0"/>
   <unicode hex="1FA9"/>
   <outline>
-    <component base="Omega" xOffset="109"/>
-    <component base="dasia.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="326"/>
+    <component base="Omega" xOffset="120.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="337.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavaria" format="2">
-  <advance width="1063"/>
+  <advance width="1074.0"/>
   <unicode hex="1F6B"/>
   <outline>
-    <component base="Omega" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Omega" xOffset="334.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1366"/>
+  <advance width="1377.0"/>
   <outline>
-    <component base="Omega" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="prosgegrammeni" xOffset="1063"/>
+    <component base="Omega" xOffset="334.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1074.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavariaprosgegrammeni" format="2">
-  <advance width="1063"/>
+  <advance width="1074.0"/>
   <unicode hex="1FAB"/>
   <outline>
-    <component base="Omega" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
-    <component base="ypogegrammeni" xOffset="540"/>
+    <component base="Omega" xOffset="334.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="551.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="846"/>
+  <advance width="856.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="106"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Omega" xOffset="116.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="990"/>
+  <advance width="1000.0"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1293"/>
+  <advance width="1303.0"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="990"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1000.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="990"/>
+  <advance width="1000.0"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="250"/>
-    <component base="psiliperispomeni.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="467"/>
+    <component base="Omega" xOffset="260.0"/>
+    <component base="psiliperispomeni.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="477.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="846"/>
+  <advance width="856.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="106"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Omega" xOffset="116.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="890"/>
+  <advance width="900.0"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="150"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Omega" xOffset="160.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasia" format="2">
-  <advance width="878"/>
+  <advance width="889.0"/>
   <unicode hex="1F49"/>
   <outline>
-    <component base="Omicron" xOffset="109"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Omicron" xOffset="120.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasiaoxia" format="2">
-  <advance width="1052"/>
+  <advance width="1063.0"/>
   <unicode hex="1F4D"/>
   <outline>
-    <component base="Omicron" xOffset="283"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Omicron" xOffset="294.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microndasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasiavaria" format="2">
-  <advance width="1092"/>
+  <advance width="1103.0"/>
   <unicode hex="1F4B"/>
   <outline>
-    <component base="Omicron" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Omicron" xOffset="334.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="875"/>
+  <advance width="885.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="106"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Omicron" xOffset="116.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="875"/>
+  <advance width="885.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="106"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Omicron" xOffset="116.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="919"/>
+  <advance width="929.0"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="150"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Omicron" xOffset="160.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/R_hodasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/R_hodasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Rhodasia" format="2">
-  <advance width="727"/>
+  <advance width="738.0"/>
   <unicode hex="1FEC"/>
   <outline>
-    <component base="Rho" xOffset="119"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Rho" xOffset="130.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasia" format="2">
-  <advance width="736"/>
+  <advance width="747.0"/>
   <unicode hex="1F59"/>
   <outline>
-    <component base="Upsilon" xOffset="159"/>
-    <component base="dasia.case" xOffset="-88"/>
+    <component base="Upsilon" xOffset="170.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaoxia" format="2">
-  <advance width="910"/>
+  <advance width="921.0"/>
   <unicode hex="1F5D"/>
   <outline>
-    <component base="Upsilon" xOffset="333"/>
-    <component base="dasiaoxia.case" xOffset="-88"/>
+    <component base="Upsilon" xOffset="344.0"/>
+    <component base="dasiaoxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="877"/>
+  <advance width="887.0"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="300"/>
-    <component base="dasiaperispomeni.case" xOffset="-87"/>
+    <component base="Upsilon" xOffset="310.0"/>
+    <component base="dasiaperispomeni.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilondasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiavaria" format="2">
-  <advance width="950"/>
+  <advance width="961.0"/>
   <unicode hex="1F5B"/>
   <outline>
-    <component base="Upsilon" xOffset="373"/>
-    <component base="dasiavaria.case" xOffset="-88"/>
+    <component base="Upsilon" xOffset="384.0"/>
+    <component base="dasiavaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="733"/>
+  <advance width="743.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="156"/>
-    <component base="oxia.case" xOffset="-143"/>
+    <component base="Upsilon" xOffset="166.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="733"/>
+  <advance width="743.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="156"/>
-    <component base="tonos.case" xOffset="-143"/>
+    <component base="Upsilon" xOffset="166.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="777"/>
+  <advance width="787.0"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="200"/>
-    <component base="varia.case" xOffset="-143"/>
+    <component base="Upsilon" xOffset="210.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="638"/>
+  <advance width="633.0"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-72"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="941"/>
+  <advance width="936.0"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-72"/>
-    <component base="prosgegrammeni" xOffset="638"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="633.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="638"/>
+  <advance width="633.0"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="dasia.case" xOffset="-72"/>
-    <component base="ypogegrammeni" xOffset="149"/>
+    <component base="Alpha" xOffset="-19.0"/>
+    <component base="dasia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="144.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="639"/>
+  <advance width="629.0"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-13"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Alpha" xOffset="-23.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsili" format="2">
-  <advance width="638"/>
+  <advance width="634.0"/>
   <unicode hex="1F08"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-73"/>
+    <component base="Alpha" xOffset="-18.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilioxia" format="2">
-  <advance width="796"/>
+  <advance width="797.0"/>
   <unicode hex="1F0C"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="145.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilioxiaprosgegrammeni.ad" format="2">
-  <advance width="1099"/>
+  <advance width="1100.0"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="796"/>
+    <component base="Alpha" xOffset="145.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="797.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilioxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilioxiaprosgegrammeni" format="2">
-  <advance width="796"/>
+  <advance width="797.0"/>
   <unicode hex="1F8C"/>
   <outline>
-    <component base="Alpha" xOffset="144"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="307"/>
+    <component base="Alpha" xOffset="145.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="308.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni.ad" format="2">
-  <advance width="941"/>
+  <advance width="937.0"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-73"/>
-    <component base="prosgegrammeni" xOffset="638"/>
+    <component base="Alpha" xOffset="-18.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="634.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni" format="2">
-  <advance width="638"/>
+  <advance width="634.0"/>
   <unicode hex="1F88"/>
   <outline>
-    <component base="Alpha" xOffset="-14"/>
-    <component base="psili.case" xOffset="-73"/>
-    <component base="ypogegrammeni" xOffset="149"/>
+    <component base="Alpha" xOffset="-18.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="145.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilivaria" format="2">
-  <advance width="826"/>
+  <advance width="827.0"/>
   <unicode hex="1F0A"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Alpha" xOffset="175.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilivariaprosgegrammeni.ad" format="2">
-  <advance width="1129"/>
+  <advance width="1130.0"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="826"/>
+    <component base="Alpha" xOffset="175.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="827.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphapsilivariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsilivariaprosgegrammeni" format="2">
-  <advance width="826"/>
+  <advance width="827.0"/>
   <unicode hex="1F8A"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="337"/>
+    <component base="Alpha" xOffset="175.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="338.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="639"/>
+  <advance width="629.0"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-13"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Alpha" xOffset="-23.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="683"/>
+  <advance width="673.0"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="31"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Alpha" xOffset="21.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="719"/>
+  <advance width="709.0"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="136"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Epsilon" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonpsili" format="2">
-  <advance width="713"/>
+  <advance width="714.0"/>
   <unicode hex="1F18"/>
   <outline>
-    <component base="Epsilon" xOffset="130"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Epsilon" xOffset="131.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonpsilioxia" format="2">
-  <advance width="876"/>
+  <advance width="877.0"/>
   <unicode hex="1F1C"/>
   <outline>
-    <component base="Epsilon" xOffset="293"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Epsilon" xOffset="294.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonpsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonpsilivaria" format="2">
-  <advance width="906"/>
+  <advance width="907.0"/>
   <unicode hex="1F1A"/>
   <outline>
-    <component base="Epsilon" xOffset="323"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Epsilon" xOffset="324.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="719"/>
+  <advance width="709.0"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="136"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Epsilon" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="763"/>
+  <advance width="753.0"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="180"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Epsilon" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="830"/>
+  <advance width="820.0"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="136"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Eta" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="610"/>
+  <advance width="600.0"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-84"/>
-    <component base="ypogegrammeni" xOffset="100"/>
+    <component base="Eta" xOffset="-94.0"/>
+    <component base="ypogegrammeni" xOffset="90.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsili" format="2">
-  <advance width="824"/>
+  <advance width="825.0"/>
   <unicode hex="1F28"/>
   <outline>
-    <component base="Eta" xOffset="130"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Eta" xOffset="131.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilioxia" format="2">
-  <advance width="987"/>
+  <advance width="988.0"/>
   <unicode hex="1F2C"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Eta" xOffset="294.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilioxiaprosgegrammeni.ad" format="2">
-  <advance width="1290"/>
+  <advance width="1291.0"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="987"/>
+    <component base="Eta" xOffset="294.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="988.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilioxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilioxiaprosgegrammeni" format="2">
-  <advance width="987"/>
+  <advance width="988.0"/>
   <unicode hex="1F9C"/>
   <outline>
-    <component base="Eta" xOffset="293"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="477"/>
+    <component base="Eta" xOffset="294.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="478.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliprosgegrammeni.ad" format="2">
-  <advance width="1127"/>
+  <advance width="1128.0"/>
   <outline>
-    <component base="Eta" xOffset="130"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="824"/>
+    <component base="Eta" xOffset="131.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="825.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliprosgegrammeni" format="2">
-  <advance width="824"/>
+  <advance width="825.0"/>
   <unicode hex="1F98"/>
   <outline>
-    <component base="Eta" xOffset="130"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="314"/>
+    <component base="Eta" xOffset="131.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="315.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilivaria" format="2">
-  <advance width="1017"/>
+  <advance width="1018.0"/>
   <unicode hex="1F2A"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Eta" xOffset="324.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilivariaprosgegrammeni.ad" format="2">
-  <advance width="1320"/>
+  <advance width="1321.0"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="1017"/>
+    <component base="Eta" xOffset="324.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1018.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tapsilivariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsilivariaprosgegrammeni" format="2">
-  <advance width="1017"/>
+  <advance width="1018.0"/>
   <unicode hex="1F9A"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="507"/>
+    <component base="Eta" xOffset="324.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="508.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="834"/>
+  <advance width="824.0"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="136"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Eta" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="874"/>
+  <advance width="864.0"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="180"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Eta" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="389"/>
+  <advance width="379.0"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="136"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Iota" xOffset="126.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsili" format="2">
-  <advance width="383"/>
+  <advance width="384.0"/>
   <unicode hex="1F38"/>
   <outline>
-    <component base="Iota" xOffset="130"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Iota" xOffset="131.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsilioxia" format="2">
-  <advance width="546"/>
+  <advance width="547.0"/>
   <unicode hex="1F3C"/>
   <outline>
-    <component base="Iota" xOffset="293"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Iota" xOffset="294.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otapsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsilivaria" format="2">
-  <advance width="576"/>
+  <advance width="577.0"/>
   <unicode hex="1F3A"/>
   <outline>
-    <component base="Iota" xOffset="323"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Iota" xOffset="324.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="389"/>
+  <advance width="379.0"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="136"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Iota" xOffset="126.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="433"/>
+  <advance width="423.0"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="180"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Iota" xOffset="170.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="866"/>
+  <advance width="856.0"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="126"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Omega" xOffset="116.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsili" format="2">
-  <advance width="860"/>
+  <advance width="861.0"/>
   <unicode hex="1F68"/>
   <outline>
-    <component base="Omega" xOffset="120"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Omega" xOffset="121.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilioxia" format="2">
-  <advance width="1023"/>
+  <advance width="1024.0"/>
   <unicode hex="1F6C"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Omega" xOffset="284.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilioxiaprosgegrammeni.ad" format="2">
-  <advance width="1326"/>
+  <advance width="1327.0"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="1023"/>
+    <component base="Omega" xOffset="284.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1024.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilioxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilioxiaprosgegrammeni" format="2">
-  <advance width="1023"/>
+  <advance width="1024.0"/>
   <unicode hex="1FAC"/>
   <outline>
-    <component base="Omega" xOffset="283"/>
-    <component base="psilioxia.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="500"/>
+    <component base="Omega" xOffset="284.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="501.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliprosgegrammeni.ad" format="2">
-  <advance width="1163"/>
+  <advance width="1164.0"/>
   <outline>
-    <component base="Omega" xOffset="120"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="860"/>
+    <component base="Omega" xOffset="121.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="861.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliprosgegrammeni" format="2">
-  <advance width="860"/>
+  <advance width="861.0"/>
   <unicode hex="1FA8"/>
   <outline>
-    <component base="Omega" xOffset="120"/>
-    <component base="psili.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="337"/>
+    <component base="Omega" xOffset="121.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="338.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilivaria" format="2">
-  <advance width="1053"/>
+  <advance width="1054.0"/>
   <unicode hex="1F6A"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Omega" xOffset="314.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilivariaprosgegrammeni.ad" format="2">
-  <advance width="1356"/>
+  <advance width="1357.0"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="prosgegrammeni" xOffset="1053"/>
+    <component base="Omega" xOffset="314.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="prosgegrammeni" xOffset="1054.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megapsilivariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsilivariaprosgegrammeni" format="2">
-  <advance width="1053"/>
+  <advance width="1054.0"/>
   <unicode hex="1FAA"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="psilivaria.case" xOffset="-78"/>
-    <component base="ypogegrammeni" xOffset="530"/>
+    <component base="Omega" xOffset="314.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
+    <component base="ypogegrammeni" xOffset="531.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="866"/>
+  <advance width="856.0"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="126"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Omega" xOffset="116.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="910"/>
+  <advance width="900.0"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="170"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Omega" xOffset="160.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="895"/>
+  <advance width="885.0"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="126"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Omicron" xOffset="116.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronpsili" format="2">
-  <advance width="889"/>
+  <advance width="890.0"/>
   <unicode hex="1F48"/>
   <outline>
-    <component base="Omicron" xOffset="120"/>
-    <component base="psili.case" xOffset="-78"/>
+    <component base="Omicron" xOffset="121.0"/>
+    <component base="psili.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsilioxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsilioxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronpsilioxia" format="2">
-  <advance width="1052"/>
+  <advance width="1053.0"/>
   <unicode hex="1F4C"/>
   <outline>
-    <component base="Omicron" xOffset="283"/>
-    <component base="psilioxia.case" xOffset="-78"/>
+    <component base="Omicron" xOffset="284.0"/>
+    <component base="psilioxia.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsilivaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronpsilivaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronpsilivaria" format="2">
-  <advance width="1082"/>
+  <advance width="1083.0"/>
   <unicode hex="1F4A"/>
   <outline>
-    <component base="Omicron" xOffset="313"/>
-    <component base="psilivaria.case" xOffset="-78"/>
+    <component base="Omicron" xOffset="314.0"/>
+    <component base="psilivaria.case" xOffset="-77.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="895"/>
+  <advance width="885.0"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="126"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Omicron" xOffset="116.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="939"/>
+  <advance width="929.0"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="170"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Omicron" xOffset="160.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="753"/>
+  <advance width="743.0"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="176"/>
-    <component base="oxia.case" xOffset="-123"/>
+    <component base="Upsilon" xOffset="166.0"/>
+    <component base="oxia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="753"/>
+  <advance width="743.0"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="176"/>
-    <component base="tonos.case" xOffset="-123"/>
+    <component base="Upsilon" xOffset="166.0"/>
+    <component base="tonos.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="797"/>
+  <advance width="787.0"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="220"/>
-    <component base="varia.case" xOffset="-123"/>
+    <component base="Upsilon" xOffset="210.0"/>
+    <component base="varia.case" xOffset="-133.0"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="634"/>
+  <advance width="644"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-35"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxia" format="2">
-  <advance width="809"/>
+  <advance width="819"/>
   <unicode hex="1F0D"/>
   <outline>
-    <component base="Alpha" xOffset="140"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Alpha" xOffset="150"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1107"/>
+  <advance width="1117"/>
   <outline>
-    <component base="Alpha" xOffset="140"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="809"/>
+    <component base="Alpha" xOffset="150"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="819"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaoxiaprosgegrammeni" format="2">
-  <advance width="809"/>
+  <advance width="819"/>
   <unicode hex="1F8D"/>
   <outline>
-    <component base="Alpha" xOffset="140"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="317"/>
+    <component base="Alpha" xOffset="150"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="327"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeni" format="2">
-  <advance width="781"/>
+  <advance width="791"/>
   <unicode hex="1F0F"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1079"/>
+  <advance width="1089"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="781"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="791"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="781"/>
+  <advance width="791"/>
   <unicode hex="1F8F"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="289"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="299"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="932"/>
+  <advance width="942"/>
   <outline>
-    <component base="Alpha" xOffset="-35"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="634"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="644"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="634"/>
+  <advance width="644"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-35"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="142"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="152"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavaria" format="2">
-  <advance width="843"/>
+  <advance width="853"/>
   <unicode hex="1F0B"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Alpha" xOffset="184"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1141"/>
+  <advance width="1151"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="843"/>
+    <component base="Alpha" xOffset="184"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="853"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiavariaprosgegrammeni" format="2">
-  <advance width="843"/>
+  <advance width="853"/>
   <unicode hex="1F8B"/>
   <outline>
-    <component base="Alpha" xOffset="174"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="351"/>
+    <component base="Alpha" xOffset="184"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="361"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="641"/>
+  <advance width="651"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-28"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Alpha" xOffset="-18"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsili" format="2">
-  <advance width="643"/>
+  <advance width="644"/>
   <unicode hex="1F08"/>
   <outline>
-    <component base="Alpha" xOffset="-26"/>
-    <component base="psili.case" xOffset="-64"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeni" format="2">
-  <advance width="781"/>
+  <advance width="791"/>
   <unicode hex="1F0E"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1079"/>
+  <advance width="1089"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="781"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="791"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="781"/>
+  <advance width="791"/>
   <unicode hex="1F8E"/>
   <outline>
-    <component base="Alpha" xOffset="112"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="289"/>
+    <component base="Alpha" xOffset="122"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="299"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni.ad" format="2">
-  <advance width="941"/>
+  <advance width="942"/>
   <outline>
-    <component base="Alpha" xOffset="-26"/>
-    <component base="psili.case" xOffset="-64"/>
-    <component base="prosgegrammeni" xOffset="643"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
+    <component base="prosgegrammeni" xOffset="644"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni" format="2">
-  <advance width="643"/>
+  <advance width="644"/>
   <unicode hex="1F88"/>
   <outline>
-    <component base="Alpha" xOffset="-26"/>
-    <component base="psili.case" xOffset="-64"/>
-    <component base="ypogegrammeni" xOffset="151"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
+    <component base="ypogegrammeni" xOffset="152"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="641"/>
+  <advance width="651"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-28"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Alpha" xOffset="-18"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="679"/>
+  <advance width="689"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="10"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Alpha" xOffset="20"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasia" format="2">
-  <advance width="664"/>
+  <advance width="674"/>
   <unicode hex="1F19"/>
   <outline>
-    <component base="Epsilon" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Epsilon" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasiaoxia" format="2">
-  <advance width="839"/>
+  <advance width="849"/>
   <unicode hex="1F1D"/>
   <outline>
-    <component base="Epsilon" xOffset="289"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Epsilon" xOffset="299"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilondasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilondasiavaria" format="2">
-  <advance width="873"/>
+  <advance width="883"/>
   <unicode hex="1F1B"/>
   <outline>
-    <component base="Epsilon" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Epsilon" xOffset="333"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="671"/>
+  <advance width="681"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="121"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Epsilon" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="671"/>
+  <advance width="681"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="121"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Epsilon" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="709"/>
+  <advance width="719"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="159"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Epsilon" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasia" format="2">
-  <advance width="812"/>
+  <advance width="822"/>
   <unicode hex="1F29"/>
   <outline>
-    <component base="Eta" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Eta" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxia" format="2">
-  <advance width="987"/>
+  <advance width="997"/>
   <unicode hex="1F2D"/>
   <outline>
-    <component base="Eta" xOffset="289"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Eta" xOffset="299"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1285"/>
+  <advance width="1295"/>
   <outline>
-    <component base="Eta" xOffset="289"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="987"/>
+    <component base="Eta" xOffset="299"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="997"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaoxiaprosgegrammeni" format="2">
-  <advance width="987"/>
+  <advance width="997"/>
   <unicode hex="1F9D"/>
   <outline>
-    <component base="Eta" xOffset="289"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="475"/>
+    <component base="Eta" xOffset="299"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="485"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeni" format="2">
-  <advance width="959"/>
+  <advance width="969"/>
   <unicode hex="1F2F"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1257"/>
+  <advance width="1267"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="959"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="969"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="959"/>
+  <advance width="969"/>
   <unicode hex="1F9F"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="447"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="457"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaprosgegrammeni.ad" format="2">
-  <advance width="1110"/>
+  <advance width="1120"/>
   <outline>
-    <component base="Eta" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="812"/>
+    <component base="Eta" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="822"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiaprosgegrammeni" format="2">
-  <advance width="812"/>
+  <advance width="822"/>
   <unicode hex="1F99"/>
   <outline>
-    <component base="Eta" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="300"/>
+    <component base="Eta" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="310"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavaria" format="2">
-  <advance width="1021"/>
+  <advance width="1031"/>
   <unicode hex="1F2B"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Eta" xOffset="333"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1319"/>
+  <advance width="1329"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="1021"/>
+    <component base="Eta" xOffset="333"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="1031"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etadasiavariaprosgegrammeni" format="2">
-  <advance width="1021"/>
+  <advance width="1031"/>
   <unicode hex="1F9B"/>
   <outline>
-    <component base="Eta" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="509"/>
+    <component base="Eta" xOffset="333"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="519"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="819"/>
+  <advance width="829"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="121"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Eta" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="599"/>
+  <advance width="609"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-99"/>
-    <component base="ypogegrammeni" xOffset="87"/>
+    <component base="Eta" xOffset="-89"/>
+    <component base="ypogegrammeni" xOffset="97"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeni" format="2">
-  <advance width="959"/>
+  <advance width="969"/>
   <unicode hex="1F2E"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1257"/>
+  <advance width="1267"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="959"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="969"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="959"/>
+  <advance width="969"/>
   <unicode hex="1F9E"/>
   <outline>
-    <component base="Eta" xOffset="261"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="447"/>
+    <component base="Eta" xOffset="271"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="457"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="819"/>
+  <advance width="829"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="121"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Eta" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="857"/>
+  <advance width="867"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="159"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Eta" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasia" format="2">
-  <advance width="358"/>
+  <advance width="368"/>
   <unicode hex="1F39"/>
   <outline>
-    <component base="Iota" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Iota" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaoxia" format="2">
-  <advance width="533"/>
+  <advance width="543"/>
   <unicode hex="1F3D"/>
   <outline>
-    <component base="Iota" xOffset="289"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Iota" xOffset="299"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiaperispomeni" format="2">
-  <advance width="505"/>
+  <advance width="515"/>
   <unicode hex="1F3F"/>
   <outline>
-    <component base="Iota" xOffset="261"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
+    <component base="Iota" xOffset="271"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotadasiavaria" format="2">
-  <advance width="567"/>
+  <advance width="577"/>
   <unicode hex="1F3B"/>
   <outline>
-    <component base="Iota" xOffset="323"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Iota" xOffset="333"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="365"/>
+  <advance width="375"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="121"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Iota" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotapsiliperispomeni" format="2">
-  <advance width="505"/>
+  <advance width="515"/>
   <unicode hex="1F3E"/>
   <outline>
-    <component base="Iota" xOffset="261"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
+    <component base="Iota" xOffset="271"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="365"/>
+  <advance width="375"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="121"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Iota" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="403"/>
+  <advance width="413"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="159"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Iota" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasia" format="2">
-  <advance width="871"/>
+  <advance width="881"/>
   <unicode hex="1F69"/>
   <outline>
-    <component base="Omega" xOffset="104"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Omega" xOffset="114"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxia" format="2">
-  <advance width="1046"/>
+  <advance width="1056"/>
   <unicode hex="1F6D"/>
   <outline>
-    <component base="Omega" xOffset="279"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Omega" xOffset="289"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxiaprosgegrammeni.ad" format="2">
-  <advance width="1344"/>
+  <advance width="1354"/>
   <outline>
-    <component base="Omega" xOffset="279"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="1046"/>
+    <component base="Omega" xOffset="289"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="1056"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaoxiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaoxiaprosgegrammeni" format="2">
-  <advance width="1046"/>
+  <advance width="1056"/>
   <unicode hex="1FAD"/>
   <outline>
-    <component base="Omega" xOffset="279"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="519"/>
+    <component base="Omega" xOffset="289"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="529"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeni" format="2">
-  <advance width="1018"/>
+  <advance width="1028"/>
   <unicode hex="1F6F"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1316"/>
+  <advance width="1326"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="1018"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="1028"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaperispomeniprosgegrammeni" format="2">
-  <advance width="1018"/>
+  <advance width="1028"/>
   <unicode hex="1FAF"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="491"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="501"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaprosgegrammeni.ad" format="2">
-  <advance width="1169"/>
+  <advance width="1179"/>
   <outline>
-    <component base="Omega" xOffset="104"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="871"/>
+    <component base="Omega" xOffset="114"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="881"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiaprosgegrammeni" format="2">
-  <advance width="871"/>
+  <advance width="881"/>
   <unicode hex="1FA9"/>
   <outline>
-    <component base="Omega" xOffset="104"/>
-    <component base="dasia.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="344"/>
+    <component base="Omega" xOffset="114"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="354"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavaria" format="2">
-  <advance width="1080"/>
+  <advance width="1090"/>
   <unicode hex="1F6B"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Omega" xOffset="323"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavariaprosgegrammeni.ad" format="2">
-  <advance width="1378"/>
+  <advance width="1388"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="prosgegrammeni" xOffset="1080"/>
+    <component base="Omega" xOffset="323"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="1090"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megadasiavariaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegadasiavariaprosgegrammeni" format="2">
-  <advance width="1080"/>
+  <advance width="1090"/>
   <unicode hex="1FAB"/>
   <outline>
-    <component base="Omega" xOffset="313"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
-    <component base="ypogegrammeni" xOffset="553"/>
+    <component base="Omega" xOffset="323"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="563"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="878"/>
+  <advance width="888"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="111"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Omega" xOffset="121"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeni" format="2">
-  <advance width="1018"/>
+  <advance width="1028"/>
   <unicode hex="1F6E"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni.ad" format="2">
-  <advance width="1316"/>
+  <advance width="1326"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="prosgegrammeni" xOffset="1018"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="prosgegrammeni" xOffset="1028"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megapsiliperispomeniprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegapsiliperispomeniprosgegrammeni" format="2">
-  <advance width="1018"/>
+  <advance width="1028"/>
   <unicode hex="1FAE"/>
   <outline>
-    <component base="Omega" xOffset="251"/>
-    <component base="psiliperispomeni.case" xOffset="-74"/>
-    <component base="ypogegrammeni" xOffset="491"/>
+    <component base="Omega" xOffset="261"/>
+    <component base="psiliperispomeni.case" xOffset="-64"/>
+    <component base="ypogegrammeni" xOffset="501"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="878"/>
+  <advance width="888"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="111"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Omega" xOffset="121"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="916"/>
+  <advance width="926"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="149"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Omega" xOffset="159"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasia" format="2">
-  <advance width="929"/>
+  <advance width="939"/>
   <unicode hex="1F49"/>
   <outline>
-    <component base="Omicron" xOffset="104"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Omicron" xOffset="114"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasiaoxia" format="2">
-  <advance width="1104"/>
+  <advance width="1114"/>
   <unicode hex="1F4D"/>
   <outline>
-    <component base="Omicron" xOffset="279"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Omicron" xOffset="289"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microndasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrondasiavaria" format="2">
-  <advance width="1138"/>
+  <advance width="1148"/>
   <unicode hex="1F4B"/>
   <outline>
-    <component base="Omicron" xOffset="313"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Omicron" xOffset="323"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="936"/>
+  <advance width="946"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="111"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Omicron" xOffset="121"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="936"/>
+  <advance width="946"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="111"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Omicron" xOffset="121"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="974"/>
+  <advance width="984"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="149"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Omicron" xOffset="159"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/R_hodasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/R_hodasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Rhodasia" format="2">
-  <advance width="690"/>
+  <advance width="700"/>
   <unicode hex="1FEC"/>
   <outline>
-    <component base="Rho" xOffset="114"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Rho" xOffset="124"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasia" format="2">
-  <advance width="749"/>
+  <advance width="759"/>
   <unicode hex="1F59"/>
   <outline>
-    <component base="Upsilon" xOffset="154"/>
-    <component base="dasia.case" xOffset="-112"/>
+    <component base="Upsilon" xOffset="164"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaoxia" format="2">
-  <advance width="924"/>
+  <advance width="934"/>
   <unicode hex="1F5D"/>
   <outline>
-    <component base="Upsilon" xOffset="329"/>
-    <component base="dasiaoxia.case" xOffset="-112"/>
+    <component base="Upsilon" xOffset="339"/>
+    <component base="dasiaoxia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiaperispomeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiaperispomeni" format="2">
-  <advance width="896"/>
+  <advance width="906"/>
   <unicode hex="1F5F"/>
   <outline>
-    <component base="Upsilon" xOffset="301"/>
-    <component base="dasiaperispomeni.case" xOffset="-74"/>
+    <component base="Upsilon" xOffset="311"/>
+    <component base="dasiaperispomeni.case" xOffset="-64"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilondasiavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilondasiavaria" format="2">
-  <advance width="958"/>
+  <advance width="968"/>
   <unicode hex="1F5B"/>
   <outline>
-    <component base="Upsilon" xOffset="363"/>
-    <component base="dasiavaria.case" xOffset="-112"/>
+    <component base="Upsilon" xOffset="373"/>
+    <component base="dasiavaria.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="756"/>
+  <advance width="766"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="161"/>
-    <component base="oxia.case" xOffset="-152"/>
+    <component base="Upsilon" xOffset="171"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilontonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="712"/>
+  <advance width="722"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="117"/>
-    <component base="tonos.case" xOffset="-152"/>
+    <component base="Upsilon" xOffset="127"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="794"/>
+  <advance width="804"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="199"/>
-    <component base="varia.case" xOffset="-152"/>
+    <component base="Upsilon" xOffset="209"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasia" format="2">
-  <advance width="659"/>
+  <advance width="644"/>
   <unicode hex="1F09"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-87"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni.ad" format="2">
-  <advance width="957"/>
+  <advance width="942"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-87"/>
-    <component base="prosgegrammeni" xOffset="659"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="prosgegrammeni" xOffset="644"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphadasiaprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphadasiaprosgegrammeni" format="2">
-  <advance width="659"/>
+  <advance width="644"/>
   <unicode hex="1F89"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="dasia.case" xOffset="-87"/>
-    <component base="ypogegrammeni" xOffset="167"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="dasia.case" xOffset="-102"/>
+    <component base="ypogegrammeni" xOffset="152"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphaoxia" format="2">
-  <advance width="661"/>
+  <advance width="651"/>
   <unicode hex="1FBB"/>
   <outline>
-    <component base="Alpha" xOffset="-8"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Alpha" xOffset="-18"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsili.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsili" format="2">
-  <advance width="659"/>
+  <advance width="644"/>
   <unicode hex="1F08"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-48"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.ad.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni.ad" format="2">
-  <advance width="957"/>
+  <advance width="942"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-48"/>
-    <component base="prosgegrammeni" xOffset="659"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
+    <component base="prosgegrammeni" xOffset="644"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphapsiliprosgegrammeni.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphapsiliprosgegrammeni" format="2">
-  <advance width="659"/>
+  <advance width="644"/>
   <unicode hex="1F88"/>
   <outline>
-    <component base="Alpha" xOffset="-10"/>
-    <component base="psili.case" xOffset="-48"/>
-    <component base="ypogegrammeni" xOffset="167"/>
+    <component base="Alpha" xOffset="-25"/>
+    <component base="psili.case" xOffset="-63"/>
+    <component base="ypogegrammeni" xOffset="152"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphatonos" format="2">
-  <advance width="661"/>
+  <advance width="651"/>
   <unicode hex="0386"/>
   <outline>
-    <component base="Alpha" xOffset="-8"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Alpha" xOffset="-18"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/A_lphavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Alphavaria" format="2">
-  <advance width="699"/>
+  <advance width="689"/>
   <unicode hex="1FBA"/>
   <outline>
-    <component base="Alpha" xOffset="30"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Alpha" xOffset="20"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonoxia" format="2">
-  <advance width="691"/>
+  <advance width="681"/>
   <unicode hex="1FC9"/>
   <outline>
-    <component base="Epsilon" xOffset="141"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Epsilon" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="691"/>
+  <advance width="681"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="Epsilon" xOffset="141"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Epsilon" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilonvaria" format="2">
-  <advance width="729"/>
+  <advance width="719"/>
   <unicode hex="1FC8"/>
   <outline>
-    <component base="Epsilon" xOffset="179"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Epsilon" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_taoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaoxia" format="2">
-  <advance width="839"/>
+  <advance width="829"/>
   <unicode hex="1FCB"/>
   <outline>
-    <component base="Eta" xOffset="141"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Eta" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_taprosgegrammeni.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etaprosgegrammeni" format="2">
-  <advance width="619"/>
+  <advance width="609"/>
   <unicode hex="1FCC"/>
   <outline>
-    <component base="Eta" xOffset="-79"/>
-    <component base="ypogegrammeni" xOffset="107"/>
+    <component base="Eta" xOffset="-89"/>
+    <component base="ypogegrammeni" xOffset="97"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="839"/>
+  <advance width="829"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="Eta" xOffset="141"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Eta" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/E_tavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etavaria" format="2">
-  <advance width="877"/>
+  <advance width="867"/>
   <unicode hex="1FCA"/>
   <outline>
-    <component base="Eta" xOffset="179"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Eta" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotaoxia" format="2">
-  <advance width="385"/>
+  <advance width="375"/>
   <unicode hex="1FDB"/>
   <outline>
-    <component base="Iota" xOffset="141"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Iota" xOffset="131"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="385"/>
+  <advance width="375"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="Iota" xOffset="141"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Iota" xOffset="131"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/I_otavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotavaria" format="2">
-  <advance width="423"/>
+  <advance width="413"/>
   <unicode hex="1FDA"/>
   <outline>
-    <component base="Iota" xOffset="179"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Iota" xOffset="169"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megaoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegaoxia" format="2">
-  <advance width="898"/>
+  <advance width="888"/>
   <unicode hex="1FFB"/>
   <outline>
-    <component base="Omega" xOffset="131"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Omega" xOffset="121"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="898"/>
+  <advance width="888"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="131"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Omega" xOffset="121"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_megavaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegavaria" format="2">
-  <advance width="936"/>
+  <advance width="926"/>
   <unicode hex="1FFA"/>
   <outline>
-    <component base="Omega" xOffset="169"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Omega" xOffset="159"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_micronoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronoxia" format="2">
-  <advance width="956"/>
+  <advance width="946"/>
   <unicode hex="1FF9"/>
   <outline>
-    <component base="Omicron" xOffset="131"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Omicron" xOffset="121"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="956"/>
+  <advance width="946"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="Omicron" xOffset="131"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Omicron" xOffset="121"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/O_micronvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicronvaria" format="2">
-  <advance width="994"/>
+  <advance width="984"/>
   <unicode hex="1FF8"/>
   <outline>
-    <component base="Omicron" xOffset="169"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Omicron" xOffset="159"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonoxia.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonoxia" format="2">
-  <advance width="776"/>
+  <advance width="766"/>
   <unicode hex="1FEB"/>
   <outline>
-    <component base="Upsilon" xOffset="181"/>
-    <component base="oxia.case" xOffset="-132"/>
+    <component base="Upsilon" xOffset="171"/>
+    <component base="oxia.case" xOffset="-142"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilontonos.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="732"/>
+  <advance width="722"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Upsilon" xOffset="137"/>
-    <component base="tonos.case" xOffset="-132"/>
+    <component base="Upsilon" xOffset="127"/>
+    <component base="tonos.case" xOffset="-142"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/U_psilonvaria.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilonvaria" format="2">
-  <advance width="814"/>
+  <advance width="804"/>
   <unicode hex="1FEA"/>
   <outline>
-    <component base="Upsilon" xOffset="219"/>
-    <component base="varia.case" xOffset="-132"/>
+    <component base="Upsilon" xOffset="209"/>
+    <component base="varia.case" xOffset="-142"/>
   </outline>
 </glyph>


### PR DESCRIPTION
I ran a script over the sources that simply set the GRAD0 width on the -50 and 200 master Polytonic Greek glyphs.

---

### TODO

- [x] Irene review of the auto-updated designs
- [x] remove copied cPython source and squash before we merge this
- [x] document that the new Python script requires Py3.9+