### PR TITLE
Add Direct Current Symbol Form Two (U+2393)

### DIFF
--- a/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Bold.ttf.glyphsetdef
@@ -7199,3 +7199,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-BoldItalic.ttf.glyphsetdef
@@ -7194,3 +7194,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic.ttf.glyphsetdef
@@ -7194,3 +7194,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Italic[GRAD,opsz,wght].ttf.glyphsetdef
@@ -7271,3 +7271,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Medium.ttf.glyphsetdef
@@ -7198,3 +7198,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-MediumItalic.ttf.glyphsetdef
@@ -7194,3 +7194,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans-Regular.ttf.glyphsetdef
@@ -7198,3 +7198,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Bold.ttf.glyphsetdef
@@ -7198,3 +7198,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-BoldItalic.ttf.glyphsetdef
@@ -7194,3 +7194,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Italic.ttf.glyphsetdef
@@ -7195,3 +7195,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Medium.ttf.glyphsetdef
@@ -7198,3 +7198,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-MediumItalic.ttf.glyphsetdef
@@ -7194,3 +7194,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
+++ b/qa/definitions/GoogleSansText-Regular.ttf.glyphsetdef
@@ -7198,3 +7198,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
+++ b/qa/definitions/GoogleSans[GRAD,opsz,wght].ttf.glyphsetdef
@@ -7275,3 +7275,4 @@ uni201C.loclKNDA
 uni201D.loclKNDA
 uni2018.loclKNDA
 uni2019.loclKNDA
+uni2393

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="72" y="454" type="line"/>
-      <point x="848" y="454" type="line"/>
-      <point x="848" y="504" type="line"/>
-      <point x="72" y="504" type="line"/>
+      <point x="72" y="438" type="line"/>
+      <point x="848" y="438" type="line"/>
+      <point x="848" y="488" type="line"/>
+      <point x="72" y="488" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="244" type="line"/>
-      <point x="268" y="244" type="line"/>
-      <point x="268" y="294" type="line"/>
-      <point x="72" y="294" type="line"/>
+      <point x="72" y="228" type="line"/>
+      <point x="268" y="228" type="line"/>
+      <point x="268" y="278" type="line"/>
+      <point x="72" y="278" type="line"/>
     </contour>
     <contour>
-      <point x="362" y="244" type="line"/>
-      <point x="558" y="244" type="line"/>
-      <point x="558" y="294" type="line"/>
-      <point x="362" y="294" type="line"/>
+      <point x="362" y="228" type="line"/>
+      <point x="558" y="228" type="line"/>
+      <point x="558" y="278" type="line"/>
+      <point x="362" y="278" type="line"/>
     </contour>
     <contour>
-      <point x="652" y="244" type="line"/>
-      <point x="848" y="244" type="line"/>
-      <point x="848" y="294" type="line"/>
-      <point x="652" y="294" type="line"/>
+      <point x="652" y="228" type="line"/>
+      <point x="848" y="228" type="line"/>
+      <point x="848" y="278" type="line"/>
+      <point x="652" y="278" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -2,34 +2,30 @@
 <glyph name="directcurrentformtwo" format="2">
   <advance width="920"/>
   <unicode hex="2393"/>
-  <guideline y="352"/>
-  <guideline y="192"/>
-  <guideline x="72"/>
-  <guideline x="848"/>
   <outline>
     <contour>
-      <point x="72" y="352" type="line"/>
-      <point x="848" y="352" type="line"/>
-      <point x="848" y="402" type="line"/>
-      <point x="72" y="402" type="line"/>
+      <point x="72" y="454" type="line"/>
+      <point x="848" y="454" type="line"/>
+      <point x="848" y="504" type="line"/>
+      <point x="72" y="504" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="142" type="line"/>
-      <point x="287" y="142" type="line"/>
-      <point x="287" y="192" type="line"/>
-      <point x="72" y="192" type="line"/>
+      <point x="72" y="244" type="line"/>
+      <point x="268" y="244" type="line"/>
+      <point x="268" y="294" type="line"/>
+      <point x="72" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="353" y="142" type="line"/>
-      <point x="568" y="142" type="line"/>
-      <point x="568" y="192" type="line"/>
-      <point x="353" y="192" type="line"/>
+      <point x="362" y="244" type="line"/>
+      <point x="558" y="244" type="line"/>
+      <point x="558" y="294" type="line"/>
+      <point x="362" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="633" y="142" type="line"/>
-      <point x="848" y="142" type="line"/>
-      <point x="848" y="192" type="line"/>
-      <point x="633" y="192" type="line"/>
+      <point x="652" y="244" type="line"/>
+      <point x="848" y="244" type="line"/>
+      <point x="848" y="294" type="line"/>
+      <point x="652" y="294" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <guideline y="352"/>
+  <guideline y="192"/>
+  <guideline x="72"/>
+  <guideline x="848"/>
+  <outline>
+    <contour>
+      <point x="72" y="352" type="line"/>
+      <point x="848" y="352" type="line"/>
+      <point x="848" y="402" type="line"/>
+      <point x="72" y="402" type="line"/>
+    </contour>
+    <contour>
+      <point x="72" y="142" type="line"/>
+      <point x="287" y="142" type="line"/>
+      <point x="287" y="192" type="line"/>
+      <point x="72" y="192" type="line"/>
+    </contour>
+    <contour>
+      <point x="353" y="142" type="line"/>
+      <point x="568" y="142" type="line"/>
+      <point x="568" y="192" type="line"/>
+      <point x="353" y="192" type="line"/>
+    </contour>
+    <contour>
+      <point x="633" y="142" type="line"/>
+      <point x="848" y="142" type="line"/>
+      <point x="848" y="192" type="line"/>
+      <point x="633" y="192" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="72" y="445" type="line"/>
-      <point x="848" y="445" type="line"/>
-      <point x="848" y="515" type="line"/>
-      <point x="72" y="515" type="line"/>
+      <point x="72" y="428" type="line"/>
+      <point x="848" y="428" type="line"/>
+      <point x="848" y="498" type="line"/>
+      <point x="72" y="498" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="235" type="line"/>
-      <point x="248" y="235" type="line"/>
-      <point x="248" y="305" type="line"/>
-      <point x="72" y="305" type="line"/>
+      <point x="72" y="218" type="line"/>
+      <point x="248" y="218" type="line"/>
+      <point x="248" y="288" type="line"/>
+      <point x="72" y="288" type="line"/>
     </contour>
     <contour>
