### PR TITLE
Some Bangla feature fixes

### DIFF
--- a/source/GoogleSans/bangla.fea
+++ b/source/GoogleSans/bangla.fea
@@ -876,14 +876,20 @@ feature pres {
         sub @BNG_eMatra' s-beng.half3 pha-beng.half1 ra-beng.blwf23.short by @BNG_eMatra_short2;
     } BNG_dflt_pres_eMatra;
 
+} pres;
+
+# This has been moved from the bottom of the above `pres` feature into a
+# standalone `dist` feature to work around a regression in HarfBuzz from v4.2.0
+# that was fixed in v7.2.0.
+feature dist {
+    script bng2;
     ## TESTING CONTEXTUAL SPACING ##
     lookup BNG_dflt_pres_contextualSpacingB {
         pos [g-beng.half2 p-beng.half2]' lookup BNG_dflt_pres_contextualSpacingA ra-beng.blwf23;
         pos nn-beng.half1' lookup BNG_dflt_pres_contextualSpacingA ra-beng.blwf0;
     } BNG_dflt_pres_contextualSpacingB;
-
     ## END TESTING CONTEXTUAL SPACING ##
-} pres;
+} dist;
 
 feature abvs {
     script bng2;

--- a/source/GoogleSans/bangla.fea
+++ b/source/GoogleSans/bangla.fea
@@ -104,7 +104,7 @@ feature half {
     ### !!! --- On-The-Fly Conjuncts --- !!! ###
     ### !!!------------------------------!!! ###
     lookup BNG_dflt_half_modularCjct_1stConsonant_triconsonant {
-        ignore sub @BNG_allBase halant-beng @BNG_allBase halant-beng @BNG_allBase halant-beng;
+        ignore sub @BNG_allBase' halant-beng' @BNG_allBase' halant-beng' @BNG_allBase' halant-beng';
         sub ga-beng' halant-beng' da-beng halant-beng [ra-beng ramiddlediagonal-beng] by g-beng.half2;
         sub nga-beng' halant-beng' gha-beng halant-beng [ba-beng ra-beng ramiddlediagonal-beng] by ng-beng.half1;
         sub nga-beng' halant-beng' k_ssa-beng halant-beng [ra-beng ramiddlediagonal-beng] by ng-beng.half1;
@@ -128,7 +128,7 @@ feature half {
     } BNG_dflt_half_modularCjct_1stConsonant_triconsonant;
 
     lookup BNG_dflt_half_modularCjct_1stConsonant_biconsonant {
-        ignore sub @BNG_allBase halant-beng @BNG_allBase halant-beng;
+        ignore sub @BNG_allBase' halant-beng' @BNG_allBase' halant-beng';
         # linear
         sub ga-beng' halant-beng' [da-beng ma-beng] by g-beng.half2;
         sub nga-beng' halant-beng' [gha-beng k_ssa-beng] by ng-beng.half1;


### PR DESCRIPTION
* Fix bad ignore sub in Bengali feature file by adding explicit marks
* Work around a regression in HarfBuzz between v4.2.0 and v7.2.0 by placing a Bangla contextual spacing lookup in a different feature.

Closes https://github.com/googlefonts/googlesans/issues/569