### PR TITLE
Add generation of interpolatable masters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean-ufo:
 # Compile
 # ------------------------------
 
-gs-static gs-vf gs-vf-vendor:
+gs-static gs-vf gs-vf-vendor gs-compatible-masters:
 	cd source && $(MAKE) $@
 
 gs-regular gs-medium gs-bold gs-italic gs-medium-italic gs-bold-italic:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MASTER_UFO_DIR=$(FONT_BUILD_DIR)/master_ufo
 INSTANCE_UFO_DIR=$(FONT_BUILD_DIR)/instance_ufo
 VENV_DIR=.venv
 
-all: gs-static gs-vf
+all: gs-static gs-vf gs-compatible-masters
 
 # ------------------------------
 # Clean

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean-ufo:
 # Compile
 # ------------------------------
 
-gs-static gs-vf gs-vf-vendor gs-compatible-masters:
+gs-static gs-vf gs-vf-vendor gs-compatible-masters gs-compatible-masters-upright gs-compatible-masters-italic:
 	cd source && $(MAKE) $@
 
 gs-regular gs-medium gs-bold gs-italic gs-medium-italic gs-bold-italic:

--- a/source/Makefile
+++ b/source/Makefile
@@ -38,6 +38,7 @@ ITALIC_SOURCE=GoogleSans/GoogleSans-Italic.designspace
 FONT_BUILD_DIR=../build/GoogleSans
 STATIC_BUILD_DIR=$(FONT_BUILD_DIR)/static
 VARIABLE_BUILD_DIR=$(FONT_BUILD_DIR)/variable
+INTERPOLATABLE_BUILD_DIR=$(FONT_BUILD_DIR)/interpolatable
 
 STAGING_DIR=GoogleSans/staging
 
@@ -137,6 +138,14 @@ VARIABLE_BUILD_PATH_ITALIC_TARGET: $(FONT_BUILD_DIR)
 	font-v write --sha1 $(VARIABLE_BUILD_PATH_ITALIC)
 	mv $(VARIABLE_BUILD_PATH_ITALIC) "$(VARIABLE_BUILD_PATH_ITALIC_TARGET)"
 
+gs-compatible-masters: gs-compatible-masters-upright gs-compatible-masters-italic
+
+gs-compatible-masters-upright: $(FONT_BUILD_DIR)
+	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR) --expand-features-to-instances
+
+gs-compatible-masters-italic: $(FONT_BUILD_DIR)
+	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR) --expand-features-to-instances
+
 gs-vf-vendor: gs-vf-vendor-glyphs2designspace
 	$(foreach \
 		file, \
@@ -215,6 +224,7 @@ $(FONT_BUILD_DIR):
 	mkdir -p $(FONT_BUILD_DIR)
 	mkdir -p $(STATIC_BUILD_DIR)
 	mkdir -p $(VARIABLE_BUILD_DIR)
+	mkdir -p $(INTERPOLATABLE_BUILD_DIR)
 
 $(STAGING_DIR):
 	mkdir -p $(STAGING_DIR)
@@ -222,7 +232,8 @@ $(STAGING_DIR):
 .PHONY: gs-static gs-vf \
 gs-regular gs-italic gs-medium gs-medium-italic gs-bold gs-bold-italic \
 gst-regular gst-italic gst-medium gst-medium-italic gst-bold gst-bold-italic \
-gs-vf-upright gs-vf-italic gs-ufo2glyphs
+gs-vf-upright gs-vf-italic gs-ufo2glyphs gs-compatible-masters \
+gs-compatible-masters-upright gs-compatible-masters-italic
 
 # Disable built-in rules to speed up source globbing.
 MAKEFLAGS += --no-builtin-rules

--- a/source/Makefile
+++ b/source/Makefile
@@ -141,10 +141,10 @@ VARIABLE_BUILD_PATH_ITALIC_TARGET: $(FONT_BUILD_DIR)
 gs-compatible-masters: gs-compatible-masters-upright gs-compatible-masters-italic
 
 gs-compatible-masters-upright: $(FONT_BUILD_DIR)
-	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR) --expand-features-to-instances
+	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
 
 gs-compatible-masters-italic: $(FONT_BUILD_DIR)
-	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR) --expand-features-to-instances
+	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
 
 gs-vf-vendor: gs-vf-vendor-glyphs2designspace
 	$(foreach \

--- a/source/Makefile
+++ b/source/Makefile
@@ -141,10 +141,10 @@ VARIABLE_BUILD_PATH_ITALIC_TARGET: $(FONT_BUILD_DIR)
 gs-compatible-masters: gs-compatible-masters-upright gs-compatible-masters-italic
 
 gs-compatible-masters-upright: $(FONT_BUILD_DIR)
-	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
+	$(FONTMAKE_EXE) --no-production-names -m $(UPRIGHT_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
 
 gs-compatible-masters-italic: $(FONT_BUILD_DIR)
-	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
+	$(FONTMAKE_EXE) --no-production-names -m $(ITALIC_SOURCE) -o ttf-interpolatable --output-dir $(INTERPOLATABLE_BUILD_DIR)
 
 gs-vf-vendor: gs-vf-vendor-glyphs2designspace
 	$(foreach \


### PR DESCRIPTION
Add a Makefile target to generate interpolatable masters.

Should it be added to `all:`? 

Closes #471 