### PR TITLE
Test latest f-actions/fontbakery changes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,21 +88,21 @@ jobs:
           name: variable-fonts
           path: 'build/GoogleSans/variable'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'
@@ -162,21 +162,21 @@ jobs:
           name: static-fonts
           path: 'build/GoogleSans/static'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@c20d1b321090ba36183cfda9841acd6b09dabba7
         with:
           version: 'latest'
           subcmd: 'check-profile'


### PR DESCRIPTION
No intent to merge.

This is a test of the [latest changes in the f-actions/font-bakery GHA](https://github.com/f-actions/font-bakery/pull/211) that we use in our CI tests.  If this succeeds, I'll release v3.0.0 of the Action and we'll update to the `v3` branch in these definitions.

