### PR TITLE
Fix fontbakery

### DIFF
--- a/qa/check-charset.py
+++ b/qa/check-charset.py
@@ -17,11 +17,11 @@ import sys
 from difflib import unified_diff
 
 from fontbakery.callable import check
+from fontbakery.checkrunner import PASS, FAIL
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.section import Section
-from fontbakery.status import FAIL, PASS
 
-profile_imports = ()
+profile_imports = [("fontbakery.profiles.shared_conditions", ("ttFont",))]
 profile = profile_factory(
     default_section=Section("Google Sans Custom Character Set Checks")
 )
@@ -107,6 +107,7 @@ def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFonts):
 # End check definitions
 #
 # ================================================
+
 
 # skip filter function to exclude checks defined in the
 # fontbakery universal profile

--- a/qa/check-fea.py
+++ b/qa/check-fea.py
@@ -19,9 +19,9 @@ from pathlib import Path
 
 import uharfbuzz
 from fontbakery.callable import check, condition
+from fontbakery.checkrunner import PASS, SKIP, FAIL
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.section import Section
-from fontbakery.status import FAIL, PASS, SKIP
 
 # Make FontBakery able to find the update_shaping_test_data package.
 sys.path.append(str(Path(__file__).parent.parent))
@@ -32,7 +32,7 @@ from qa.update_shaping_test_data import (  # noqa: E402
     shape_texts,
 )
 
-profile_imports = ()
+profile_imports = [("fontbakery.profiles.shared_conditions", ("ttFont",))]
 profile = profile_factory(
     default_section=Section("Google Sans Custom Feature Support Checks")
 )
@@ -313,6 +313,7 @@ def hb_font(font):
 # Feature support
 # ================================================
 
+
 # statics
 @check(
     id="com.google.fonts/check/googlesans/features/staticuprights",
@@ -507,7 +508,9 @@ def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
                         )
                         continue
                     if shaped_text != expected:
-                        shaped_texts_str = textwrap.indent("\n".join(shaped_text), "\t  ")
+                        shaped_texts_str = textwrap.indent(
+                            "\n".join(shaped_text), "\t  "
+                        )
                         shaped_texts_expected_str = textwrap.indent(
                             "\n".join(expected), "\t  "
                         )


### PR DESCRIPTION
@chrissimpkins this should fix the failing CI on main. I think there's been an update to Font Bakery that broke the couple of custom profiles that we have (hence the cryptic message about `KeyError: 'ttFont'` - Font Bakery seems to expect more explicit imports of dependencies now).

I had this commit laying around in a few PRs that are still under review, with this PR we can put it in main earlier and fix the CI, if you're OK to merge.