-      <point x="372" y="235" type="line"/>
-      <point x="548" y="235" type="line"/>
-      <point x="548" y="305" type="line"/>
-      <point x="372" y="305" type="line"/>
+      <point x="372" y="218" type="line"/>
+      <point x="548" y="218" type="line"/>
+      <point x="548" y="288" type="line"/>
+      <point x="372" y="288" type="line"/>
     </contour>
     <contour>
-      <point x="672" y="235" type="line"/>
-      <point x="848" y="235" type="line"/>
-      <point x="848" y="305" type="line"/>
-      <point x="672" y="305" type="line"/>
+      <point x="672" y="218" type="line"/>
+      <point x="848" y="218" type="line"/>
+      <point x="848" y="288" type="line"/>
+      <point x="672" y="288" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <guideline y="199"/>
+  <guideline y="339"/>
+  <guideline x="72"/>
+  <guideline x="848"/>
+  <outline>
+    <contour>
+      <point x="72" y="339" type="line"/>
+      <point x="848" y="339" type="line"/>
+      <point x="848" y="409" type="line"/>
+      <point x="72" y="409" type="line"/>
+    </contour>
+    <contour>
+      <point x="72" y="129" type="line"/>
+      <point x="274" y="129" type="line"/>
+      <point x="274" y="199" type="line"/>
+      <point x="72" y="199" type="line"/>
+    </contour>
+    <contour>
+      <point x="359" y="129" type="line"/>
+      <point x="561" y="129" type="line"/>
+      <point x="561" y="199" type="line"/>
+      <point x="359" y="199" type="line"/>
+    </contour>
+    <contour>
+      <point x="646" y="129" type="line"/>
+      <point x="848" y="129" type="line"/>
+      <point x="848" y="199" type="line"/>
+      <point x="646" y="199" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -2,34 +2,30 @@
 <glyph name="directcurrentformtwo" format="2">
   <advance width="920"/>
   <unicode hex="2393"/>
-  <guideline y="199"/>
-  <guideline y="339"/>
-  <guideline x="72"/>
-  <guideline x="848"/>
   <outline>
     <contour>
-      <point x="72" y="339" type="line"/>
-      <point x="848" y="339" type="line"/>
-      <point x="848" y="409" type="line"/>
-      <point x="72" y="409" type="line"/>
+      <point x="72" y="445" type="line"/>
+      <point x="848" y="445" type="line"/>
+      <point x="848" y="515" type="line"/>
+      <point x="72" y="515" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="129" type="line"/>
-      <point x="274" y="129" type="line"/>
-      <point x="274" y="199" type="line"/>
-      <point x="72" y="199" type="line"/>
+      <point x="72" y="235" type="line"/>
+      <point x="248" y="235" type="line"/>
+      <point x="248" y="305" type="line"/>
+      <point x="72" y="305" type="line"/>
     </contour>
     <contour>
-      <point x="359" y="129" type="line"/>
-      <point x="561" y="129" type="line"/>
-      <point x="561" y="199" type="line"/>
-      <point x="359" y="199" type="line"/>
+      <point x="372" y="235" type="line"/>
+      <point x="548" y="235" type="line"/>
+      <point x="548" y="305" type="line"/>
+      <point x="372" y="305" type="line"/>
     </contour>
     <contour>
-      <point x="646" y="129" type="line"/>
-      <point x="848" y="129" type="line"/>
-      <point x="848" y="199" type="line"/>
-      <point x="646" y="199" type="line"/>
+      <point x="672" y="235" type="line"/>
+      <point x="848" y="235" type="line"/>
+      <point x="848" y="305" type="line"/>
+      <point x="672" y="305" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="72" y="420" type="line"/>
-      <point x="848" y="420" type="line"/>
-      <point x="848" y="525" type="line"/>
-      <point x="72" y="525" type="line"/>
+      <point x="72" y="403" type="line"/>
+      <point x="848" y="403" type="line"/>
+      <point x="848" y="508" type="line"/>
+      <point x="72" y="508" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="225" type="line"/>
-      <point x="236" y="225" type="line"/>
-      <point x="236" y="330" type="line"/>
-      <point x="72" y="330" type="line"/>
+      <point x="72" y="208" type="line"/>
+      <point x="236" y="208" type="line"/>
+      <point x="236" y="313" type="line"/>
+      <point x="72" y="313" type="line"/>
     </contour>
     <contour>
