### PR TITLE
Update f-actions/font-bakery Action to v3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,21 +88,21 @@ jobs:
           name: variable-fonts
           path: 'build/GoogleSans/variable'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/variable/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'
@@ -162,21 +162,21 @@ jobs:
           name: static-fonts
           path: 'build/GoogleSans/static'
       - name: Font Bakery GS profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-googlesans.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery character set profile tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'
           args: '--auto-jobs -C --loglevel WARN qa/check-charset.py'
           path: 'build/GoogleSans/static/*.ttf'
       - name: Font Bakery feature tag and shaping tests
-        uses: f-actions/font-bakery@71309f8cfd40e005d104693d531dbb3684a5537d
+        uses: f-actions/font-bakery@v3
         with:
           version: 'latest'
           subcmd: 'check-profile'


### PR DESCRIPTION
This PR updates our GHA CI/CD testing worklow to use the latest font-bakery Action changes to support the [all] extras dependencies installation prior to execution of our fontbakery tests. https://github.com/f-actions/font-bakery/pull/211 

We remove the development git commit SHA pinned f-actions/fontbakery Action version and move to the `v3` release branch with the edits here.