### PR TITLE
Update README CI badges with the correct workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Google Sans
 
-[![Static CI](https://github.com/googlefonts/googlesans/workflows/Static%20CI/badge.svg)](https://github.com/googlefonts/googlesans/actions?query=workflow%3A%22Static+CI%22)
-[![Variable CI](https://github.com/googlefonts/googlesans/workflows/Variable%20CI/badge.svg)](https://github.com/googlefonts/googlesans/actions?query=workflow%3A%22Variable+CI%22)
+[![CI/CD](https://github.com/googlefonts/googlesans/actions/workflows/cicd.yml/badge.svg)](https://github.com/googlefonts/googlesans/actions/workflows/cicd.yml)
 
 Google Sans is a geometric sans-serif typeface for use as the corporate branding typeface. Originally based off of Product Sans, the Google Sans design has been modified for more general purpose use across systems, product areas, advertising, and marketing.
 


### PR DESCRIPTION
It looks like our CI workflows have changed and badges either reflect old CI test fails, or the badge image is not showing up at all any longer.  This replaces both of the previous badges with a new one gen'd from our "CI/CD" Action workflow

Can view the new README badge on [this branch](https://github.com/googlefonts/googlesans/tree/chrissimpkins-readme-ci-status).