### PR TITLE
Use multiple cores when running fontbakery checks locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,17 +98,17 @@ test-fb-static:
 	@echo "========================================================="
 	@echo " fontbakery v`fontbakery --version` static font checks"
 	@echo "========================================================="
-	fontbakery check-profile -C --loglevel WARN qa/check-googlesans.py $(STATIC_BUILD_DIR)/*.ttf
-	fontbakery check-profile -C --loglevel WARN qa/check-fea.py $(STATIC_BUILD_DIR)/*.ttf
-	fontbakery check-profile -C --loglevel WARN qa/check-charset.py $(STATIC_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-googlesans.py $(STATIC_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-fea.py $(STATIC_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-charset.py $(STATIC_BUILD_DIR)/*.ttf
 
 test-fb-vf:
 	@echo "========================================================="
 	@echo " fontbakery v`fontbakery --version` variable font checks"
 	@echo "========================================================="
-	fontbakery check-profile -C --loglevel WARN qa/check-googlesans.py $(VARIABLE_BUILD_DIR)/*.ttf
-	fontbakery check-profile -C --loglevel WARN qa/check-fea.py $(VARIABLE_BUILD_DIR)/*.ttf
-	fontbakery check-profile -C --loglevel WARN qa/check-charset.py $(VARIABLE_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-googlesans.py $(VARIABLE_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-fea.py $(VARIABLE_BUILD_DIR)/*.ttf
+	fontbakery check-profile --auto-jobs -C --loglevel WARN qa/check-charset.py $(VARIABLE_BUILD_DIR)/*.ttf
 
 update-glyphset-defs:
 	python3 scripts/gs-update-glyphset-qa-files.py


### PR DESCRIPTION
This brings the Makefile in line with what we currently do on the CI, and is significantly faster.