-      <point x="378" y="225" type="line"/>
-      <point x="542" y="225" type="line"/>
-      <point x="542" y="330" type="line"/>
-      <point x="378" y="330" type="line"/>
+      <point x="378" y="208" type="line"/>
+      <point x="542" y="208" type="line"/>
+      <point x="542" y="313" type="line"/>
+      <point x="378" y="313" type="line"/>
     </contour>
     <contour>
-      <point x="684" y="225" type="line"/>
-      <point x="848" y="225" type="line"/>
-      <point x="848" y="330" type="line"/>
-      <point x="684" y="330" type="line"/>
+      <point x="684" y="208" type="line"/>
+      <point x="848" y="208" type="line"/>
+      <point x="848" y="313" type="line"/>
+      <point x="684" y="313" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <guideline y="309"/>
+  <guideline y="219"/>
+  <guideline x="72"/>
+  <guideline x="848"/>
+  <outline>
+    <contour>
+      <point x="72" y="309" type="line"/>
+      <point x="848" y="309" type="line"/>
+      <point x="848" y="414" type="line"/>
+      <point x="72" y="414" type="line"/>
+    </contour>
+    <contour>
+      <point x="72" y="114" type="line"/>
+      <point x="257" y="114" type="line"/>
+      <point x="257" y="219" type="line"/>
+      <point x="72" y="219" type="line"/>
+    </contour>
+    <contour>
+      <point x="367" y="114" type="line"/>
+      <point x="552" y="114" type="line"/>
+      <point x="552" y="219" type="line"/>
+      <point x="367" y="219" type="line"/>
+    </contour>
+    <contour>
+      <point x="663" y="114" type="line"/>
+      <point x="848" y="114" type="line"/>
+      <point x="848" y="219" type="line"/>
+      <point x="663" y="219" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -2,34 +2,30 @@
 <glyph name="directcurrentformtwo" format="2">
   <advance width="920"/>
   <unicode hex="2393"/>
-  <guideline y="309"/>
-  <guideline y="219"/>
-  <guideline x="72"/>
-  <guideline x="848"/>
   <outline>
     <contour>
-      <point x="72" y="309" type="line"/>
-      <point x="848" y="309" type="line"/>
-      <point x="848" y="414" type="line"/>
-      <point x="72" y="414" type="line"/>
+      <point x="72" y="420" type="line"/>
+      <point x="848" y="420" type="line"/>
+      <point x="848" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="114" type="line"/>
-      <point x="257" y="114" type="line"/>
-      <point x="257" y="219" type="line"/>
-      <point x="72" y="219" type="line"/>
+      <point x="72" y="225" type="line"/>
+      <point x="236" y="225" type="line"/>
+      <point x="236" y="330" type="line"/>
+      <point x="72" y="330" type="line"/>
     </contour>
     <contour>
-      <point x="367" y="114" type="line"/>
-      <point x="552" y="114" type="line"/>
-      <point x="552" y="219" type="line"/>
-      <point x="367" y="219" type="line"/>
+      <point x="378" y="225" type="line"/>
+      <point x="542" y="225" type="line"/>
+      <point x="542" y="330" type="line"/>
+      <point x="378" y="330" type="line"/>
     </contour>
     <contour>
-      <point x="663" y="114" type="line"/>
-      <point x="848" y="114" type="line"/>
-      <point x="848" y="219" type="line"/>
-      <point x="663" y="219" type="line"/>
+      <point x="684" y="225" type="line"/>
+      <point x="848" y="225" type="line"/>
+      <point x="848" y="330" type="line"/>
+      <point x="684" y="330" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="949"/>
+  <unicode hex="2393"/>
+  <guideline y="318"/>
+  <guideline y="218"/>
+  <guideline x="72"/>
+  <guideline x="877"/>
+  <outline>
+    <contour>
+      <point x="72" y="318" type="line"/>
+      <point x="877" y="318" type="line"/>
+      <point x="877" y="434" type="line"/>
+      <point x="72" y="434" type="line"/>
+    </contour>
+    <contour>
+      <point x="72" y="102" type="line"/>
+      <point x="262" y="102" type="line"/>
+      <point x="262" y="218" type="line"/>
+      <point x="72" y="218" type="line"/>
+    </contour>
+    <contour>
+      <point x="380" y="102" type="line"/>
+      <point x="570" y="102" type="line"/>
+      <point x="570" y="218" type="line"/>
+      <point x="380" y="218" type="line"/>
+    </contour>
+    <contour>
+      <point x="688" y="102" type="line"/>
+      <point x="878" y="102" type="line"/>
+      <point x="878" y="218" type="line"/>
+      <point x="688" y="218" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -2,31 +2,30 @@
 <glyph name="directcurrentformtwo" format="2">
   <advance width="949"/>
   <unicode hex="2393"/>
-  <guideline y="193"/>
   <outline>
     <contour>
-      <point x="72" y="409" type="line"/>
-      <point x="877" y="409" type="line"/>
-      <point x="877" y="525" type="line"/>
-      <point x="72" y="525" type="line"/>
+      <point x="72" y="408" type="line"/>
+      <point x="877" y="408" type="line"/>
+      <point x="877" y="524" type="line"/>
+      <point x="72" y="524" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="193" type="line"/>
-      <point x="241" y="193" type="line"/>
-      <point x="241" y="309" type="line"/>
-      <point x="72" y="309" type="line"/>
+      <point x="72" y="192" type="line"/>
+      <point x="241" y="192" type="line"/>
+      <point x="241" y="308" type="line"/>
+      <point x="72" y="308" type="line"/>
     </contour>
     <contour>
