### PR TITLE
Automate figma workaround as part of the pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: variable-fonts
-          path: 'build/GoogleSans/variable'
+          path: |
+            build/GoogleSans/variable
+            build/GoogleSans/.intermediate
 
   check-variable:
     needs:
@@ -86,7 +88,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: variable-fonts
-          path: 'build/GoogleSans/variable'
+          path: 'build/GoogleSans'
       - name: Font Bakery GS profile tests
         uses: f-actions/font-bakery@v3
         with:
@@ -135,7 +137,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: variable-fonts
-          path: 'build/GoogleSans/variable'
+          path: 'build/GoogleSans'
       - name: Build static fonts
         run: |
           make setup
@@ -239,7 +241,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: variable-fonts
-          path: 'build/GoogleSans/variable'
+          path: 'build/GoogleSans'
       - uses: actions/download-artifact@v3
         with:
           name: static-fonts
@@ -248,6 +250,8 @@ jobs:
         with:
           name: interpolatable-fonts
           path: 'build/GoogleSans/interpolatable'
+      - name: Delete intermediate VFs
+        run: rm -r build/GoogleSans/.intermediate
       - name: Create build artifact zip archive
         run: zip GoogleSans-${{ steps.vars.outputs.tag }}.zip -r build/GoogleSans
       - name: Create Google Sans release

--- a/qa/check-fea.py
+++ b/qa/check-fea.py
@@ -539,6 +539,7 @@ def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
 
     if not shaping_file_found:
         yield SKIP, "No test files found."
+    yield PASS, "No regressions detected."
 
 
 profile.auto_register(globals())

