### PR TITLE
Pin CI Python to 3.10

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Lint UFO sources
         run: |
@@ -42,10 +42,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Lint scripts
         run: |
@@ -57,10 +57,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Build variable fonts
         run: |
@@ -78,10 +78,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/download-artifact@v3
         with:
@@ -127,10 +127,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/download-artifact@v3
         with:
@@ -152,10 +152,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/download-artifact@v3
         with:
@@ -199,10 +199,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Build interpolatable fonts
         run: |
@@ -227,10 +227,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Set env variables
         id: vars

--- a/.github/workflows/diffenate.yml
+++ b/.github/workflows/diffenate.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - name: Build variable fonts
         run: |
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/download-artifact@v3
         with:
@@ -63,10 +63,10 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.x environment
+      - name: Set up Python v3.10 environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This unbreaks CI.

Before, we were requesting Python "3.x", which is a moving target, and we would need to update dependencies to make it work properly. Therefore, do the easy thing and request 3.10 instead, until we are ready.