-      <point x="390" y="193" type="line"/>
-      <point x="559" y="193" type="line"/>
-      <point x="559" y="309" type="line"/>
-      <point x="390" y="309" type="line"/>
+      <point x="390" y="192" type="line"/>
+      <point x="559" y="192" type="line"/>
+      <point x="559" y="308" type="line"/>
+      <point x="390" y="308" type="line"/>
     </contour>
     <contour>
-      <point x="708" y="193" type="line"/>
-      <point x="877" y="193" type="line"/>
-      <point x="877" y="309" type="line"/>
-      <point x="708" y="309" type="line"/>
+      <point x="708" y="192" type="line"/>
+      <point x="877" y="192" type="line"/>
+      <point x="877" y="308" type="line"/>
+      <point x="708" y="308" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -2,34 +2,31 @@
 <glyph name="directcurrentformtwo" format="2">
   <advance width="949"/>
   <unicode hex="2393"/>
-  <guideline y="318"/>
-  <guideline y="218"/>
-  <guideline x="72"/>
-  <guideline x="877"/>
+  <guideline y="193"/>
   <outline>
     <contour>
-      <point x="72" y="318" type="line"/>
-      <point x="877" y="318" type="line"/>
-      <point x="877" y="434" type="line"/>
-      <point x="72" y="434" type="line"/>
+      <point x="72" y="409" type="line"/>
+      <point x="877" y="409" type="line"/>
+      <point x="877" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
     <contour>
-      <point x="72" y="102" type="line"/>
-      <point x="262" y="102" type="line"/>
-      <point x="262" y="218" type="line"/>
-      <point x="72" y="218" type="line"/>
+      <point x="72" y="193" type="line"/>
+      <point x="241" y="193" type="line"/>
+      <point x="241" y="309" type="line"/>
+      <point x="72" y="309" type="line"/>
     </contour>
     <contour>
-      <point x="380" y="102" type="line"/>
-      <point x="570" y="102" type="line"/>
-      <point x="570" y="218" type="line"/>
-      <point x="380" y="218" type="line"/>
+      <point x="390" y="193" type="line"/>
+      <point x="559" y="193" type="line"/>
+      <point x="559" y="309" type="line"/>
+      <point x="390" y="309" type="line"/>
     </contour>
     <contour>
-      <point x="688" y="102" type="line"/>
-      <point x="878" y="102" type="line"/>
-      <point x="878" y="218" type="line"/>
-      <point x="688" y="218" type="line"/>
+      <point x="708" y="193" type="line"/>
+      <point x="877" y="193" type="line"/>
+      <point x="877" y="309" type="line"/>
+      <point x="708" y="309" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="434" type="line"/>
-      <point x="838" y="434" type="line"/>
-      <point x="838" y="484" type="line"/>
-      <point x="62" y="484" type="line"/>
+      <point x="62" y="428" type="line"/>
+      <point x="838" y="428" type="line"/>
+      <point x="838" y="478" type="line"/>
+      <point x="62" y="478" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="244" type="line"/>
-      <point x="268" y="244" type="line"/>
-      <point x="268" y="294" type="line"/>
-      <point x="62" y="294" type="line"/>
+      <point x="62" y="238" type="line"/>
+      <point x="268" y="238" type="line"/>
+      <point x="268" y="288" type="line"/>
+      <point x="62" y="288" type="line"/>
     </contour>
     <contour>
-      <point x="347" y="244" type="line"/>
-      <point x="553" y="244" type="line"/>
-      <point x="553" y="294" type="line"/>
-      <point x="347" y="294" type="line"/>
+      <point x="347" y="238" type="line"/>
+      <point x="553" y="238" type="line"/>
+      <point x="553" y="288" type="line"/>
+      <point x="347" y="288" type="line"/>
     </contour>
     <contour>
