### PR TITLE
Add a normalization step for public.glyphOrder

### DIFF
--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple, Union
 
 import ufo2ft
+from ufo2ft.util import makeOfficialGlyphOrder
 import ufoLib2
 from fontTools.designspaceLib import (
     DesignSpaceDocument,
@@ -129,6 +130,8 @@ def scrub_ufo(
     ufo.lib["public.postscriptNames"] = {
         k: v for k, v in ufo.lib["public.postscriptNames"].items() if k in ufo
     }
+    # Expand public.glyphOrder to include any missing glyphs and remove missing ones
+    ufo.lib["public.glyphOrder"] = makeOfficialGlyphOrder(ufo)
 
     # Reset the ufo2ft filters.
     ufo.lib["com.github.googlei18n.ufo2ft.filters"] = [

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>92f11410-26b3-40bc-b4ec-524c52cdeed9</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>15F39A2A-7598-44C5-A4AA-18A6AD645EAA</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>98a9e9ff-ade9-4310-9b10-220681c05269</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>3E1A77A5-2AAF-4B97-842E-5802590C9619</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>c57f2823-92b8-454b-98a9-d13dc6114053</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>BE1166E3-1CAA-4651-A534-350E8BF10E0B</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>4f80e45e-cdf8-4683-baae-29ff950e5666</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>090CB6A0-BE7C-4D17-A551-206C7456A8A3</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,41 +216,9 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
-      <string>G.ss06</string>
       <string>a</string>
       <string>aacute</string>
       <string>abreve</string>
@@ -426,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -452,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -501,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -684,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1835,16 +1727,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -1935,16 +1817,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -1989,7 +1861,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2035,11 +1906,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2065,7 +1931,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2221,25 +2086,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>dieresiscomb</string>
@@ -2277,9 +2131,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2382,21 +2233,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>vavvav-hb</string>
       <string>vavyod-hb</string>
       <string>yodyod-hb</string>
@@ -2573,7 +2416,6 @@
       <string>a-ring.sc</string>
       <string>aring-acute</string>
       <string>asteriskcomb</string>
-      <string>bar-lccy</string>
       <string>dcroat-bar</string>
       <string>descender-cy</string>
       <string>descender1sc-cy</string>
@@ -2584,12 +2426,10 @@
       <string>descenderlc2-cy</string>
       <string>descenderlc2-cy.sc</string>
       <string>descenderlc3-cy</string>
-      <string>descenderrightcase-cy</string>
       <string>dieresis-Ukraine</string>
       <string>dieresisYi-cy</string>
       <string>dieresislc-Ukraine</string>
       <string>dieresissc-Ukraine</string>
-      <string>downturn-cy</string>
       <string>eng-tail</string>
       <string>eth-bar.sc</string>
       <string>flig1</string>
@@ -3461,31 +3301,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3864,8 +3679,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>0e63ca23-ca20-4b77-a701-0e10c93db66a</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>0e63ca23-ca20-4b77-a701-0e10c93db66a</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>7af3fc87-e33c-421c-9e9d-1e330cb62376</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -39,6 +39,7 @@
     <true/>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -213,38 +214,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -423,7 +393,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -449,31 +418,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -498,15 +444,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -681,58 +618,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1005,7 +898,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1920,16 +1812,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2010,16 +1892,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2064,7 +1936,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2109,11 +1980,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2145,7 +2011,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2304,25 +2169,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2361,9 +2215,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2525,21 +2376,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3451,31 +3294,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3854,8 +3672,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>3b7f28c8-0206-4593-ace5-1a4118c52af0</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>3b7f28c8-0206-4593-ace5-1a4118c52af0</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -41,6 +41,7 @@
     <string>a7ad747e-5eb6-4dfc-b2ad-bddd350c27c6</string>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -215,38 +216,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -425,7 +395,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -451,31 +420,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -500,15 +446,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -683,58 +620,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1007,7 +900,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1922,16 +1814,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2012,16 +1894,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2066,7 +1938,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2111,11 +1982,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2147,7 +2013,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2306,25 +2171,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2363,9 +2217,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2527,21 +2378,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3453,31 +3296,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3856,8 +3674,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -39,6 +39,7 @@
     <true/>
     <key>public.glyphOrder</key>
     <array>
+      <string>.notdef</string>
       <string>A</string>
       <string>Aacute</string>
       <string>Abreve</string>
@@ -213,38 +214,7 @@
       <string>Zacute</string>
       <string>Zcaron</string>
       <string>Zdotaccent</string>
-      <string>Ccedilla.alt</string>
-      <string>G.alt</string>
-      <string>Gbreve.alt</string>
-      <string>Gcircumflex.alt</string>
-      <string>Gcommaaccent.alt</string>
-      <string>Gdotaccent.alt</string>
-      <string>I.alt</string>
-      <string>Iacute.alt</string>
-      <string>Ibreve.alt</string>
-      <string>Icircumflex.alt</string>
-      <string>Idieresis.alt</string>
-      <string>Idotaccent.alt</string>
-      <string>Igrave.alt</string>
-      <string>Imacron.alt</string>
-      <string>Iogonek.alt</string>
-      <string>Itilde.alt</string>
-      <string>J.alt</string>
-      <string>Jcircumflex.alt</string>
       <string>K.alt</string>
-      <string>Kcommaaccent.alt</string>
-      <string>M.alt</string>
-      <string>Q.alt</string>
-      <string>R.alt</string>
-      <string>Racute.alt</string>
-      <string>Rcaron.alt</string>
-      <string>Rcommaaccent.alt</string>
-      <string>Scedilla.alt</string>
-      <string>W.alt</string>
-      <string>Wacute.alt</string>
-      <string>Wcircumflex.alt</string>
-      <string>Wdieresis.alt</string>
-      <string>Wgrave.alt</string>
       <string>G.logo</string>
       <string>G.super</string>
       <string>a</string>
@@ -423,7 +393,6 @@
       <string>zacute</string>
       <string>zcaron</string>
       <string>zdotaccent</string>
-      <string>tcedilla.alt.2</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -449,31 +418,8 @@
       <string>atilde.alt</string>
       <string>ae.alt</string>
       <string>aeacute.alt</string>
-      <string>ccedilla.alt</string>
-      <string>j.alt</string>
-      <string>jdotless.alt</string>
-      <string>jcircumflex.alt</string>
       <string>k.alt</string>
-      <string>kcommaaccent.alt</string>
-      <string>q.alt</string>
       <string>r.alt</string>
-      <string>racute.alt</string>
-      <string>rcaron.alt</string>
-      <string>rcommaaccent.alt</string>
-      <string>scedilla.alt</string>
-      <string>t.alt</string>
-      <string>tbar.alt</string>
-      <string>tcaron.alt</string>
-      <string>tcedilla.alt</string>
-      <string>tcommaaccent.alt</string>
-      <string>y.alt</string>
-      <string>yacute.alt</string>
-      <string>ycircumflex.alt</string>
-      <string>ydieresis.alt</string>
-      <string>ydotbelow.alt</string>
-      <string>ygrave.alt</string>
-      <string>yhookabove.alt</string>
-      <string>ytilde.alt</string>
       <string>e.logo</string>
       <string>g.logo</string>
       <string>l.logo</string>
@@ -498,15 +444,6 @@
       <string>r_t</string>
       <string>t_f</string>
       <string>t_t</string>
-      <string>f_f_j.alt</string>
-      <string>f_f_k.alt</string>
-      <string>f_f_t.alt</string>
-      <string>f_j.alt</string>
-      <string>f_k.alt</string>
-      <string>f_t.alt</string>
-      <string>r_t.alt</string>
-      <string>t_f.alt</string>
-      <string>t_t.alt</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
       <string>abreve.sc</string>
@@ -681,58 +618,14 @@
       <string>zacute.sc</string>
       <string>zcaron.sc</string>
       <string>zdotaccent.sc</string>
-      <string>a.sc.lc.ss04</string>
-      <string>b.sc.lc.ss04</string>
-      <string>c.sc.lc.ss04</string>
-      <string>d.sc.lc.ss04</string>
-      <string>e.sc.lc.ss04</string>
-      <string>f.sc.lc.ss04</string>
-      <string>g.sc.lc.ss04</string>
-      <string>h.sc.lc.ss04</string>
-      <string>i.sc.lc.ss04</string>
-      <string>j.sc.lc.ss04</string>
       <string>k.sc.lc.ss04</string>
-      <string>l.sc.lc.ss04</string>
-      <string>m.sc.lc.ss04</string>
-      <string>n.sc.lc.ss04</string>
-      <string>o.sc.lc.ss04</string>
-      <string>p.sc.lc.ss04</string>
-      <string>q.sc.lc.ss04</string>
-      <string>r.sc.lc.ss04</string>
-      <string>s.sc.lc.ss04</string>
-      <string>t.sc.lc.ss04</string>
-      <string>u.sc.lc.ss04</string>
-      <string>v.sc.lc.ss04</string>
-      <string>w.sc.lc.ss04</string>
-      <string>x.sc.lc.ss04</string>
-      <string>y.sc.lc.ss04</string>
-      <string>z.sc.lc.ss04</string>
-      <string>a.sc.ss04</string>
       <string>b.sc.ss04</string>
-      <string>c.sc.ss04</string>
-      <string>d.sc.ss04</string>
       <string>e.sc.ss04</string>
-      <string>f.sc.ss04</string>
       <string>g.sc.ss04</string>
-      <string>h.sc.ss04</string>
-      <string>i.sc.ss04</string>
-      <string>j.sc.ss04</string>
       <string>k.sc.ss04</string>
-      <string>l.sc.ss04</string>
       <string>m.sc.ss04</string>
-      <string>n.sc.ss04</string>
-      <string>o.sc.ss04</string>
       <string>p.sc.ss04</string>
-      <string>q.sc.ss04</string>
-      <string>r.sc.ss04</string>
-      <string>s.sc.ss04</string>
       <string>t.sc.ss04</string>
-      <string>u.sc.ss04</string>
-      <string>v.sc.ss04</string>
-      <string>w.sc.ss04</string>
-      <string>x.sc.ss04</string>
-      <string>y.sc.ss04</string>
-      <string>z.sc.ss04</string>
       <string>ordfeminine</string>
       <string>ordmasculine</string>
       <string>A-cy</string>
@@ -1005,7 +898,6 @@
       <string>ge-cy.loclMKD</string>
       <string>gje-cy.loclMKD</string>
       <string>be-cy.loclSRB</string>
-      <string>ge-cy.loclSRB</string>
       <string>de-cy.loclSRB</string>
       <string>pe-cy.loclSRB</string>
       <string>te-cy.loclSRB</string>
@@ -1920,16 +1812,6 @@
       <string>seven.sansSerifBlackCircled</string>
       <string>eight.sansSerifBlackCircled</string>
       <string>nine.sansSerifBlackCircled</string>
-      <string>zero.alt</string>
-      <string>one.alt</string>
-      <string>six.alt</string>
-      <string>seven.alt</string>
-      <string>nine.alt</string>
-      <string>zero.alt.cap</string>
-      <string>one.alt.cap</string>
-      <string>six.alt.cap</string>
-      <string>seven.alt.cap</string>
-      <string>nine.alt.cap</string>
       <string>zero.cap</string>
       <string>one.cap</string>
       <string>two.cap</string>
@@ -2010,16 +1892,6 @@
       <string>seven.sc</string>
       <string>eight.sc</string>
       <string>nine.sc</string>
-      <string>zero.sc.ss04</string>
-      <string>one.sc.ss04</string>
-      <string>two.sc.ss04</string>
-      <string>three.sc.ss04</string>
-      <string>four.sc.ss04</string>
-      <string>five.sc.ss04</string>
-      <string>six.sc.ss04</string>
-      <string>seven.sc.ss04</string>
-      <string>eight.sc.ss04</string>
-      <string>nine.sc.ss04</string>
       <string>One-roman</string>
       <string>Two-roman</string>
       <string>Three-roman</string>
@@ -2064,7 +1936,6 @@
       <string>backslash</string>
       <string>twoasterisksvertical</string>
       <string>comma.alt</string>
-      <string>semicolon.alt</string>
       <string>exclamdown.cap</string>
       <string>questiondown.cap</string>
       <string>bullet.cap</string>
@@ -2109,11 +1980,6 @@
       <string>guilsinglright</string>
       <string>quotedbl</string>
       <string>quotesingle</string>
-      <string>quotesinglbase.alt</string>
-      <string>quotedblbase.alt</string>
-      <string>quotedblleft.alt</string>
-      <string>quotedblright.alt</string>
-      <string>quoteleft.alt</string>
       <string>quoteright.alt</string>
       <string>guillemetleft.cap</string>
       <string>guillemetright.cap</string>
@@ -2145,7 +2011,6 @@
       <string>zerowidthspace</string>
       <string>space.tf</string>
       <string>CR</string>
-      <string>.notdef</string>
       <string>baht</string>
       <string>cent</string>
       <string>currency</string>
@@ -2304,25 +2169,14 @@
       <string>prescription</string>
       <string>replacementCharacter</string>
       <string>servicemark</string>
-      <string>ampersand.alt</string>
       <string>copyright.alt</string>
       <string>registered.alt</string>
       <string>published.alt</string>
-      <string>trademark.alt</string>
-      <string>servicemark.alt</string>
-      <string>trademark.alt2</string>
-      <string>servicemark.alt2</string>
-      <string>trademark.alt3</string>
-      <string>servicemark.alt3</string>
       <string>at.cap</string>
       <string>degree.cap</string>
       <string>centigrade.cap</string>
       <string>fahrenheit.cap</string>
       <string>section.tf</string>
-      <string>peace</string>
-      <string>whiteFrowningFace</string>
-      <string>whiteSmilingFace</string>
-      <string>apple</string>
       <string>numeral-greek</string>
       <string>lowernumeral-greek</string>
       <string>apostrophemod</string>
@@ -2361,9 +2215,6 @@
       <string>macron</string>
       <string>cedilla</string>
       <string>ogonek</string>
-      <string>cedillacomb.alt</string>
-      <string>caron.alt</string>
-      <string>cedilla.alt</string>
       <string>dieresiscomb.cap</string>
       <string>dotaccentcomb.cap</string>
       <string>gravecomb.cap</string>
@@ -2525,21 +2376,13 @@
       <string>circumflexcomb_tildecomb.sc</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>Glogo</string>
-      <string>ologo</string>
-      <string>glogo</string>
-      <string>llogo</string>
-      <string>elogo</string>
       <string>Gsuper</string>
-      <string>Googlelogo</string>
       <string>uniE007</string>
       <string>brevecombcy.sc</string>
       <string>brevecombcy.cap</string>
       <string>brevecombcy</string>
       <string>NULL</string>
       <string>Google.logo</string>
-      <string>__descender-cy.case</string>
-      <string>__descender-cy</string>
       <string>A-ring</string>
       <string>C-figureht</string>
       <string>DCroat-bar</string>
@@ -3451,31 +3294,6 @@
       <string>lari</string>
       <string>lari.cap</string>
       <string>lari.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflex.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adieresis.alt</string>
-      <string>adotbelow.alt</string>
-      <string>agrave.alt</string>
-      <string>ahookabove.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>koKai-thai</string>
       <string>thoThung-thai</string>
       <string>phoSamphao-thai</string>
@@ -3854,8 +3672,6 @@
       <string>oVowel-lao</string>
       <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
       <string>zero-lao</string>
       <string>one-lao</string>
       <string>two-lao</string>


### PR DESCRIPTION
I spotted while cleaning up the Latin extension branch that the public.glyphOrder had leftover entries that had been since deleted from the fonts. It's not an issue but maybe could be normalized. Also it seems some UFOs are missing slash.loclTAML.

Fixes #590 
Needs #516 first