### PR TITLE
diffenate: add android testing strings

### DIFF
--- a/.github/workflows/diffenate.yml
+++ b/.github/workflows/diffenate.yml
@@ -83,3 +83,4 @@ jobs:
           run-diffenator: true
           run-diffbrowsers: false
           filter-styles: "Regular|Italic|Bold|Bold Italic|Text Regular|Text Italic|Text Bold|Text Bold Italic"
+          user-wordlist: 'qa/diffenator2_input/test_strings.txt'


### PR DESCRIPTION
This PR will test the Android strings in diffenator2. I got the strings by following: https://github.com/googlefonts/googlesans/tree/add-kerning-strategy-measurement-framework/scripts/measure_kerning_optimizations#extract-aosp-app-strings. This has been requested by @chrissimpkins and @MariannaPaszkowska in a meeting we had earlier today.

Happy to upload my script to transform aosp.json into the supplied text file if people want it.