-      <point x="632" y="244" type="line"/>
-      <point x="838" y="244" type="line"/>
-      <point x="838" y="294" type="line"/>
-      <point x="632" y="294" type="line"/>
+      <point x="632" y="238" type="line"/>
+      <point x="838" y="238" type="line"/>
+      <point x="838" y="288" type="line"/>
+      <point x="632" y="288" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="342" type="line"/>
-      <point x="838" y="342" type="line"/>
-      <point x="838" y="392" type="line"/>
-      <point x="62" y="392" type="line"/>
+      <point x="62" y="434" type="line"/>
+      <point x="838" y="434" type="line"/>
+      <point x="838" y="484" type="line"/>
+      <point x="62" y="484" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="152" type="line"/>
-      <point x="278" y="152" type="line"/>
-      <point x="278" y="202" type="line"/>
-      <point x="62" y="202" type="line"/>
+      <point x="62" y="244" type="line"/>
+      <point x="268" y="244" type="line"/>
+      <point x="268" y="294" type="line"/>
+      <point x="62" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="341" y="152" type="line"/>
-      <point x="557" y="152" type="line"/>
-      <point x="557" y="202" type="line"/>
-      <point x="341" y="202" type="line"/>
+      <point x="347" y="244" type="line"/>
+      <point x="553" y="244" type="line"/>
+      <point x="553" y="294" type="line"/>
+      <point x="347" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="622" y="152" type="line"/>
-      <point x="838" y="152" type="line"/>
-      <point x="838" y="202" type="line"/>
-      <point x="622" y="202" type="line"/>
+      <point x="632" y="244" type="line"/>
+      <point x="838" y="244" type="line"/>
+      <point x="838" y="294" type="line"/>
+      <point x="632" y="294" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="62" y="342" type="line"/>
+      <point x="838" y="342" type="line"/>
+      <point x="838" y="392" type="line"/>
+      <point x="62" y="392" type="line"/>
+    </contour>
+    <contour>
+      <point x="62" y="152" type="line"/>
+      <point x="278" y="152" type="line"/>
+      <point x="278" y="202" type="line"/>
+      <point x="62" y="202" type="line"/>
+    </contour>
+    <contour>
+      <point x="341" y="152" type="line"/>
+      <point x="557" y="152" type="line"/>
+      <point x="557" y="202" type="line"/>
+      <point x="341" y="202" type="line"/>
+    </contour>
+    <contour>
+      <point x="622" y="152" type="line"/>
+      <point x="838" y="152" type="line"/>
+      <point x="838" y="202" type="line"/>
+      <point x="622" y="202" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="329" type="line"/>
-      <point x="838" y="329" type="line"/>
-      <point x="838" y="399" type="line"/>
-      <point x="62" y="399" type="line"/>
+      <point x="62" y="425" type="line"/>
+      <point x="838" y="425" type="line"/>
+      <point x="838" y="495" type="line"/>
+      <point x="62" y="495" type="line"/>
     </contour>
     <contour>
-      <point x="61" y="139" type="line"/>
-      <point x="257" y="139" type="line"/>
-      <point x="257" y="209" type="line"/>
-      <point x="61" y="209" type="line"/>
+      <point x="62" y="235" type="line"/>
+      <point x="248" y="235" type="line"/>
+      <point x="248" y="305" type="line"/>
+      <point x="62" y="305" type="line"/>
     </contour>
     <contour>
-      <point x="351" y="139" type="line"/>
-      <point x="547" y="139" type="line"/>
-      <point x="547" y="209" type="line"/>
-      <point x="351" y="209" type="line"/>
+      <point x="357" y="235" type="line"/>
+      <point x="543" y="235" type="line"/>
+      <point x="543" y="305" type="line"/>
+      <point x="357" y="305" type="line"/>
     </contour>
     <contour>
-      <point x="641" y="139" type="line"/>
-      <point x="837" y="139" type="line"/>
-      <point x="837" y="209" type="line"/>
-      <point x="641" y="209" type="line"/>
+      <point x="652" y="235" type="line"/>
+      <point x="838" y="235" type="line"/>
+      <point x="838" y="305" type="line"/>
+      <point x="652" y="305" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="62" y="329" type="line"/>
+      <point x="838" y="329" type="line"/>
+      <point x="838" y="399" type="line"/>
+      <point x="62" y="399" type="line"/>
+    </contour>
+    <contour>
+      <point x="61" y="139" type="line"/>
+      <point x="257" y="139" type="line"/>
+      <point x="257" y="209" type="line"/>
+      <point x="61" y="209" type="line"/>
+    </contour>
+    <contour>
+      <point x="351" y="139" type="line"/>
+      <point x="547" y="139" type="line"/>
+      <point x="547" y="209" type="line"/>
+      <point x="351" y="209" type="line"/>
+    </contour>
+    <contour>
+      <point x="641" y="139" type="line"/>
+      <point x="837" y="139" type="line"/>
+      <point x="837" y="209" type="line"/>
+      <point x="641" y="209" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="425" type="line"/>
-      <point x="838" y="425" type="line"/>
-      <point x="838" y="495" type="line"/>
-      <point x="62" y="495" type="line"/>
+      <point x="62" y="418" type="line"/>
+      <point x="838" y="418" type="line"/>
+      <point x="838" y="488" type="line"/>
+      <point x="62" y="488" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="235" type="line"/>
-      <point x="248" y="235" type="line"/>
-      <point x="248" y="305" type="line"/>
-      <point x="62" y="305" type="line"/>
+      <point x="62" y="228" type="line"/>
+      <point x="248" y="228" type="line"/>
+      <point x="248" y="298" type="line"/>
+      <point x="62" y="298" type="line"/>
     </contour>
     <contour>
-      <point x="357" y="235" type="line"/>
-      <point x="543" y="235" type="line"/>
-      <point x="543" y="305" type="line"/>
-      <point x="357" y="305" type="line"/>
+      <point x="357" y="228" type="line"/>
+      <point x="543" y="228" type="line"/>
+      <point x="543" y="298" type="line"/>
+      <point x="357" y="298" type="line"/>
     </contour>
     <contour>
-      <point x="652" y="235" type="line"/>
-      <point x="838" y="235" type="line"/>
-      <point x="838" y="305" type="line"/>
-      <point x="652" y="305" type="line"/>
+      <point x="652" y="228" type="line"/>
+      <point x="838" y="228" type="line"/>
+      <point x="838" y="298" type="line"/>
+      <point x="652" y="298" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="299" type="line"/>
-      <point x="838" y="299" type="line"/>
-      <point x="838" y="404" type="line"/>
-      <point x="62" y="404" type="line"/>
+      <point x="62" y="400" type="line"/>
+      <point x="838" y="400" type="line"/>
+      <point x="838" y="505" type="line"/>
+      <point x="62" y="505" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="124" type="line"/>
-      <point x="246" y="124" type="line"/>
-      <point x="246" y="229" type="line"/>
-      <point x="62" y="229" type="line"/>
+      <point x="62" y="225" type="line"/>
+      <point x="236" y="225" type="line"/>
+      <point x="236" y="330" type="line"/>
+      <point x="62" y="330" type="line"/>
     </contour>
     <contour>