--- a/scripts/patch-figma-fvar.py
+++ b/scripts/patch-figma-fvar.py
@@ -1,0 +1,73 @@
+# Copyright 2022 Google Sans Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Remove variable font instances that are not in the default position on the
+optical sizing axis.
+
+This is a workaround for Figma: if it identifies such instances, it will not
+enable automatic optical sizing by default.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+from fontTools.ttLib import TTFont  # pyright: ignore
+
+FVAR_TABLE_NAME = "fvar"
+OPTICAL_SIZE_TAG = "opsz"
+
+
+def remove_non_default(ttf: TTFont) -> None:
+    fvar: Any = ttf[FVAR_TABLE_NAME]
+
+    # Get default optical size.
+    for axis in fvar.axes:
+        if axis.axisTag == OPTICAL_SIZE_TAG:
+            default_opsz = axis.defaultValue
+            break
+    else:
+        raise ValueError("Font has no 'opsz' axis")
+
+    # Only keep instances that are at the default optical size.
+    fvar.instances = [
+        instance
+        for instance in fvar.instances
+        if instance.coordinates[OPTICAL_SIZE_TAG] == default_opsz
+    ]
+
+    # Modifications have been performed in-place.
+    return
+
+
+def main():
+    # Parse arguments.
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("ttf", type=Path, help="Path to variable TTF.")
+    parser.add_argument(
+        "-o", "--output", type=Path, help="Path to write patched TTF to."
+    )
+    args = parser.parse_args()
+
+    # Patch provided fonts, and write out.
+    with TTFont(args.ttf) as ttf:
+        remove_non_default(ttf)
+        ttf.save(  # pyright: ignore
+            args.output if args.output is not None else args.ttf
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/source/Makefile
+++ b/source/Makefile
@@ -90,26 +90,30 @@ gs-vf: gs-vf-upright gs-vf-italic
 gs-vf-upright: $(VARIABLE_UPRIGHT_TARGET)
 gs-vf-italic: $(VARIABLE_ITALIC_TARGET)
 
-$(VARIABLE_UPRIGHT_TARGET): $(FONT_BUILD_DIR) $(UPRIGHT_ALL_SOURCES)
-	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o variable --output-path $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gs-subset.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gs-stat.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
-	font-v write --sha1 $(VARIABLE_UPRIGHT_INTERMEDIATE)
+$(VARIABLE_UPRIGHT_INTERMEDIATE): $(FONT_BUILD_DIR) $(UPRIGHT_ALL_SOURCES)
+	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o variable --output-path $@
+	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
+	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $@
+	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $@
+	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $@
+	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $@
+	$(PYTHON3_EXE) ../scripts/gs-stat.py $@
+	font-v write --sha1 $@
+
+$(VARIABLE_UPRIGHT_TARGET): $(VARIABLE_UPRIGHT_INTERMEDIATE)
 	$(PYTHON3_EXE) ../scripts/patch-figma-fvar.py $(VARIABLE_UPRIGHT_INTERMEDIATE) --output $@
 
-$(VARIABLE_ITALIC_TARGET): $(FONT_BUILD_DIR) $(ITALIC_ALL_SOURCES)
-	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o variable --output-path $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gs-subset.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	$(PYTHON3_EXE) ../scripts/gs-stat.py $(VARIABLE_ITALIC_INTERMEDIATE)
-	font-v write --sha1 $(VARIABLE_ITALIC_INTERMEDIATE)
+$(VARIABLE_ITALIC_INTERMEDIATE): $(FONT_BUILD_DIR) $(ITALIC_ALL_SOURCES)
+	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o variable --output-path $@
+	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
+	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $@
+	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $@
+	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $@
+	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $@
+	$(PYTHON3_EXE) ../scripts/gs-stat.py $@
+	font-v write --sha1 $@
+
+$(VARIABLE_ITALIC_TARGET): $(VARIABLE_ITALIC_INTERMEDIATE)
 	$(PYTHON3_EXE) ../scripts/patch-figma-fvar.py $(VARIABLE_ITALIC_INTERMEDIATE) --output $@
 
 
@@ -117,13 +121,13 @@ gs-static: gs-static-upright gs-static-italic
 gs-static-upright: $(STATIC_UPRIGHTS_TARGETS)
 gs-static-italic: $(STATIC_ITALICS_TARGETS)
 
-$(STATIC_UPRIGHTS_TARGETS): $(VARIABLE_UPRIGHT_TARGET)
+$(STATIC_UPRIGHTS_TARGETS): $(VARIABLE_UPRIGHT_INTERMEDIATE)
 	$(PYTHON3_EXE) ../scripts/internal/cut-instances.py $< $(UPRIGHT_SOURCE) $@
 	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
 	$(PYTHON3_EXE) -m fontTools.otlLib.optimize --gpos-compression-level 5 $@
 	font-v write --sha1 $@
 
-$(STATIC_ITALICS_TARGETS): $(VARIABLE_ITALIC_TARGET)
+$(STATIC_ITALICS_TARGETS): $(VARIABLE_ITALIC_INTERMEDIATE)
 	$(PYTHON3_EXE) ../scripts/internal/cut-instances.py $< $(ITALIC_SOURCE) $@
 	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
 	$(PYTHON3_EXE) -m fontTools.otlLib.optimize --gpos-compression-level 5 $@

--- a/source/Makefile
+++ b/source/Makefile
@@ -38,6 +38,7 @@ ITALIC_SOURCE=GoogleSans/GoogleSans-Italic.designspace
 # --------------------------------------------------------
 FONT_BUILD_DIR=../build/GoogleSans
 STATIC_BUILD_DIR=$(FONT_BUILD_DIR)/static
+INTERMEDIATE_VARIABLE_DIR=$(FONT_BUILD_DIR)/.intermediate
 VARIABLE_BUILD_DIR=$(FONT_BUILD_DIR)/variable
 INTERPOLATABLE_BUILD_DIR=$(FONT_BUILD_DIR)/interpolatable
 
@@ -50,6 +51,8 @@ STATIC_ITALICS_TARGETS = $(addprefix $(STATIC_BUILD_DIR)/,GoogleSans-BoldItalic.
 INTERPOLATABLE_UPRIGHTS_TARGET = $(INTERPOLATABLE_BUILD_DIR)/GoogleSans.designspace
 INTERPOLATABLE_ITALICS_TARGET = $(INTERPOLATABLE_BUILD_DIR)/GoogleSans-Italic.designspace
 
+VARIABLE_UPRIGHT_INTERMEDIATE = $(INTERMEDIATE_VARIABLE_DIR)/GoogleSans[GRAD,opsz,wght].ttf
+VARIABLE_ITALIC_INTERMEDIATE = $(INTERMEDIATE_VARIABLE_DIR)/GoogleSans-Italic[GRAD,opsz,wght].ttf
 VARIABLE_UPRIGHT_TARGET = $(VARIABLE_BUILD_DIR)/GoogleSans[GRAD,opsz,wght].ttf
 VARIABLE_ITALIC_TARGET = $(VARIABLE_BUILD_DIR)/GoogleSans-Italic[GRAD,opsz,wght].ttf
 
@@ -88,24 +91,26 @@ gs-vf-upright: $(VARIABLE_UPRIGHT_TARGET)
 gs-vf-italic: $(VARIABLE_ITALIC_TARGET)
 
 $(VARIABLE_UPRIGHT_TARGET): $(FONT_BUILD_DIR) $(UPRIGHT_ALL_SOURCES)
-	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o variable --output-path $@
-	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
-	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $@
-	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $@
-	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $@
-	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $@
-	$(PYTHON3_EXE) ../scripts/gs-stat.py $@
-	font-v write --sha1 $@
+	$(FONTMAKE_EXE) -m $(UPRIGHT_SOURCE) -o variable --output-path $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gs-subset.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gs-stat.py $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	font-v write --sha1 $(VARIABLE_UPRIGHT_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/patch-figma-fvar.py $(VARIABLE_UPRIGHT_INTERMEDIATE) --output $@
 
 $(VARIABLE_ITALIC_TARGET): $(FONT_BUILD_DIR) $(ITALIC_ALL_SOURCES)
-	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o variable --output-path $@
-	$(PYTHON3_EXE) ../scripts/gs-subset.py $@
-	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $@
-	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $@
-	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $@
-	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $@
-	$(PYTHON3_EXE) ../scripts/gs-stat.py $@
-	font-v write --sha1 $@
+	$(FONTMAKE_EXE) -m $(ITALIC_SOURCE) -o variable --output-path $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gs-subset.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/internal/set-overlap-bits.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/set-unicoderange.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gftools-fix-unwanted-tables.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gftools-fix-nonhinting.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/gs-stat.py $(VARIABLE_ITALIC_INTERMEDIATE)
+	font-v write --sha1 $(VARIABLE_ITALIC_INTERMEDIATE)
+	$(PYTHON3_EXE) ../scripts/patch-figma-fvar.py $(VARIABLE_ITALIC_INTERMEDIATE) --output $@
 
 
 gs-static: gs-static-upright gs-static-italic
@@ -204,10 +209,7 @@ gst-bold-italic: $(FONT_BUILD_DIR)
 # Utilities
 #
 $(FONT_BUILD_DIR):
-	mkdir -p $(FONT_BUILD_DIR)
-	mkdir -p $(STATIC_BUILD_DIR)
-	mkdir -p $(VARIABLE_BUILD_DIR)
-	mkdir -p $(INTERPOLATABLE_BUILD_DIR)
+	mkdir -p $(STATIC_BUILD_DIR) $(INTERMEDIATE_VARIABLE_DIR) $(VARIABLE_BUILD_DIR) $(INTERPOLATABLE_BUILD_DIR)
 
 $(STAGING_DIR):
 	mkdir -p $(STAGING_DIR)


### PR DESCRIPTION
## Motivation

Closes #521.

## Progress

1. [X] Implement a script to automate ["fvar" table modification](https://github.com/googlefonts/googlesans/issues/521#issuecomment-1211839192).
2. [ ] Test that the automatically patched TTF functions correctly in Figma, looking out for regressions.
3. [ ] Create a Figma build target using the script.
4. [ ] Build the target in the pipeline.

