### PR TITLE
Bump actions from the deprecated Node 12 to Node 16

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,28 +88,28 @@ jobs:
           name: variable-fonts
           path: 'build/GoogleSans/variable'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-fea.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: OpenType Sanitizer checks
-        uses: f-actions/opentype-sanitizer@v1
+        uses: f-actions/opentype-sanitizer@v2
         with:
           path: 'build/GoogleSans/variable/*.ttf'
       - name: File size analysis
@@ -162,28 +162,28 @@ jobs:
           name: static-fonts
           path: 'build/GoogleSans/static'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@v1
+        uses: f-actions/font-bakery@v2
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-fea.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: OpenType Sanitizer checks
-        uses: f-actions/opentype-sanitizer@v1
+        uses: f-actions/opentype-sanitizer@v2
         with:
           path: 'build/GoogleSans/static/*.ttf'
       - name: File size analysis


### PR DESCRIPTION
This PR bumps two actions to their next major version, to partially address #558. Between the old and new versions, neither action makes any behavioural changes (within the scope of our usage) aside from addressing the deprecation of Node 12:
- [f-actions/opentype-sanitizer](https://github.com/f-actions/opentype-sanitizer/blob/master/CHANGELOG.md#v200)
- [f-actions/fontbakery](https://github.com/f-actions/font-bakery/blob/master/CHANGELOG.md#v200)

Next, we can compare the QA CI output before and after the change to reassure ourselves of the versions' equivalence, otherwise we can proceed directly with review and merging if we are confident that the bumps have no other effect 🚀