-      <point x="357" y="124" type="line"/>
-      <point x="543" y="124" type="line"/>
-      <point x="543" y="229" type="line"/>
-      <point x="357" y="229" type="line"/>
+      <point x="363" y="225" type="line"/>
+      <point x="537" y="225" type="line"/>
+      <point x="537" y="330" type="line"/>
+      <point x="363" y="330" type="line"/>
     </contour>
     <contour>
-      <point x="654" y="124" type="line"/>
-      <point x="838" y="124" type="line"/>
-      <point x="838" y="229" type="line"/>
-      <point x="654" y="229" type="line"/>
+      <point x="664" y="225" type="line"/>
+      <point x="838" y="225" type="line"/>
+      <point x="838" y="330" type="line"/>
+      <point x="664" y="330" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="62" y="299" type="line"/>
+      <point x="838" y="299" type="line"/>
+      <point x="838" y="404" type="line"/>
+      <point x="62" y="404" type="line"/>
+    </contour>
+    <contour>
+      <point x="62" y="124" type="line"/>
+      <point x="246" y="124" type="line"/>
+      <point x="246" y="229" type="line"/>
+      <point x="62" y="229" type="line"/>
+    </contour>
+    <contour>
+      <point x="357" y="124" type="line"/>
+      <point x="543" y="124" type="line"/>
+      <point x="543" y="229" type="line"/>
+      <point x="357" y="229" type="line"/>
+    </contour>
+    <contour>
+      <point x="654" y="124" type="line"/>
+      <point x="838" y="124" type="line"/>
+      <point x="838" y="229" type="line"/>
+      <point x="654" y="229" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="400" type="line"/>
-      <point x="838" y="400" type="line"/>
-      <point x="838" y="505" type="line"/>
-      <point x="62" y="505" type="line"/>
+      <point x="62" y="393" type="line"/>
+      <point x="838" y="393" type="line"/>
+      <point x="838" y="498" type="line"/>
+      <point x="62" y="498" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="225" type="line"/>
-      <point x="236" y="225" type="line"/>
-      <point x="236" y="330" type="line"/>
-      <point x="62" y="330" type="line"/>
+      <point x="62" y="218" type="line"/>
+      <point x="236" y="218" type="line"/>
+      <point x="236" y="323" type="line"/>
+      <point x="62" y="323" type="line"/>
     </contour>
     <contour>
-      <point x="363" y="225" type="line"/>
-      <point x="537" y="225" type="line"/>
-      <point x="537" y="330" type="line"/>
-      <point x="363" y="330" type="line"/>
+      <point x="363" y="218" type="line"/>
+      <point x="537" y="218" type="line"/>
+      <point x="537" y="323" type="line"/>
+      <point x="363" y="323" type="line"/>
     </contour>
     <contour>
-      <point x="664" y="225" type="line"/>
-      <point x="838" y="225" type="line"/>
-      <point x="838" y="330" type="line"/>
-      <point x="664" y="330" type="line"/>
+      <point x="664" y="218" type="line"/>
+      <point x="838" y="218" type="line"/>
+      <point x="838" y="323" type="line"/>
+      <point x="664" y="323" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -3812,6 +3812,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="62" y="393" type="line"/>
-      <point x="869" y="393" type="line"/>
-      <point x="869" y="509" type="line"/>
-      <point x="62" y="509" type="line"/>
+      <point x="62" y="400" type="line"/>
+      <point x="869" y="400" type="line"/>
+      <point x="869" y="516" type="line"/>
+      <point x="62" y="516" type="line"/>
     </contour>
     <contour>
-      <point x="62" y="193" type="line"/>
-      <point x="241" y="193" type="line"/>
-      <point x="241" y="309" type="line"/>
-      <point x="62" y="309" type="line"/>
+      <point x="62" y="200" type="line"/>
+      <point x="241" y="200" type="line"/>
+      <point x="241" y="316" type="line"/>
+      <point x="62" y="316" type="line"/>
     </contour>
     <contour>
-      <point x="376" y="193" type="line"/>
-      <point x="555" y="193" type="line"/>
-      <point x="555" y="309" type="line"/>
-      <point x="376" y="309" type="line"/>
+      <point x="376" y="200" type="line"/>
+      <point x="555" y="200" type="line"/>
+      <point x="555" y="316" type="line"/>
+      <point x="376" y="316" type="line"/>
     </contour>
     <contour>
-      <point x="690" y="193" type="line"/>
-      <point x="869" y="193" type="line"/>
-      <point x="869" y="309" type="line"/>
-      <point x="690" y="309" type="line"/>
+      <point x="690" y="200" type="line"/>
+      <point x="869" y="200" type="line"/>
+      <point x="869" y="316" type="line"/>
+      <point x="690" y="316" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="931"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="63" y="311" type="line"/>
+      <point x="868" y="311" type="line"/>
+      <point x="868" y="427" type="line"/>
+      <point x="63" y="427" type="line"/>
+    </contour>
+    <contour>
+      <point x="63" y="111" type="line"/>
+      <point x="253" y="111" type="line"/>
+      <point x="253" y="227" type="line"/>
+      <point x="63" y="227" type="line"/>
+    </contour>
+    <contour>
+      <point x="370" y="111" type="line"/>
+      <point x="560" y="111" type="line"/>
+      <point x="560" y="227" type="line"/>
+      <point x="370" y="227" type="line"/>
+    </contour>
+    <contour>
+      <point x="678" y="111" type="line"/>
+      <point x="868" y="111" type="line"/>
+      <point x="868" y="227" type="line"/>
+      <point x="678" y="227" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -4,28 +4,28 @@
   <unicode hex="2393"/>
   <outline>
     <contour>
-      <point x="63" y="311" type="line"/>
-      <point x="868" y="311" type="line"/>
-      <point x="868" y="427" type="line"/>
-      <point x="63" y="427" type="line"/>
+      <point x="62" y="393" type="line"/>
+      <point x="869" y="393" type="line"/>
+      <point x="869" y="509" type="line"/>
+      <point x="62" y="509" type="line"/>
     </contour>
     <contour>
-      <point x="63" y="111" type="line"/>
-      <point x="253" y="111" type="line"/>
-      <point x="253" y="227" type="line"/>
-      <point x="63" y="227" type="line"/>
+      <point x="62" y="193" type="line"/>
+      <point x="241" y="193" type="line"/>
+      <point x="241" y="309" type="line"/>
+      <point x="62" y="309" type="line"/>
     </contour>
     <contour>
-      <point x="370" y="111" type="line"/>
-      <point x="560" y="111" type="line"/>
-      <point x="560" y="227" type="line"/>
-      <point x="370" y="227" type="line"/>
+      <point x="376" y="193" type="line"/>
+      <point x="555" y="193" type="line"/>
+      <point x="555" y="309" type="line"/>
+      <point x="376" y="309" type="line"/>
     </contour>
     <contour>
-      <point x="678" y="111" type="line"/>
-      <point x="868" y="111" type="line"/>
-      <point x="868" y="227" type="line"/>
-      <point x="678" y="227" type="line"/>
+      <point x="690" y="193" type="line"/>
+      <point x="869" y="193" type="line"/>
+      <point x="869" y="309" type="line"/>
+      <point x="690" y="309" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -7574,6 +7574,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20442,6 +20443,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="88" y="438" type="line"/>
+      <point x="864" y="438" type="line"/>
+      <point x="864" y="488" type="line"/>
+      <point x="88" y="488" type="line"/>
+    </contour>
+    <contour>
+      <point x="88" y="228" type="line"/>
+      <point x="284" y="228" type="line"/>
+      <point x="284" y="278" type="line"/>
+      <point x="88" y="278" type="line"/>
+    </contour>
+    <contour>
+      <point x="378" y="228" type="line"/>
+      <point x="574" y="228" type="line"/>
+      <point x="574" y="278" type="line"/>
+      <point x="378" y="278" type="line"/>
+    </contour>
+    <contour>
+      <point x="668" y="228" type="line"/>
+      <point x="864" y="228" type="line"/>
+      <point x="864" y="278" type="line"/>
+      <point x="668" y="278" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="88" y="428" type="line"/>
+      <point x="864" y="428" type="line"/>
+      <point x="864" y="498" type="line"/>
+      <point x="88" y="498" type="line"/>
+    </contour>
+    <contour>
+      <point x="88" y="218" type="line"/>
+      <point x="264" y="218" type="line"/>
+      <point x="264" y="288" type="line"/>
+      <point x="88" y="288" type="line"/>
+    </contour>
+    <contour>
+      <point x="388" y="218" type="line"/>
+      <point x="564" y="218" type="line"/>
+      <point x="564" y="288" type="line"/>
+      <point x="388" y="288" type="line"/>
+    </contour>
+    <contour>
+      <point x="688" y="218" type="line"/>
+      <point x="864" y="218" type="line"/>
+      <point x="864" y="288" type="line"/>
+      <point x="688" y="288" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="920"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="89" y="403" type="line"/>
+      <point x="865" y="403" type="line"/>
+      <point x="865" y="508" type="line"/>
+      <point x="89" y="508" type="line"/>
+    </contour>
+    <contour>
+      <point x="89" y="208" type="line"/>
+      <point x="253" y="208" type="line"/>
+      <point x="253" y="313" type="line"/>
+      <point x="89" y="313" type="line"/>
+    </contour>
+    <contour>
+      <point x="395" y="208" type="line"/>
+      <point x="559" y="208" type="line"/>
+      <point x="559" y="313" type="line"/>
+      <point x="395" y="313" type="line"/>
+    </contour>
+    <contour>
+      <point x="701" y="208" type="line"/>
+      <point x="865" y="208" type="line"/>
+      <point x="865" y="313" type="line"/>
+      <point x="701" y="313" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="949"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="89" y="408" type="line"/>
+      <point x="894" y="408" type="line"/>
+      <point x="894" y="524" type="line"/>
+      <point x="89" y="524" type="line"/>
+    </contour>
+    <contour>
+      <point x="89" y="192" type="line"/>
+      <point x="258" y="192" type="line"/>
+      <point x="258" y="308" type="line"/>
+      <point x="89" y="308" type="line"/>
+    </contour>
+    <contour>
+      <point x="407" y="192" type="line"/>
+      <point x="576" y="192" type="line"/>
+      <point x="576" y="308" type="line"/>
+      <point x="407" y="308" type="line"/>
+    </contour>
+    <contour>
+      <point x="725" y="192" type="line"/>
+      <point x="894" y="192" type="line"/>
+      <point x="894" y="308" type="line"/>
+      <point x="725" y="308" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/lib.plist
@@ -7564,6 +7564,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20438,6 +20439,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="80" y="428" type="line"/>
+      <point x="856" y="428" type="line"/>
+      <point x="856" y="478" type="line"/>
+      <point x="80" y="478" type="line"/>
+    </contour>
+    <contour>
+      <point x="80" y="238" type="line"/>
+      <point x="286" y="238" type="line"/>
+      <point x="286" y="288" type="line"/>
+      <point x="80" y="288" type="line"/>
+    </contour>
+    <contour>
+      <point x="365" y="238" type="line"/>
+      <point x="571" y="238" type="line"/>
+      <point x="571" y="288" type="line"/>
+      <point x="365" y="288" type="line"/>
+    </contour>
+    <contour>
+      <point x="650" y="238" type="line"/>
+      <point x="856" y="238" type="line"/>
+      <point x="856" y="288" type="line"/>
+      <point x="650" y="288" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="80" y="418" type="line"/>
+      <point x="856" y="418" type="line"/>
+      <point x="856" y="488" type="line"/>
+      <point x="80" y="488" type="line"/>
+    </contour>
+    <contour>
+      <point x="80" y="228" type="line"/>
+      <point x="266" y="228" type="line"/>
+      <point x="266" y="298" type="line"/>
+      <point x="80" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="375" y="228" type="line"/>
+      <point x="561" y="228" type="line"/>
+      <point x="561" y="298" type="line"/>
+      <point x="375" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="670" y="228" type="line"/>
+      <point x="856" y="228" type="line"/>
+      <point x="856" y="298" type="line"/>
+      <point x="670" y="298" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="900"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="80" y="393" type="line"/>
+      <point x="856" y="393" type="line"/>
+      <point x="856" y="498" type="line"/>
+      <point x="80" y="498" type="line"/>
+    </contour>
+    <contour>
+      <point x="80" y="218" type="line"/>
+      <point x="254" y="218" type="line"/>
+      <point x="254" y="323" type="line"/>
+      <point x="80" y="323" type="line"/>
+    </contour>
+    <contour>
+      <point x="381" y="218" type="line"/>
+      <point x="555" y="218" type="line"/>
+      <point x="555" y="323" type="line"/>
+      <point x="381" y="323" type="line"/>
+    </contour>
+    <contour>
+      <point x="682" y="218" type="line"/>
+      <point x="856" y="218" type="line"/>
+      <point x="856" y="323" type="line"/>
+      <point x="682" y="323" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/lib.plist
@@ -7566,6 +7566,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20440,6 +20441,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/contents.plist
@@ -3810,6 +3810,8 @@
     <string>dii-sinhala.glif</string>
     <key>dii-telugu</key>
     <string>dii-telugu.glif</string>
+    <key>directcurrentformtwo</key>
+    <string>directcurrentformtwo.glif</string>
     <key>divide</key>
     <string>divide.glif</string>
     <key>divide.tf</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/directcurrentformtwo.glif
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="directcurrentformtwo" format="2">
+  <advance width="931"/>
+  <unicode hex="2393"/>
+  <outline>
+    <contour>
+      <point x="80" y="400" type="line"/>
+      <point x="887" y="400" type="line"/>
+      <point x="887" y="516" type="line"/>
+      <point x="80" y="516" type="line"/>
+    </contour>
+    <contour>
+      <point x="80" y="200" type="line"/>
+      <point x="259" y="200" type="line"/>
+      <point x="259" y="316" type="line"/>
+      <point x="80" y="316" type="line"/>
+    </contour>
+    <contour>
+      <point x="394" y="200" type="line"/>
+      <point x="573" y="200" type="line"/>
+      <point x="573" y="316" type="line"/>
+      <point x="394" y="316" type="line"/>
+    </contour>
+    <contour>
+      <point x="708" y="200" type="line"/>
+      <point x="887" y="200" type="line"/>
+      <point x="887" y="316" type="line"/>
+      <point x="708" y="316" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/lib.plist
@@ -7564,6 +7564,7 @@
       <string>quotedblright.loclKNDA</string>
       <string>quoteleft.loclKNDA</string>
       <string>quoteright.loclKNDA</string>
+      <string>directcurrentformtwo</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -20438,6 +20439,8 @@
       <string>uni0DAF0DD3</string>
       <key>dii-telugu</key>
       <string>diitelugu</string>
+      <key>directcurrentformtwo</key>
+      <string>uni2393</string>
       <key>divisionslash</key>
       <string>uni2215</string>
       <key>dje-cy</key>


### PR DESCRIPTION
Design work is taking place on a smaller internal repository, but we will import into this branch when we need to produce TTFs with the original build workflow, and to do the final import when the process is complete.

---

After design work is complete:

- [x] Add glyph to `public.glyphOrder`
- [x] Add glyph to `public.postscriptNames`
- [x] Add glyph to italics
- [x] Update glyphsetdef

Closes #535.